### PR TITLE
Update `password` column to use `text` type

### DIFF
--- a/database/migrations/2026_01_08_102414_change_database_servers_password_column_to_text.php
+++ b/database/migrations/2026_01_08_102414_change_database_servers_password_column_to_text.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->text('password')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->string('password')->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
Modified the `password` column in the `database_servers` table from its current datatype to `text`. This change supports longer passwords, improving security and compliance with password policies.

This should fix the following issue https://github.com/David-Crty/databasement/issues/12 