### PR TITLE
fix: Implement per-database GFS retention logic

### DIFF
--- a/docs/docs/user-guide/backups.md
+++ b/docs/docs/user-guide/backups.md
@@ -102,6 +102,10 @@ Today ◄───────────────────────�
 
 **Best for:** Production environments, compliance requirements, or when you need long-term recovery options without excessive storage costs.
 
+:::info Per-Database Retention
+Retention policies are applied **per database**, not per server. If you backup 3 databases with GFS (7 daily), each database keeps its own 7 most recent backups — totaling 21 backups across all databases.
+:::
+
 ### Choosing a Retention Policy
 
 | Scenario | Recommended Policy |

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -298,7 +298,7 @@
                                 <div>
                                     <p class="text-sm font-medium">{{ __('Grandfather-Father-Son (GFS) Retention') }}</p>
                                     <p class="text-sm text-base-content/70 mt-1">
-                                        {{ __('Keeps recent backups for quick recovery while preserving older snapshots for archival. Default: 7 daily + 4 weekly + 12 monthly backups.') }}
+                                        {{ __('Keeps recent backups for quick recovery while preserving older snapshots for archival. Retention is applied per database. Default: 7 daily + 4 weekly + 12 monthly backups.') }}
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
- Refactors GFS retention logic to operate on a per-database basis.
- Updates related tests to validate GFS tiers (daily, weekly, monthly) for each database.
- Extends documentation and form UI to reflect new behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Snapshot retention (daily, weekly, and monthly tiers) now applies independently per database rather than globally, ensuring each database maintains its own retention schedule.

* **Documentation**
  * Updated documentation and interface descriptions to clarify that retention policies are applied per database, with examples showing total backup counts across multiple databases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->