### PR TITLE
Update Docker Compose docs to include .env usage

### DIFF
--- a/docs/docs/self-hosting/docker-compose.md
+++ b/docs/docs/self-hosting/docker-compose.md
@@ -70,6 +70,7 @@ DB_PASSWORD=your-secure-password
 # AWS_USE_PATH_STYLE_ENDPOINT=false
 ```
 
+
 ### 4. Create docker-compose.yml
 
 #### SQLite (Simple Setup)
@@ -163,7 +164,7 @@ volumes:
 ```
 
 :::tip
-Remembers to restart the `worker` service whenever you make changes to the `.env` file. `docker compose restart app worker`
+Remember to restart both the `app` and `worker` services whenever you change the `.env` file: `docker compose restart app worker`
 :::
 
 :::tip


### PR DESCRIPTION
Update the Docker Compose documentation to:
- Use `.env` files for configuration.
- Enhance clarity of setup instructions.

Coming from https://github.com/David-Crty/databasement/issues/7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting Docker Compose guide to use a shared .env (env_file) instead of inline environment variables.
  * Added instructions and examples for creating/populating the .env for SQLite and MySQL production.
  * Revised deployment steps and numbering; replaced the previous APP_KEY mismatch warning with a reminder to restart services when .env changes.
  * Added note about using Traefik for HTTPS exposure in production.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->