### PR TITLE
Expand `listDatabases` test to support PostgreSQL

### DIFF
--- a/app/Services/Backup/DatabaseListService.php
+++ b/app/Services/Backup/DatabaseListService.php
@@ -15,7 +15,12 @@ class DatabaseListService
         'sys',
     ];
 
-    private const EXCLUDED_POSTGRESQL_DATABASES = [];
+    private const EXCLUDED_POSTGRESQL_DATABASES = [
+        'postgres',          // Default administrative database
+        'rdsadmin',          // AWS RDS internal database
+        'azure_maintenance', // Azure Database for PostgreSQL internal database
+        'azure_sys',         // Azure Database for PostgreSQL internal database
+    ];
 
     /**
      * Get list of databases/schemas from a database server

--- a/tests/Unit/Services/Backup/DatabaseListServiceTest.php
+++ b/tests/Unit/Services/Backup/DatabaseListServiceTest.php
@@ -3,16 +3,23 @@
 use App\Models\DatabaseServer;
 use App\Services\Backup\DatabaseListService;
 
-test('listDatabases returns mysql databases excluding system databases', function () {
+test('listDatabases returns databases excluding system databases', function (
+    string $databaseType,
+    int $port,
+    string $query,
+    array $allDatabases,
+    array $excludedDatabases,
+    array $expectedDatabases
+) {
     // Arrange - Create a test double for the server
-    $server = new class extends DatabaseServer
+    $server = new class($databaseType, $port) extends DatabaseServer
     {
-        public function __construct()
+        public function __construct(string $databaseType, int $port)
         {
             // Skip parent constructor to avoid database interaction
-            $this->database_type = 'mysql';
+            $this->database_type = $databaseType;
             $this->host = '127.0.0.1';
-            $this->port = 3306;
+            $this->port = $port;
             $this->username = 'admin';
             $this->password = 'admin';
         }
@@ -23,21 +30,13 @@ test('listDatabases returns mysql databases excluding system databases', functio
     $pdoStatement->shouldReceive('fetchAll')
         ->once()
         ->with(PDO::FETCH_COLUMN, 0)
-        ->andReturn([
-            'information_schema',
-            'performance_schema',
-            'mysql',
-            'sys',
-            'app_database',
-            'test_database',
-            'production_db',
-        ]);
+        ->andReturn($allDatabases);
 
     // Mock PDO
     $pdo = Mockery::mock(PDO::class);
     $pdo->shouldReceive('query')
         ->once()
-        ->with('SHOW DATABASES')
+        ->with($query)
         ->andReturn($pdoStatement);
 
     // Partial mock the service to inject our mocked PDO
@@ -52,14 +51,48 @@ test('listDatabases returns mysql databases excluding system databases', functio
     // Act
     $databases = $service->listDatabases($server);
 
-    // Assert
+    // Assert - check expected databases are present
     expect($databases)->toBeArray()
-        ->and($databases)->toHaveCount(3)
-        ->and($databases)->toContain('app_database')
-        ->and($databases)->toContain('test_database')
-        ->and($databases)->toContain('production_db')
-        ->and($databases)->not->toContain('information_schema')
-        ->and($databases)->not->toContain('performance_schema')
-        ->and($databases)->not->toContain('mysql')
-        ->and($databases)->not->toContain('sys');
-});
+        ->and($databases)->toHaveCount(count($expectedDatabases));
+
+    foreach ($expectedDatabases as $db) {
+        expect($databases)->toContain($db);
+    }
+
+    // Assert - check excluded databases are not present
+    foreach ($excludedDatabases as $db) {
+        expect($databases)->not->toContain($db);
+    }
+})->with([
+    'mysql' => [
+        'databaseType' => 'mysql',
+        'port' => 3306,
+        'query' => 'SHOW DATABASES',
+        'allDatabases' => [
+            'information_schema',
+            'performance_schema',
+            'mysql',
+            'sys',
+            'app_database',
+            'test_database',
+            'production_db',
+        ],
+        'excludedDatabases' => ['information_schema', 'performance_schema', 'mysql', 'sys'],
+        'expectedDatabases' => ['app_database', 'test_database', 'production_db'],
+    ],
+    'postgres' => [
+        'databaseType' => 'postgres',
+        'port' => 5432,
+        'query' => 'SELECT datname FROM pg_database WHERE datistemplate = false',
+        'allDatabases' => [
+            'postgres',
+            'rdsadmin',
+            'azure_maintenance',
+            'azure_sys',
+            'app_database',
+            'analytics_db',
+        ],
+        'excludedDatabases' => ['postgres', 'rdsadmin', 'azure_maintenance', 'azure_sys'],
+        'expectedDatabases' => ['app_database', 'analytics_db'],
+    ],
+]);


### PR DESCRIPTION
### Description of changes

This pull request updates the `listDatabases` test to add compatibility for PostgreSQL in addition to MySQL, ensuring broader database testing coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup operations now properly exclude internal PostgreSQL system databases (postgres, rdsadmin, azure_maintenance, and azure_sys) from database selection lists.

* **Tests**
  * Database listing tests have been refactored to use a data-driven testing approach, providing improved validation coverage across MySQL and PostgreSQL database platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->