### PR TITLE
Add timezone configuration support

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -77,9 +77,11 @@ return [
     | will be used by the PHP date and date-time functions. The timezone
     | is set to "UTC" by default as it is suitable for most use cases.
     |
+    | See: https://www.php.net/manual/en/timezones.php
+    |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => env('TZ', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     extra_hosts:
       - "dex-local:host-gateway"
     environment:
+      TZ: UTC
       XDG_CONFIG_HOME: /tmp
       AWS_ACCESS_KEY_ID: rustfsadmin
       AWS_SECRET_ACCESS_KEY: rustfsadmin
@@ -32,6 +33,7 @@ services:
     command: sh -c "php artisan db:wait --check-migrations && php artisan queue:work --queue=backups,default --tries=3 --timeout=3600 --sleep=3 --max-jobs=1000"
     restart: unless-stopped
     environment:
+      TZ: UTC
       AWS_ACCESS_KEY_ID: rustfsadmin
       AWS_SECRET_ACCESS_KEY: rustfsadmin
       AWS_DEFAULT_REGION: us-east-1

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -23,12 +23,13 @@ RUN install-php-extensions \
 
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 
-# Add DB CLI tools and compression utilities
+# Add tools
 RUN apk add --no-cache git \
         mariadb-client mariadb-connector-c \
         postgresql-client \
         supervisor \
-        gzip zstd
+        gzip zstd \
+        tzdata
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php-custom-production.ini /usr/local/etc/php/php-custom-production.ini
@@ -55,6 +56,7 @@ ENV SERVER_NAME=":2226"
 ENV MYSQL_CLI_TYPE="mariadb"
 ENV ENABLE_QUEUE_WORKER="false"
 ENV ENABLE_DATABASE_MIGRATION="true"
+ENV TZ="UTC"
 
 HEALTHCHECK NONE
 

--- a/docs/docs/self-hosting/configuration.md
+++ b/docs/docs/self-hosting/configuration.md
@@ -13,6 +13,18 @@ This page contains all the environment variables you can use to configure Databa
 | `APP_DEBUG` | Enable debug mode (set to `false` in production) | `false` |
 | `APP_URL` | Full URL where the app is accessible | `http://localhost:2226` |
 | `APP_KEY` | Application encryption key (required) | - |
+| `TZ` | Application timezone | `UTC` |
+
+### Timezone Configuration
+
+Set the `TZ` environment variable to configure the application timezone.
+```bash
+TZ=America/New_York
+TZ=Europe/London
+TZ=Asia/Tokyo
+```
+
+See the [list of supported timezones](https://www.php.net/manual/en/timezones.php).
 
 ### Generating the Application Key
 


### PR DESCRIPTION
This pull request introduces support for timezone configuration in the application using a `TZ` environment variable. Key changes:

- Added the `TZ` environment variable for setting the application's timezone.
- Modified `app.php` to utilize `TZ`, defaulting to `UTC` if unset.
- Updated the Docker environment settings to include the `TZ` variable.
- Included `tzdata` in the Dockerfile to support timezone adjustments.
- Updated the documentation with instructions for timezone configuration.


Should solve https://github.com/David-Crty/databasement/issues/16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Timezone is now configurable via the `TZ` environment variable, allowing customization from the default UTC during deployment and setup.

* **Documentation**
  * Added guidance on configuring application timezone, including supported timezone values and how to set the `TZ` environment variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->