### PR TITLE
feat: add SSH tunnel support for database connections

### DIFF
--- a/.env
+++ b/.env
@@ -127,6 +127,9 @@ OAUTH_OIDC_LABEL=SSO
 # Enable failure notifications for backup/restore jobs (default: false)
 NOTIFICATION_ENABLED=false
 
+# Notification channels (comma-separated): mail, slack, discord
+NOTIFICATION_CHANNELS=mail
+
 # Email recipient for failure notifications
 NOTIFICATION_MAIL_TO=
 

--- a/.env.mysql.testing
+++ b/.env.mysql.testing
@@ -1,6 +1,0 @@
-DB_CONNECTION=mysql
-DB_HOST=mysql
-DB_PORT=3306
-DB_DATABASE=databasement_app_test
-DB_USERNAME=root
-DB_PASSWORD=root

--- a/.env.postgres.testing
+++ b/.env.postgres.testing
@@ -1,6 +1,0 @@
-DB_CONNECTION=pgsql
-DB_HOST=postgres
-DB_PORT=5432
-DB_DATABASE=databasement_app_test
-DB_USERNAME=root
-DB_PASSWORD=root

--- a/Makefile
+++ b/Makefile
@@ -49,35 +49,17 @@ create-bucket: ## Create S3 bucket in rustfs (usage: make create-bucket BUCKET=m
 test: ## Run all tests in parallel (default)
 	$(PHP_ARTISAN) test --parallel
 
-test-sequential: ## Run all tests sequentially (for debugging)
-	$(PHP_ARTISAN) test
-
-test-mysql: ## Run all tests with MySQL
-	$(DOCKER_COMPOSE) exec -T mysql mysql -uroot -proot -e "DROP DATABASE IF EXISTS databasement_app_test; CREATE DATABASE databasement_app_test;" 2>/dev/null || true
-	$(DOCKER_COMPOSE) exec -T -e EXTRA_ENV_FILE=.env.mysql.testing $(PHP_SERVICE) php artisan test
-
 test-filter: ## Run tests with filter (usage: make test-filter FILTER=DatabaseServer)
-	$(PHP_ARTISAN) test --filter="$(FILTER)"
-
-test-filter-mysql: ## Run tests with filter using MySQL (usage: make test-filter-mysql FILTER=DatabaseServer)
-	$(DOCKER_COMPOSE) exec -T mysql mysql -uroot -proot -e "CREATE DATABASE IF NOT EXISTS databasement_app_test;" 2>/dev/null || true
-	$(DOCKER_COMPOSE) exec -T -e EXTRA_ENV_FILE=.env.mysql.testing $(PHP_SERVICE) php artisan test --filter="$(FILTER)"
-
-test-postgres: ## Run all tests with PostgreSQL
-	$(DOCKER_COMPOSE) exec -T postgres psql -U root -d postgres -c "DROP DATABASE IF EXISTS databasement_app_test;"
-	$(DOCKER_COMPOSE) exec -T postgres psql -U root -d postgres -c "CREATE DATABASE databasement_app_test;"
-	$(DOCKER_COMPOSE) exec -T -e EXTRA_ENV_FILE=.env.postgres.testing $(PHP_SERVICE) php artisan test
-
-test-filter-postgres: ## Run tests with filter using PostgreSQL (usage: make test-filter-postgres FILTER=DatabaseServer)
-	$(DOCKER_COMPOSE) exec -T postgres psql -U root -d postgres -c "DROP DATABASE IF EXISTS databasement_app_test;"
-	$(DOCKER_COMPOSE) exec -T postgres psql -U root -d postgres -c "CREATE DATABASE databasement_app_test;"
-	$(DOCKER_COMPOSE) exec -T -e EXTRA_ENV_FILE=.env.postgres.testing $(PHP_SERVICE) php artisan test --filter="$(FILTER)"
+	$(PHP_ARTISAN) test --parallel  --filter="$(FILTER)"
 
 test-coverage: ## Run tests with coverage
-	$(PHP_ARTISAN) test --coverage
+	$(PHP_ARTISAN) test --parallel --coverage
 
 test-coverage-filter: ## Run tests with coverage and filter (usage: make test-coverage-filter FILTER=FailureNotification)
-	$(PHP_EXEC) php -d xdebug.mode=coverage ./vendor/bin/pest --filter="$(FILTER)" --coverage
+	$(PHP_ARTISAN) test --parallel --coverage --filter="$(FILTER)"
+
+test-sequential: ## Run all tests sequentially (for debugging)
+	$(PHP_ARTISAN) test
 
 ##@ Code Quality
 

--- a/app/Exceptions/SshTunnelException.php
+++ b/app/Exceptions/SshTunnelException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+class SshTunnelException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        int $code = 0,
+        ?\Throwable $previous = null,
+        public readonly ?string $sshErrorOutput = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/app/Facades/DatabaseConnectionTester.php
+++ b/app/Facades/DatabaseConnectionTester.php
@@ -5,7 +5,7 @@ namespace App\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static array<string, mixed> test(array<string, mixed> $config)
+ * @method static array<string, mixed> test(array<string, mixed> $config, \App\Models\DatabaseServerSshConfig|null $sshConfig = null)
  *
  * @see \App\Services\DatabaseConnectionTester
  */

--- a/app/Livewire/DatabaseServer/Create.php
+++ b/app/Livewire/DatabaseServer/Create.php
@@ -43,6 +43,11 @@ class Create extends Component
         $this->form->testConnection();
     }
 
+    public function testSshConnection(): void
+    {
+        $this->form->testSshConnection();
+    }
+
     public function refreshVolumes(): void
     {
         $this->success(__('Volume list refreshed.'), position: 'toast-bottom');

--- a/app/Livewire/DatabaseServer/Edit.php
+++ b/app/Livewire/DatabaseServer/Edit.php
@@ -45,9 +45,21 @@ class Edit extends Component
         $this->form->testConnection();
     }
 
+    public function testSshConnection(): void
+    {
+        $this->form->testSshConnection();
+    }
+
     public function refreshVolumes(): void
     {
         $this->success(__('Volume list refreshed.'), position: 'toast-bottom');
+    }
+
+    public function loadDatabases(): void
+    {
+        if (! $this->form->isSqlite()) {
+            $this->form->loadAvailableDatabases();
+        }
     }
 
     public function render(): View

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -61,8 +61,7 @@ class Index extends Component
     public function headers(): array
     {
         return [
-            ['key' => 'name', 'label' => __('Name'), 'class' => 'w-64'],
-            ['key' => 'host', 'label' => __('Connection'), 'class' => 'w-48'],
+            ['key' => 'name', 'label' => __('Name'), 'class' => 'w-80'],
             ['key' => 'database_names', 'label' => __('Databases'), 'sortable' => false],
             ['key' => 'backup', 'label' => __('Backup'), 'sortable' => false],
             ['key' => 'jobs', 'label' => __('Jobs'), 'sortable' => false, 'class' => 'w-32'],

--- a/app/Models/DatabaseServerSshConfig.php
+++ b/app/Models/DatabaseServerSshConfig.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\DatabaseServerSshConfigFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $host
+ * @property int $port
+ * @property string $username
+ * @property string $auth_type
+ * @property string|null $password
+ * @property string|null $private_key
+ * @property string|null $key_passphrase
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Collection<int, DatabaseServer> $databaseServers
+ *
+ * @method static DatabaseServerSshConfigFactory factory($count = null, $state = [])
+ */
+class DatabaseServerSshConfig extends Model
+{
+    /** @use HasFactory<DatabaseServerSshConfigFactory> */
+    use HasFactory;
+
+    use HasUlids;
+
+    /** @var array<string> Sensitive fields that contain encrypted data */
+    public const SENSITIVE_FIELDS = ['password', 'private_key', 'key_passphrase'];
+
+    protected $fillable = [
+        'host',
+        'port',
+        'username',
+        'auth_type',
+        'password',
+        'private_key',
+        'key_passphrase',
+    ];
+
+    protected $hidden = [
+        'password',
+        'private_key',
+        'key_passphrase',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'port' => 'integer',
+            'password' => 'encrypted',
+            'private_key' => 'encrypted',
+            'key_passphrase' => 'encrypted',
+        ];
+    }
+
+    /**
+     * @return HasMany<DatabaseServer, DatabaseServerSshConfig>
+     */
+    public function databaseServers(): HasMany
+    {
+        return $this->hasMany(DatabaseServer::class, 'ssh_config_id');
+    }
+
+    /**
+     * Get display name in format: username@host:port
+     */
+    public function getDisplayName(): string
+    {
+        return "{$this->username}@{$this->host}:{$this->port}";
+    }
+
+    /**
+     * Get all config values with sensitive fields decrypted.
+     * Used when establishing SSH connections.
+     *
+     * @return array<string, mixed>
+     */
+    public function getDecrypted(): array
+    {
+        return [
+            'host' => $this->host,
+            'port' => $this->port,
+            'username' => $this->username,
+            'auth_type' => $this->auth_type,
+            'password' => $this->password,
+            'private_key' => $this->private_key,
+            'key_passphrase' => $this->key_passphrase,
+        ];
+    }
+
+    /**
+     * Get config with sensitive fields removed (for logging/display).
+     *
+     * @return array<string, mixed>
+     */
+    public function getSafe(): array
+    {
+        return [
+            'host' => $this->host,
+            'port' => $this->port,
+            'username' => $this->username,
+            'auth_type' => $this->auth_type,
+        ];
+    }
+}

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -17,7 +17,7 @@ class DatabaseServerQuery
     public static function make(): QueryBuilder
     {
         return QueryBuilder::for(DatabaseServer::class)
-            ->with(['backup.volume'])
+            ->with(['backup.volume', 'sshConfig'])
             ->allowedFilters([
                 AllowedFilter::partial('name'),
                 AllowedFilter::partial('host'),
@@ -44,7 +44,7 @@ class DatabaseServerQuery
         string $sortDirection = 'desc'
     ): Builder {
         return DatabaseServer::query()
-            ->with(['backup.volume'])
+            ->with(['backup.volume', 'sshConfig'])
             ->withCount('snapshots')
             ->addSelect([
                 'restores_count' => Restore::selectRaw('count(*)')

--- a/app/Services/Backup/Concerns/UsesSshTunnel.php
+++ b/app/Services/Backup/Concerns/UsesSshTunnel.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Services\Backup\Concerns;
+
+use App\Exceptions\SshTunnelException;
+use App\Models\BackupJob;
+use App\Models\DatabaseServer;
+use App\Services\SshTunnelService;
+
+/**
+ * Provides SSH tunnel management for backup and restore tasks.
+ */
+trait UsesSshTunnel
+{
+    /** @var array{host: string, port: int}|null */
+    private ?array $tunnelEndpoint = null;
+
+    abstract protected function getSshTunnelService(): SshTunnelService;
+
+    /**
+     * Establish SSH tunnel for the database server.
+     *
+     * @throws SshTunnelException
+     */
+    protected function establishSshTunnel(DatabaseServer $server, BackupJob $job): void
+    {
+        $sshConfig = $server->sshConfig;
+        if ($sshConfig === null) {
+            throw new SshTunnelException('SSH configuration not found for this server');
+        }
+        $this->tunnelEndpoint = $this->getSshTunnelService()->establish($server);
+
+        $safeSshConfig = $sshConfig->getSafe();
+        $job->log('SSH tunnel established', 'success', [
+            'local_port' => $this->tunnelEndpoint['port'],
+            'ssh_host' => $safeSshConfig['host'] ?? null,
+            'ssh_port' => $safeSshConfig['port'] ?? 22,
+            'ssh_username' => $safeSshConfig['username'] ?? null,
+        ]);
+    }
+
+    /**
+     * Close SSH tunnel if active.
+     */
+    protected function closeSshTunnel(BackupJob $job): void
+    {
+        if ($this->getSshTunnelService()->isActive()) {
+            $this->getSshTunnelService()->close();
+            $job->log('SSH tunnel closed');
+        }
+        $this->tunnelEndpoint = null;
+    }
+
+    /**
+     * Get connection host, using tunnel endpoint if active.
+     */
+    protected function getConnectionHost(DatabaseServer $server): string
+    {
+        return $this->tunnelEndpoint['host'] ?? $server->host;
+    }
+
+    /**
+     * Get connection port, using tunnel endpoint if active.
+     */
+    protected function getConnectionPort(DatabaseServer $server): int
+    {
+        return $this->tunnelEndpoint['port'] ?? $server->port;
+    }
+}

--- a/app/Services/Backup/ShellProcessor.php
+++ b/app/Services/Backup/ShellProcessor.php
@@ -89,6 +89,10 @@ class ShellProcessor
             // Match 7z password: -p'password' or -p"password" or -ppassword
             "/-p'[^']*'/" => '-p***',
             '/-p"[^"]*"/' => '-p***',
+            // SSH password via sshpass: sshpass -p 'password' or sshpass -p "password" or sshpass -p password
+            '/sshpass\s+-p\s+[\'"]?[^\s\'"]+[\'"]?/' => 'sshpass -p ***',
+            // SSH_ASKPASS scripts may contain passphrases
+            '/SSH_ASKPASS=[^\s]+/' => 'SSH_ASKPASS=***',
         ];
 
         foreach ($patterns as $pattern => $replacement) {

--- a/app/Services/SshTunnelService.php
+++ b/app/Services/SshTunnelService.php
@@ -1,0 +1,431 @@
+<?php
+
+namespace App\Services;
+
+use App\Exceptions\SshTunnelException;
+use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
+use Symfony\Component\Process\Process;
+
+class SshTunnelService
+{
+    private const CONNECTION_TIMEOUT_SECONDS = 30;
+
+    private const WAIT_INTERVAL_MS = 100;
+
+    /** Derived from CONNECTION_TIMEOUT_SECONDS * 1000 / WAIT_INTERVAL_MS */
+    private const MAX_WAIT_ATTEMPTS = 300;
+
+    private ?Process $tunnelProcess = null;
+
+    private ?int $localPort = null;
+
+    private ?string $keyFile = null;
+
+    private ?string $askPassScript = null;
+
+    /**
+     * Establish an SSH tunnel for the given database server.
+     *
+     * @return array{host: string, port: int} The local endpoint to connect to
+     *
+     * @throws SshTunnelException
+     */
+    public function establish(DatabaseServer $server): array
+    {
+        if (! $server->requiresSshTunnel()) {
+            throw new SshTunnelException('SSH tunnel is not configured for this server');
+        }
+
+        $sshConfig = $server->sshConfig;
+        if ($sshConfig === null) {
+            throw new SshTunnelException('SSH configuration not found for this server');
+        }
+
+        $decrypted = $sshConfig->getDecrypted();
+
+        $this->localPort = $this->allocateLocalPort();
+        $command = $this->buildSshCommand(
+            sshHost: $decrypted['host'],
+            sshPort: (int) ($decrypted['port'] ?? 22),
+            sshUsername: $decrypted['username'],
+            authType: $decrypted['auth_type'] ?? 'password',
+            password: $decrypted['password'] ?? null,
+            privateKey: $decrypted['private_key'] ?? null,
+            keyPassphrase: $decrypted['key_passphrase'] ?? null,
+            remoteHost: $server->host,
+            remotePort: $server->port,
+            localPort: $this->localPort
+        );
+
+        $this->tunnelProcess = $this->createTunnelProcess($command);
+        $this->tunnelProcess->setTimeout(null);
+        $this->tunnelProcess->start();
+
+        // Wait for tunnel to be established
+        if (! $this->waitForTunnel()) {
+            $errorOutput = $this->tunnelProcess->getErrorOutput();
+            $this->close();
+            throw new SshTunnelException(
+                'Failed to establish SSH tunnel: '.$this->sanitizeError($errorOutput),
+                sshErrorOutput: $errorOutput
+            );
+        }
+
+        return [
+            'host' => '127.0.0.1',
+            'port' => $this->localPort,
+        ];
+    }
+
+    /**
+     * Close the SSH tunnel and clean up resources.
+     */
+    public function close(): void
+    {
+        if ($this->tunnelProcess !== null && $this->tunnelProcess->isRunning()) {
+            $this->tunnelProcess->stop(3);
+        }
+
+        $this->tunnelProcess = null;
+        $this->localPort = null;
+        $this->cleanupTempFiles();
+    }
+
+    /**
+     * Test an SSH connection without establishing a tunnel.
+     *
+     * @return array{success: bool, message: string, details: array<string, mixed>}
+     */
+    public static function testConnection(DatabaseServerSshConfig $sshConfig): array
+    {
+        $instance = new self;
+
+        try {
+            $decrypted = $sshConfig->getDecrypted();
+            $command = $instance->buildTestCommand($decrypted);
+
+            $process = Process::fromShellCommandLine($command);
+            $process->setTimeout(self::CONNECTION_TIMEOUT_SECONDS);
+
+            $startTime = microtime(true);
+            $process->run();
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+
+            if (! $process->isSuccessful()) {
+                $errorOutput = trim($process->getErrorOutput() ?: $process->getOutput());
+
+                return [
+                    'success' => false,
+                    'message' => $instance->sanitizeError($errorOutput) ?: 'SSH connection failed',
+                    'details' => [],
+                ];
+            }
+
+            return [
+                'success' => true,
+                'message' => 'SSH connection successful',
+                'details' => [
+                    'ping_ms' => $durationMs,
+                ],
+            ];
+        } finally {
+            $instance->cleanupTempFiles();
+        }
+    }
+
+    /**
+     * Check if the tunnel is currently active.
+     */
+    public function isActive(): bool
+    {
+        return $this->tunnelProcess !== null && $this->tunnelProcess->isRunning();
+    }
+
+    /**
+     * Get the local port being used for the tunnel.
+     */
+    public function getLocalPort(): ?int
+    {
+        return $this->localPort;
+    }
+
+    /**
+     * Allocate an available local port by binding to port 0.
+     *
+     * @throws SshTunnelException
+     */
+    protected function allocateLocalPort(): int
+    {
+        $socket = @socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
+        if ($socket === false) {
+            throw new SshTunnelException('Failed to create socket for port allocation');
+        }
+
+        if (! @socket_bind($socket, '127.0.0.1', 0)) {
+            socket_close($socket);
+            throw new SshTunnelException('Failed to bind socket for port allocation');
+        }
+
+        if (! @socket_getsockname($socket, $addr, $port)) {
+            socket_close($socket);
+            throw new SshTunnelException('Failed to get allocated port');
+        }
+
+        socket_close($socket);
+
+        return $port;
+    }
+
+    /**
+     * Create a Process instance for the tunnel command.
+     * Protected to allow mocking in tests.
+     */
+    protected function createTunnelProcess(string $command): Process
+    {
+        return Process::fromShellCommandLine($command);
+    }
+
+    /**
+     * Build the SSH tunnel command.
+     */
+    private function buildSshCommand(
+        string $sshHost,
+        int $sshPort,
+        string $sshUsername,
+        string $authType,
+        ?string $password,
+        ?string $privateKey,
+        ?string $keyPassphrase,
+        string $remoteHost,
+        int $remotePort,
+        int $localPort
+    ): string {
+        // BatchMode=yes only for passphrase-less key auth; password and key+passphrase need interactive mode
+        $batchMode = $authType === 'key' && empty($keyPassphrase);
+
+        $sshOptions = $this->buildBaseOptions($sshPort, $batchMode, [
+            '-N', // Don't execute remote command
+            '-o', 'ServerAliveInterval=30',
+            '-o', 'ServerAliveCountMax=3',
+            '-o', 'ExitOnForwardFailure=yes',
+            '-L', sprintf('%d:%s:%d', $localPort, $remoteHost, $remotePort),
+        ]);
+
+        return $this->buildAuthenticatedCommand(
+            $sshOptions,
+            $sshHost,
+            $sshUsername,
+            $authType,
+            $password,
+            $privateKey,
+            $keyPassphrase
+        );
+    }
+
+    /**
+     * Build command to test SSH connection.
+     *
+     * @param  array<string, mixed>  $sshConfig
+     */
+    private function buildTestCommand(array $sshConfig): string
+    {
+        $sshHost = $sshConfig['host'] ?? '';
+        $sshPort = (int) ($sshConfig['port'] ?? 22);
+        $sshUsername = $sshConfig['username'] ?? '';
+        $authType = $sshConfig['auth_type'] ?? 'password';
+        $password = $sshConfig['password'] ?? null;
+        $privateKey = $sshConfig['private_key'] ?? null;
+        $keyPassphrase = $sshConfig['key_passphrase'] ?? null;
+
+        // BatchMode=yes only for passphrase-less key auth; password and key+passphrase need interactive mode
+        $batchMode = $authType === 'key' && empty($keyPassphrase);
+
+        $sshOptions = $this->buildBaseOptions($sshPort, $batchMode);
+
+        return $this->buildAuthenticatedCommand(
+            $sshOptions,
+            $sshHost,
+            $sshUsername,
+            $authType,
+            $password,
+            $privateKey,
+            $keyPassphrase,
+            'exit 0'
+        );
+    }
+
+    /**
+     * Build base SSH options common to all commands.
+     *
+     * @param  bool  $batchMode  Use BatchMode=yes for non-interactive auth (passphrase-less keys), BatchMode=no for password/passphrase auth
+     * @param  array<string>  $additionalOptions
+     * @return array<string>
+     */
+    private function buildBaseOptions(int $sshPort, bool $batchMode = true, array $additionalOptions = []): array
+    {
+        return array_merge([
+            '-o', 'StrictHostKeyChecking=accept-new',
+            '-o', $batchMode ? 'BatchMode=yes' : 'BatchMode=no',
+            '-o', sprintf('ConnectTimeout=%d', self::CONNECTION_TIMEOUT_SECONDS),
+            '-p', (string) $sshPort,
+        ], $additionalOptions);
+    }
+
+    /**
+     * Build the final SSH command with authentication.
+     *
+     * @param  array<string>  $sshOptions
+     */
+    private function buildAuthenticatedCommand(
+        array $sshOptions,
+        string $sshHost,
+        string $sshUsername,
+        string $authType,
+        ?string $password,
+        ?string $privateKey,
+        ?string $keyPassphrase,
+        string $remoteCommand = ''
+    ): string {
+        $optionsString = implode(' ', array_map('escapeshellarg', $sshOptions));
+        $userHost = escapeshellarg($sshUsername).'@'.escapeshellarg($sshHost);
+        $suffix = $remoteCommand !== '' ? ' '.$remoteCommand : '';
+
+        if ($authType === 'key' && ! empty($privateKey)) {
+            $this->keyFile = $this->writeKeyToTempFile($privateKey);
+            $optionsString .= ' -i '.escapeshellarg($this->keyFile);
+
+            if (! empty($keyPassphrase)) {
+                try {
+                    $this->askPassScript = $this->createAskPassScript($keyPassphrase);
+                } catch (SshTunnelException $e) {
+                    // Clean up the key file if askpass creation fails
+                    @unlink($this->keyFile);
+                    $this->keyFile = null;
+                    throw $e;
+                }
+
+                return sprintf(
+                    'SSH_ASKPASS=%s SSH_ASKPASS_REQUIRE=force setsid ssh %s %s%s',
+                    escapeshellarg($this->askPassScript),
+                    $optionsString,
+                    $userHost,
+                    $suffix
+                );
+            }
+        } elseif ($authType === 'password' && ! empty($password)) {
+            // Use SSHPASS env var with -e flag to avoid exposing password in process args
+            return sprintf(
+                'SSHPASS=%s sshpass -e ssh %s %s%s',
+                escapeshellarg($password),
+                $optionsString,
+                $userHost,
+                $suffix
+            );
+        }
+
+        return sprintf('ssh %s %s%s', $optionsString, $userHost, $suffix);
+    }
+
+    /**
+     * Write private key to a temporary file with proper permissions.
+     *
+     * @throws SshTunnelException
+     */
+    private function writeKeyToTempFile(string $key): string
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'ssh_key_');
+        if ($tempFile === false) {
+            throw new SshTunnelException('Failed to create temporary file for SSH key');
+        }
+
+        if (file_put_contents($tempFile, $key) === false) {
+            @unlink($tempFile);
+            throw new SshTunnelException('Failed to write SSH key to temporary file');
+        }
+
+        if (chmod($tempFile, 0600) === false) {
+            @unlink($tempFile);
+            throw new SshTunnelException('Failed to set permissions on SSH key temporary file');
+        }
+
+        return $tempFile;
+    }
+
+    /**
+     * Create a temporary script for SSH_ASKPASS.
+     *
+     * @throws SshTunnelException
+     */
+    private function createAskPassScript(string $passphrase): string
+    {
+        $script = tempnam(sys_get_temp_dir(), 'askpass_');
+        if ($script === false) {
+            throw new SshTunnelException('Failed to create askpass script');
+        }
+
+        $content = "#!/bin/bash\necho ".escapeshellarg($passphrase);
+        if (file_put_contents($script, $content) === false) {
+            @unlink($script);
+            throw new SshTunnelException('Failed to write askpass script');
+        }
+
+        if (chmod($script, 0700) === false) {
+            @unlink($script);
+            throw new SshTunnelException('Failed to set permissions on askpass script');
+        }
+
+        return $script;
+    }
+
+    /**
+     * Wait for the tunnel to be established by checking if the local port is accepting connections.
+     * Protected to allow mocking in tests.
+     */
+    protected function waitForTunnel(): bool
+    {
+        for ($i = 0; $i < self::MAX_WAIT_ATTEMPTS; $i++) {
+            // Check if the process has terminated with an error
+            if (! $this->tunnelProcess->isRunning()) {
+                return false;
+            }
+
+            // Try to connect to the local port
+            $socket = @fsockopen('127.0.0.1', $this->localPort, $errno, $errstr, 1);
+            if ($socket !== false) {
+                fclose($socket);
+
+                return true;
+            }
+
+            usleep(self::WAIT_INTERVAL_MS * 1000);
+        }
+
+        return false;
+    }
+
+    /**
+     * Sanitize SSH error output for display.
+     */
+    private function sanitizeError(string $error): string
+    {
+        $lines = explode("\n", trim($error));
+        $filtered = array_filter($lines, fn (string $line) => $line !== '' && ! str_starts_with($line, 'Warning:'));
+
+        return implode(' ', array_map('trim', $filtered));
+    }
+
+    /**
+     * Clean up temporary files (key file and askpass script).
+     */
+    private function cleanupTempFiles(): void
+    {
+        foreach ([$this->keyFile, $this->askPassScript] as $file) {
+            if ($file !== null && file_exists($file)) {
+                unlink($file);
+            }
+        }
+        $this->keyFile = null;
+        $this->askPassScript = null;
+    }
+}

--- a/database/factories/DatabaseServerSshConfigFactory.php
+++ b/database/factories/DatabaseServerSshConfigFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\DatabaseServerSshConfig>
+ */
+class DatabaseServerSshConfigFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'host' => 'bastion.example.com',
+            'port' => 22,
+            'username' => 'tunnel_user',
+            'auth_type' => 'password',
+            'password' => 'ssh_password',
+            'private_key' => null,
+            'key_passphrase' => null,
+        ];
+    }
+
+    /**
+     * Configure the factory for key-based authentication.
+     */
+    public function withKeyAuth(): static
+    {
+        // Use a placeholder string to avoid triggering secret scanners
+        $sampleKey = 'FAKE_SSH_PRIVATE_KEY_FOR_TESTS_ONLY';
+
+        return $this->state(fn () => [
+            'auth_type' => 'key',
+            'password' => null,
+            'private_key' => $sampleKey,
+            'key_passphrase' => null,
+        ]);
+    }
+
+    /**
+     * Configure the factory for key-based authentication with passphrase.
+     */
+    public function withKeyAuthAndPassphrase(): static
+    {
+        $sampleKey = 'FAKE_SSH_PRIVATE_KEY_FOR_TESTS_ONLY';
+
+        return $this->state(fn () => [
+            'auth_type' => 'key',
+            'password' => null,
+            'private_key' => $sampleKey,
+            'key_passphrase' => 'test_passphrase',
+        ]);
+    }
+}

--- a/database/migrations/2026_02_02_161742_create_database_server_ssh_configs_table.php
+++ b/database/migrations/2026_02_02_161742_create_database_server_ssh_configs_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('database_server_ssh_configs', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->string('host');
+            $table->integer('port')->default(22);
+            $table->string('username');
+            $table->string('auth_type'); // 'password' or 'key'
+            $table->text('password')->nullable(); // encrypted
+            $table->text('private_key')->nullable(); // encrypted
+            $table->text('key_passphrase')->nullable(); // encrypted
+            $table->timestamps();
+        });
+
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->ulid('ssh_config_id')->nullable()->after('backups_enabled');
+            $table->foreign('ssh_config_id')
+                ->references('id')
+                ->on('database_server_ssh_configs')
+                ->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->dropForeign(['ssh_config_id']);
+            $table->dropColumn('ssh_config_id');
+        });
+
+        Schema::dropIfExists('database_server_ssh_configs');
+    }
+};

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -21,7 +21,7 @@ RUN install-php-extensions \
     opcache \
     pcov \
     ftp \
-    ssh2
+    sockets
 
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 
@@ -34,7 +34,9 @@ RUN apk add --no-cache git \
         tzdata \
         shadow \
         findutils \
-        bash
+        bash \
+        openssh-client \
+        sshpass
 
 COPY supervisord.conf /config/supervisord.conf
 COPY php-custom-production.ini /usr/local/etc/php/php-custom-production.ini

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -98,6 +98,10 @@
                     </div>
                 @endif
 
+                @if(!$form->isSqlite())
+                    @include('livewire.database-server._ssh-tunnel-config', ['form' => $form, 'isEdit' => $isEdit])
+                @endif
+
                 <!-- Test Connection Button -->
                 <div class="flex flex-wrap items-center gap-2 pt-2">
                     <x-button
@@ -144,6 +148,12 @@
                             class="btn-ghost btn-sm mt-2"
                             icon="o-arrow-top-right-on-square"
                         />
+                    </x-alert>
+                @endif
+
+                @if($form->connectionTestSuccess && !empty($form->connectionTestDetails['ssh_tunnel']))
+                    <x-alert class="alert-info mt-2" icon="o-server-stack">
+                        {{ __('Connected via SSH tunnel through') }} {{ $form->connectionTestDetails['ssh_host'] }}
                     </x-alert>
                 @endif
 

--- a/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
+++ b/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
@@ -1,0 +1,186 @@
+@props(['form', 'isEdit' => false])
+
+@php
+    $sshConfigOptions = $form->getSshConfigOptions();
+    $hasExistingConfigs = count($sshConfigOptions) > 0;
+    $isExistingConfig = $form->ssh_config_mode === 'existing' && $form->ssh_config_id;
+    $credentialsOptional = $isEdit || $isExistingConfig;
+@endphp
+
+<!-- SSH Tunnel Configuration -->
+<div class="mt-4 border border-base-300 rounded-lg bg-base-200">
+    <!-- Toggle Header -->
+    <label class="flex items-center gap-3 p-4 cursor-pointer">
+        <x-toggle
+            wire:model.live="form.ssh_enabled"
+            class="toggle-primary"
+        />
+        <span class="font-medium">{{ __('Use SSH Tunnel') }}</span>
+    </label>
+
+    <!-- SSH Configuration Form (shown only when enabled) -->
+    @if($form->ssh_enabled)
+        <div class="border-t border-base-300 bg-base-100 p-4 rounded-b-lg">
+            <div class="space-y-4">
+                <!-- SSH Configuration Mode -->
+                @if($hasExistingConfigs)
+                    <div class="form-control">
+                        <label class="label">
+                            <span class="label-text font-medium">{{ __('SSH Configuration') }}</span>
+                        </label>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            <label class="cursor-pointer">
+                                <input type="radio" name="ssh_config_mode" value="existing"
+                                       wire:model.live="form.ssh_config_mode" class="peer hidden">
+                                <div class="card bg-base-200 border-2 border-transparent peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-200 hover:bg-base-300">
+                                    <div class="card-body p-4 flex-row items-center gap-3">
+                                        <div class="w-4 h-4 rounded-full border-2 border-base-content/30 peer-checked:border-primary flex items-center justify-center">
+                                            <div class="w-2 h-2 rounded-full bg-primary {{ $form->ssh_config_mode === 'existing' ? 'scale-100' : 'scale-0' }} transition-transform"></div>
+                                        </div>
+                                        <div>
+                                            <div class="font-medium text-sm">{{ __('Use existing') }}</div>
+                                            <div class="text-xs text-base-content/60">{{ __('Select from saved configs') }}</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </label>
+                            <label class="cursor-pointer">
+                                <input type="radio" name="ssh_config_mode" value="create"
+                                       wire:model.live="form.ssh_config_mode" class="peer hidden">
+                                <div class="card bg-base-200 border-2 border-transparent peer-checked:border-primary peer-checked:bg-primary/5 transition-all duration-200 hover:bg-base-300">
+                                    <div class="card-body p-4 flex-row items-center gap-3">
+                                        <div class="w-4 h-4 rounded-full border-2 border-base-content/30 peer-checked:border-primary flex items-center justify-center">
+                                            <div class="w-2 h-2 rounded-full bg-primary {{ $form->ssh_config_mode === 'create' ? 'scale-100' : 'scale-0' }} transition-transform"></div>
+                                        </div>
+                                        <div>
+                                            <div class="font-medium text-sm">{{ __('Create new') }}</div>
+                                            <div class="text-xs text-base-content/60">{{ __('Set up a new SSH config') }}</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </label>
+                        </div>
+                    </div>
+
+                    @if($form->ssh_config_mode === 'existing')
+                        <x-select
+                            wire:model.live="form.ssh_config_id"
+                            label="{{ __('Select SSH Configuration') }}"
+                            :options="$sshConfigOptions"
+                            option-value="id"
+                            option-label="name"
+                            required
+                        />
+                    @endif
+                @endif
+
+                <!-- SSH Host, Port & Username -->
+                <div class="grid grid-cols-1 sm:grid-cols-6 gap-3">
+                    <div class="sm:col-span-3">
+                        <x-input
+                            wire:model.blur="form.ssh_host"
+                            label="{{ __('SSH Host') }}"
+                            placeholder="{{ __('bastion.example.com') }}"
+                            type="text"
+                            required
+                        />
+                    </div>
+                    <div class="sm:col-span-1">
+                        <x-input
+                            wire:model.blur="form.ssh_port"
+                            label="{{ __('Port') }}"
+                            placeholder="22"
+                            type="number"
+                            min="1"
+                            max="65535"
+                            required
+                        />
+                    </div>
+                    <div class="sm:col-span-2">
+                        <x-input
+                            wire:model.blur="form.ssh_username"
+                            label="{{ __('Username') }}"
+                            placeholder="{{ __('ssh_user') }}"
+                            type="text"
+                            required
+                            autocomplete="off"
+                        />
+                    </div>
+                </div>
+
+                <!-- Authentication Method -->
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text font-medium">{{ __('Authentication Method') }}</span>
+                    </label>
+                    <div class="flex flex-wrap gap-2">
+                        <label class="cursor-pointer">
+                            <input type="radio" name="ssh_auth_type" value="password"
+                                   wire:model.live="form.ssh_auth_type" class="peer hidden">
+                            <div class="btn btn-sm peer-checked:btn-primary peer-checked:btn-active btn-outline gap-2">
+                                <x-icon name="o-key" class="w-4 h-4" />
+                                {{ __('Password') }}
+                            </div>
+                        </label>
+                        <label class="cursor-pointer">
+                            <input type="radio" name="ssh_auth_type" value="key"
+                                   wire:model.live="form.ssh_auth_type" class="peer hidden">
+                            <div class="btn btn-sm peer-checked:btn-primary peer-checked:btn-active btn-outline gap-2">
+                                <x-icon name="o-finger-print" class="w-4 h-4" />
+                                {{ __('Private Key') }}
+                            </div>
+                        </label>
+                    </div>
+                </div>
+
+                @if($form->ssh_auth_type === 'password')
+                    <x-password
+                        wire:model.blur="form.ssh_password"
+                        label="{{ __('SSH Password') }}"
+                        placeholder="{{ $credentialsOptional ? __('Leave blank to keep current') : __('SSH password') }}"
+                        :required="!$credentialsOptional"
+                        autocomplete="off"
+                    />
+                @else
+                    <x-textarea
+                        wire:model.blur="form.ssh_private_key"
+                        label="{{ __('Private Key') }}"
+                        placeholder="{{ $credentialsOptional ? __('Leave blank to keep current') : __('Paste your private key here...') }}"
+                        hint="{{ __('OpenSSH format (begins with -----BEGIN OPENSSH PRIVATE KEY-----)') }}"
+                        rows="3"
+                        class="font-mono text-xs"
+                        :required="!$credentialsOptional"
+                    />
+                    <x-password
+                        wire:model.blur="form.ssh_key_passphrase"
+                        label="{{ __('Key Passphrase') }}"
+                        placeholder="{{ __('Enter passphrase if key is encrypted') }}"
+                        hint="{{ __('Only required if your private key is encrypted') }}"
+                        autocomplete="off"
+                    />
+                @endif
+
+                <!-- Test SSH Connection -->
+                <div class="flex flex-wrap items-center gap-2">
+                    <x-button
+                        class="btn-sm {{ $form->sshTestSuccess ? 'btn-success' : 'btn-outline' }}"
+                        type="button"
+                        icon="{{ $form->sshTestSuccess ? 'o-check-circle' : 'o-signal' }}"
+                        wire:click="testSshConnection"
+                        spinner="testSshConnection"
+                    >
+                        @if($form->sshTestSuccess)
+                            {{ __('Connected') }}
+                        @else
+                            {{ __('Test SSH') }}
+                        @endif
+                    </x-button>
+
+                    @if($form->sshTestMessage && !$form->sshTestSuccess)
+                        <span class="text-error text-xs">{{ $form->sshTestMessage }}</span>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/database-server/edit.blade.php
+++ b/resources/views/livewire/database-server/edit.blade.php
@@ -1,4 +1,4 @@
-<div wire:init="testConnection">
+<div wire:init="loadDatabases">
     <div class="mx-auto max-w-4xl">
         <x-header title="{{ __('Edit Database Server') }}" subtitle="{{ __('Update your database server configuration') }}" size="text-2xl" separator class="mb-6" />
 

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -57,36 +57,36 @@
                     <x-database-type-icon :type="$server->database_type" />
                     <div>
                         <div class="table-cell-primary">{{ $server->name }}</div>
+                        <div class="flex items-center gap-2 text-sm text-base-content/70">
+                            <x-popover>
+                                <x-slot:trigger>
+                                    <div class="flex items-center gap-1 cursor-pointer">
+                                        @if($server->database_type->value === 'sqlite')
+                                            <x-icon name="o-document" class="w-3 h-3" />
+                                        @endif
+                                        <span class="font-mono truncate max-w-48">{{ $server->getConnectionLabel() }}</span>
+                                    </div>
+                                </x-slot:trigger>
+                                <x-slot:content class="text-sm font-mono">
+                                    {{ $server->getConnectionDetails() }}
+                                </x-slot:content>
+                            </x-popover>
+                            @if($server->getSshDisplayName())
+                                <x-popover>
+                                    <x-slot:trigger>
+                                        <x-badge value="SSH" class="badge-warning badge-soft badge-xs cursor-pointer" />
+                                    </x-slot:trigger>
+                                    <x-slot:content class="text-sm">
+                                        {{ __('Via') }} {{ $server->getSshDisplayName() }}
+                                    </x-slot:content>
+                                </x-popover>
+                            @endif
+                        </div>
                         @if($server->description)
-                            <div class="text-sm text-base-content/70">{{ Str::limit($server->description, 50) }}</div>
+                            <div class="text-sm text-base-content/50">{{ Str::limit($server->description, 50) }}</div>
                         @endif
                     </div>
                 </div>
-            @endscope
-
-            @scope('cell_host', $server)
-                @if($server->database_type === 'sqlite')
-                    <x-popover>
-                        <x-slot:trigger>
-                            <div class="flex items-center gap-1 cursor-pointer">
-                                <x-icon name="o-document" class="w-4 h-4 text-base-content/50" />
-                                <span class="font-mono text-sm truncate max-w-48">{{ basename($server->sqlite_path) }}</span>
-                            </div>
-                        </x-slot:trigger>
-                        <x-slot:content class="text-sm font-mono">
-                            {{ $server->sqlite_path }}
-                        </x-slot:content>
-                    </x-popover>
-                @else
-                    <x-popover>
-                        <x-slot:trigger>
-                            <span class="font-mono text-sm truncate max-w-48 block cursor-pointer">{{ $server->host }}:{{ $server->port }}</span>
-                        </x-slot:trigger>
-                        <x-slot:content class="text-sm font-mono">
-                            {{ $server->host }}:{{ $server->port }}
-                        </x-slot:content>
-                    </x-popover>
-                @endif
             @endscope
 
             @scope('cell_database_names', $server)

--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -1,23 +1,12 @@
 <?php
 
-use App\Facades\DatabaseConnectionTester;
 use App\Livewire\DatabaseServer\Create;
 use App\Models\DatabaseServer;
 use App\Models\User;
 use App\Models\Volume;
-use App\Services\Backup\DatabaseListService;
 use Livewire\Livewire;
 
 test('can create database server', function (array $config) {
-    DatabaseConnectionTester::shouldReceive('test')
-        ->once()
-        ->andReturn(['success' => true, 'message' => 'Connected!']);
-
-    // Mock DatabaseListService to avoid connection errors for fake servers
-    $this->mock(DatabaseListService::class, function ($mock) {
-        $mock->shouldReceive('listDatabases')->andReturn(['myapp_production']);
-    });
-
     $user = User::factory()->create();
     $volume = Volume::create([
         'name' => 'Test Volume',
@@ -75,10 +64,6 @@ test('can create database server', function (array $config) {
 })->with('database server configs');
 
 test('can create database server with backups disabled', function () {
-    DatabaseConnectionTester::shouldReceive('test')
-        ->once()
-        ->andReturn(['success' => true, 'message' => 'Connected!']);
-
     $user = User::factory()->create();
 
     Livewire::actingAs($user)
@@ -109,14 +94,6 @@ test('can create database server with backups disabled', function () {
 });
 
 test('can create database server with retention policy', function (array $config) {
-    DatabaseConnectionTester::shouldReceive('test')
-        ->once()
-        ->andReturn(['success' => true, 'message' => 'Connected!']);
-
-    $this->mock(DatabaseListService::class, function ($mock) {
-        $mock->shouldReceive('listDatabases')->andReturn(['myapp_production']);
-    });
-
     $user = User::factory()->create();
     $volume = Volume::create([
         'name' => 'Test Volume',
@@ -155,8 +132,6 @@ test('can create database server with retention policy', function (array $config
 })->with('retention policies');
 
 test('cannot create database server with GFS retention when all tiers are empty', function () {
-    // No mock for DatabaseConnectionTester needed - validation fails before connection test
-
     $user = User::factory()->create();
     $volume = Volume::create([
         'name' => 'GFS Validation Test Volume',

--- a/tests/Feature/DatabaseServer/SshTunnelTest.php
+++ b/tests/Feature/DatabaseServer/SshTunnelTest.php
@@ -1,0 +1,243 @@
+<?php
+
+use App\Livewire\DatabaseServer\Create;
+use App\Livewire\DatabaseServer\Edit;
+use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
+use App\Models\User;
+use App\Models\Volume;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('can create database server with SSH tunnel (password auth)', function () {
+    $user = User::factory()->create();
+    $volume = Volume::create([
+        'name' => 'Test Volume',
+        'type' => 'local',
+        'config' => ['path' => '/var/backups'],
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.name', 'SSH Tunnel Server')
+        ->set('form.database_type', 'mysql')
+        ->set('form.host', 'private-db.internal')
+        ->set('form.port', 3306)
+        ->set('form.username', 'dbuser')
+        ->set('form.password', 'secret123')
+        ->set('form.database_names_input', 'myapp_production')
+        ->set('form.volume_id', $volume->id)
+        ->set('form.recurrence', 'daily')
+        ->set('form.retention_days', 14)
+        // SSH tunnel config
+        ->set('form.ssh_enabled', true)
+        ->set('form.ssh_config_mode', 'create')
+        ->set('form.ssh_host', 'bastion.example.com')
+        ->set('form.ssh_port', 22)
+        ->set('form.ssh_username', 'tunnel_user')
+        ->set('form.ssh_auth_type', 'password')
+        ->set('form.ssh_password', 'ssh_secret')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('database-servers.index'));
+
+    $this->assertDatabaseHas('database_servers', [
+        'name' => 'SSH Tunnel Server',
+        'database_type' => 'mysql',
+    ]);
+
+    $server = DatabaseServer::where('name', 'SSH Tunnel Server')->first();
+    expect($server->ssh_config_id)->not->toBeNull();
+    expect($server->sshConfig)->not->toBeNull();
+    expect($server->sshConfig->host)->toBe('bastion.example.com');
+    expect($server->sshConfig->port)->toBe(22);
+    expect($server->sshConfig->username)->toBe('tunnel_user');
+    expect($server->sshConfig->auth_type)->toBe('password');
+    // Password should be stored (encrypted by model cast)
+    expect($server->sshConfig->password)->toBe('ssh_secret');
+});
+
+test('can create database server with SSH tunnel (key auth)', function () {
+    $user = User::factory()->create();
+    $volume = Volume::create([
+        'name' => 'Test Volume',
+        'type' => 'local',
+        'config' => ['path' => '/var/backups'],
+    ]);
+
+    $privateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest_key_content\n-----END OPENSSH PRIVATE KEY-----";
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.name', 'SSH Key Auth Server')
+        ->set('form.database_type', 'postgres')
+        ->set('form.host', 'private-postgres.internal')
+        ->set('form.port', 5432)
+        ->set('form.username', 'dbuser')
+        ->set('form.password', 'secret123')
+        ->set('form.database_names_input', 'myapp_production')
+        ->set('form.volume_id', $volume->id)
+        ->set('form.recurrence', 'daily')
+        ->set('form.retention_days', 14)
+        // SSH tunnel config
+        ->set('form.ssh_enabled', true)
+        ->set('form.ssh_config_mode', 'create')
+        ->set('form.ssh_host', 'bastion.example.com')
+        ->set('form.ssh_port', 2222)
+        ->set('form.ssh_username', 'tunnel_user')
+        ->set('form.ssh_auth_type', 'key')
+        ->set('form.ssh_private_key', $privateKey)
+        ->set('form.ssh_key_passphrase', 'keypass123')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('database-servers.index'));
+
+    $server = DatabaseServer::where('name', 'SSH Key Auth Server')->first();
+    expect($server->sshConfig->auth_type)->toBe('key');
+    expect($server->sshConfig->port)->toBe(2222);
+    // Private key and passphrase should be stored (encrypted by model cast)
+    expect($server->sshConfig->private_key)->toBe($privateKey);
+    expect($server->sshConfig->key_passphrase)->toBe('keypass123');
+});
+
+test('can create database server using existing SSH config', function () {
+    $user = User::factory()->create();
+    $volume = Volume::create([
+        'name' => 'Test Volume',
+        'type' => 'local',
+        'config' => ['path' => '/var/backups'],
+    ]);
+
+    // Create existing SSH config
+    $existingSshConfig = DatabaseServerSshConfig::factory()->create([
+        'host' => 'shared-bastion.example.com',
+        'username' => 'shared_user',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.name', 'Server Using Existing SSH')
+        ->set('form.database_type', 'mysql')
+        ->set('form.host', 'private-db.internal')
+        ->set('form.port', 3306)
+        ->set('form.username', 'dbuser')
+        ->set('form.password', 'secret123')
+        ->set('form.database_names_input', 'myapp_production')
+        ->set('form.volume_id', $volume->id)
+        ->set('form.recurrence', 'daily')
+        ->set('form.retention_days', 14)
+        // Use existing SSH config
+        ->set('form.ssh_enabled', true)
+        ->set('form.ssh_config_mode', 'existing')
+        ->set('form.ssh_config_id', $existingSshConfig->id)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('database-servers.index'));
+
+    $server = DatabaseServer::where('name', 'Server Using Existing SSH')->first();
+    expect($server->ssh_config_id)->toBe($existingSshConfig->id);
+    expect($server->sshConfig->host)->toBe('shared-bastion.example.com');
+});
+
+test('requiresSshTunnel returns correct value', function () {
+    $serverWithTunnel = DatabaseServer::factory()->withSshTunnel()->create();
+    $serverWithoutTunnel = DatabaseServer::factory()->create();
+
+    expect($serverWithTunnel->requiresSshTunnel())->toBeTrue();
+    expect($serverWithoutTunnel->requiresSshTunnel())->toBeFalse();
+});
+
+test('SSH config model provides accessor methods', function () {
+    $sshConfig = DatabaseServerSshConfig::factory()->create([
+        'host' => 'bastion.example.com',
+        'port' => 2222,
+        'username' => 'myuser',
+        'password' => 'test_password',
+    ]);
+
+    // getDecrypted returns decrypted values
+    $decrypted = $sshConfig->getDecrypted();
+    expect($decrypted['host'])->toBe('bastion.example.com')
+        ->and($decrypted['password'])->toBe('test_password');
+
+    // getSafe removes sensitive fields
+    $safe = $sshConfig->getSafe();
+    expect($safe)->toHaveKey('host')
+        ->and($safe)->toHaveKey('username')
+        ->and($safe)->not->toHaveKey('password')
+        ->and($safe)->not->toHaveKey('private_key')
+        ->and($safe)->not->toHaveKey('key_passphrase');
+
+    // getDisplayName returns correct format
+    expect($sshConfig->getDisplayName())->toBe('myuser@bastion.example.com:2222');
+});
+
+test('SSH tunnel section is not shown for SQLite', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.database_type', 'sqlite')
+        ->assertDontSee('SSH Tunnel');
+});
+
+test('updating database server preserves SSH config when not changed', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->withSshTunnel()->create([
+        'database_names' => ['mydb'],
+    ]);
+    $originalSshConfigId = $server->ssh_config_id;
+    $originalHost = $server->sshConfig->host;
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['server' => $server])
+        ->set('form.name', 'Updated Name')
+        // SSH fields left empty (should preserve existing)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $server->refresh();
+    expect($server->name)->toBe('Updated Name');
+    // SSH config should be preserved
+    expect($server->ssh_config_id)->toBe($originalSshConfigId);
+    expect($server->sshConfig->host)->toBe($originalHost);
+});
+
+test('disabling SSH tunnel clears SSH config link', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->withSshTunnel()->create([
+        'database_names' => ['mydb'],
+    ]);
+
+    expect($server->requiresSshTunnel())->toBeTrue();
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['server' => $server])
+        ->set('form.ssh_enabled', false)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $server->refresh();
+    expect($server->ssh_config_id)->toBeNull();
+    expect($server->requiresSshTunnel())->toBeFalse();
+});
+
+test('testSshConnection calls form method', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->withSshTunnel()->create();
+
+    // Calling testSshConnection should update form state
+    // The actual test will fail (no real SSH server) but the code path is exercised
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['server' => $server])
+        ->set('form.ssh_enabled', true)
+        ->set('form.ssh_host', 'nonexistent.invalid.host')
+        ->set('form.ssh_port', 22)
+        ->set('form.ssh_username', 'testuser')
+        ->set('form.ssh_password', 'testpass')
+        ->call('testSshConnection')
+        ->assertSet('form.testingSshConnection', false)
+        ->assertSet('form.sshTestSuccess', false);
+});

--- a/tests/Feature/Services/DatabaseConnectionTesterTest.php
+++ b/tests/Feature/Services/DatabaseConnectionTesterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
+use App\Services\DatabaseConnectionTester;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('test with SSH config returns error for SQLite', function () {
+    $sshConfig = new DatabaseServerSshConfig;
+    $sshConfig->host = 'bastion.example.com';
+    $sshConfig->port = 22;
+    $sshConfig->username = 'test';
+    $sshConfig->auth_type = 'password';
+    $sshConfig->password = 'test';
+
+    $result = DatabaseConnectionTester::test([
+        'database_type' => 'sqlite',
+        'host' => '/path/to/database.sqlite',
+        'port' => 0,
+        'username' => '',
+        'password' => '',
+        'database_name' => null,
+    ], $sshConfig);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('SSH tunneling is not supported for SQLite');
+});
+
+test('test with SSH config fails when SSH connection fails', function () {
+    $sshConfig = new DatabaseServerSshConfig;
+    $sshConfig->host = 'nonexistent.invalid.host.example';
+    $sshConfig->port = 22;
+    $sshConfig->username = 'test';
+    $sshConfig->auth_type = 'password';
+    $sshConfig->password = 'test';
+
+    $result = DatabaseConnectionTester::test([
+        'database_type' => 'mysql',
+        'host' => 'db.internal',
+        'port' => 3306,
+        'username' => 'root',
+        'password' => 'secret',
+        'database_name' => 'mydb',
+    ], $sshConfig);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('SSH connection failed');
+});
+
+test('forConnectionTest creates temporary server with SSH config', function () {
+    $sshConfig = DatabaseServerSshConfig::factory()->create([
+        'host' => 'bastion.example.com',
+        'username' => 'tunnel_user',
+    ]);
+
+    $server = DatabaseServer::forConnectionTest([
+        'host' => 'private-db.internal',
+        'port' => 3306,
+        'database_type' => 'mysql',
+        'username' => 'dbuser',
+        'password' => 'secret',
+    ], $sshConfig);
+
+    expect($server->host)->toBe('private-db.internal')
+        ->and($server->port)->toBe(3306)
+        ->and($server->username)->toBe('dbuser')
+        ->and($server->requiresSshTunnel())->toBeTrue()
+        ->and($server->sshConfig)->toBe($sshConfig)
+        ->and($server->exists)->toBeFalse(); // Not persisted
+});
+
+test('forConnectionTest creates temporary server without SSH config', function () {
+    $server = DatabaseServer::forConnectionTest([
+        'host' => 'db.example.com',
+        'port' => 5432,
+        'database_type' => 'postgres',
+        'username' => 'pguser',
+        'password' => 'secret',
+    ]);
+
+    expect($server->host)->toBe('db.example.com')
+        ->and($server->port)->toBe(5432)
+        ->and($server->requiresSshTunnel())->toBeFalse()
+        ->and($server->sshConfig)->toBeNull()
+        ->and($server->exists)->toBeFalse();
+});
+
+test('forConnectionTest uses default port when not specified', function () {
+    $server = DatabaseServer::forConnectionTest([
+        'host' => 'db.example.com',
+    ]);
+
+    expect($server->port)->toBe(3306); // Default MySQL port
+});
+
+test('getConnectionLabel returns basename for SQLite', function () {
+    $server = DatabaseServer::factory()->make([
+        'database_type' => 'sqlite',
+        'sqlite_path' => '/var/data/myapp.sqlite',
+    ]);
+
+    expect($server->getConnectionLabel())->toBe('myapp.sqlite')
+        ->and($server->getConnectionDetails())->toBe('/var/data/myapp.sqlite');
+});
+
+test('getConnectionLabel returns host:port for client-server databases', function () {
+    $server = DatabaseServer::factory()->make([
+        'database_type' => 'mysql',
+        'host' => 'db.example.com',
+        'port' => 3306,
+    ]);
+
+    expect($server->getConnectionLabel())->toBe('db.example.com:3306')
+        ->and($server->getConnectionDetails())->toBe('db.example.com:3306');
+});
+
+test('getSshDisplayName returns null when SSH not configured', function () {
+    $server = DatabaseServer::factory()->make();
+
+    expect($server->getSshDisplayName())->toBeNull();
+});
+
+test('getSshDisplayName returns display name when SSH configured', function () {
+    $server = DatabaseServer::factory()->withSshTunnel()->create();
+
+    expect($server->getSshDisplayName())->not->toBeNull()
+        ->and($server->getSshDisplayName())->toContain('@'); // Format: user@host:port
+});

--- a/tests/Feature/Services/SshTunnelServiceTest.php
+++ b/tests/Feature/Services/SshTunnelServiceTest.php
@@ -1,0 +1,226 @@
+<?php
+
+use App\Exceptions\SshTunnelException;
+use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
+use App\Services\SshTunnelService;
+
+test('throws exception when SSH is not configured', function () {
+    $server = DatabaseServer::factory()->make(); // No SSH config
+
+    $service = new SshTunnelService;
+
+    expect(fn () => $service->establish($server))
+        ->toThrow(SshTunnelException::class, 'SSH tunnel is not configured for this server');
+});
+
+test('service has safe defaults when no tunnel is established', function () {
+    $service = new SshTunnelService;
+
+    expect($service->isActive())->toBeFalse()
+        ->and($service->getLocalPort())->toBeNull();
+
+    // close should not throw
+    $service->close();
+    expect($service->isActive())->toBeFalse();
+});
+
+test('testConnection returns error for invalid config', function (array $config) {
+    $sshConfig = new DatabaseServerSshConfig;
+    foreach ($config as $key => $value) {
+        $sshConfig->$key = $value;
+    }
+
+    $result = SshTunnelService::testConnection($sshConfig);
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->not->toBeEmpty();
+})->with([
+    'invalid host' => [[
+        'host' => 'nonexistent.invalid.host.example',
+        'port' => 22,
+        'username' => 'test',
+        'auth_type' => 'password',
+        'password' => 'test',
+    ]],
+    'empty credentials' => [[
+        'host' => 'bastion.example.com',
+        'port' => 22,
+        'username' => '',
+        'auth_type' => 'password',
+        'password' => '',
+    ]],
+]);
+
+test('testConnection cleans up key file after test', function () {
+    $sshConfig = new DatabaseServerSshConfig;
+    $sshConfig->host = 'nonexistent.invalid.host.example';
+    $sshConfig->port = 22;
+    $sshConfig->username = 'test';
+    $sshConfig->auth_type = 'key';
+    $sshConfig->private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest_key\n-----END OPENSSH PRIVATE KEY-----";
+    $sshConfig->key_passphrase = null;
+
+    $result = SshTunnelService::testConnection($sshConfig);
+
+    // Test should fail but that's expected - we're testing cleanup
+    expect($result['success'])->toBeFalse();
+
+    // Key file should have been cleaned up (no lingering temp files)
+    $tempFiles = glob(sys_get_temp_dir().'/ssh_key_*');
+    expect($tempFiles)->toBeEmpty();
+});
+
+test('testConnection handles key with passphrase', function () {
+    $sshConfig = new DatabaseServerSshConfig;
+    $sshConfig->host = 'nonexistent.invalid.host.example';
+    $sshConfig->port = 22;
+    $sshConfig->username = 'test';
+    $sshConfig->auth_type = 'key';
+    $sshConfig->private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest_key\n-----END OPENSSH PRIVATE KEY-----";
+    $sshConfig->key_passphrase = 'secret_passphrase';
+
+    $result = SshTunnelService::testConnection($sshConfig);
+
+    // Test should fail but that's expected - we're verifying the code path doesn't throw
+    expect($result['success'])->toBeFalse();
+    expect($result['message'])->not->toBeEmpty();
+});
+
+test('establish returns local endpoint on successful tunnel', function () {
+    // Create SSH config without persisting to database
+    $sshConfig = new DatabaseServerSshConfig;
+    $sshConfig->host = 'bastion.example.com';
+    $sshConfig->port = 22;
+    $sshConfig->username = 'tunnel_user';
+    $sshConfig->auth_type = 'password';
+    $sshConfig->password = 'ssh_password';
+
+    // Create server with SSH config relationship set
+    $server = new DatabaseServer;
+    $server->host = 'database.internal';
+    $server->port = 3306;
+    $server->database_type = 'mysql';
+    $server->ssh_config_id = 'temp';
+    $server->setRelation('sshConfig', $sshConfig);
+
+    // Mock the Process
+    $mockProcess = Mockery::mock(\Symfony\Component\Process\Process::class);
+    $mockProcess->shouldReceive('setTimeout')->once()->with(null);
+    $mockProcess->shouldReceive('start')->once();
+    $mockProcess->shouldReceive('isRunning')->andReturn(true);
+    $mockProcess->shouldReceive('stop')->andReturn(0);
+
+    // Create partial mock of SshTunnelService
+    $service = Mockery::mock(SshTunnelService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('allocateLocalPort')->once()->andReturn(54321);
+    $service->shouldReceive('createTunnelProcess')->once()->andReturn($mockProcess);
+    $service->shouldReceive('waitForTunnel')->once()->andReturn(true);
+
+    // Act
+    $result = $service->establish($server);
+
+    // Assert
+    expect($result)->toBe(['host' => '127.0.0.1', 'port' => 54321]);
+    expect($service->getLocalPort())->toBe(54321);
+    expect($service->isActive())->toBeTrue();
+
+    // Cleanup
+    $service->close();
+});
+
+test('establish throws exception when tunnel fails to connect', function () {
+    // Create SSH config without persisting to database
+    $sshConfig = new DatabaseServerSshConfig;
+    $sshConfig->host = 'bastion.example.com';
+    $sshConfig->port = 22;
+    $sshConfig->username = 'tunnel_user';
+    $sshConfig->auth_type = 'password';
+    $sshConfig->password = 'ssh_password';
+
+    // Create server with SSH config relationship set
+    $server = new DatabaseServer;
+    $server->host = 'database.internal';
+    $server->port = 3306;
+    $server->database_type = 'mysql';
+    $server->ssh_config_id = 'temp';
+    $server->setRelation('sshConfig', $sshConfig);
+
+    // Mock the Process to simulate failure
+    $mockProcess = Mockery::mock(\Symfony\Component\Process\Process::class);
+    $mockProcess->shouldReceive('setTimeout')->once()->with(null);
+    $mockProcess->shouldReceive('start')->once();
+    $mockProcess->shouldReceive('isRunning')->andReturn(false);
+    $mockProcess->shouldReceive('getErrorOutput')->andReturn('Connection refused');
+    $mockProcess->shouldReceive('stop')->andReturn(0);
+
+    // Create partial mock
+    $service = Mockery::mock(SshTunnelService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('allocateLocalPort')->once()->andReturn(54321);
+    $service->shouldReceive('createTunnelProcess')->once()->andReturn($mockProcess);
+    $service->shouldReceive('waitForTunnel')->once()->andReturn(false);
+
+    // Act & Assert
+    expect(fn () => $service->establish($server))
+        ->toThrow(SshTunnelException::class, 'Failed to establish SSH tunnel');
+
+    // Service should have cleaned up
+    expect($service->isActive())->toBeFalse();
+    expect($service->getLocalPort())->toBeNull();
+});
+
+test('establish with key auth creates temp key file', function () {
+    // Create SSH config without persisting to database
+    $sshConfig = new DatabaseServerSshConfig;
+    $sshConfig->host = 'bastion.example.com';
+    $sshConfig->port = 2222;
+    $sshConfig->username = 'key_user';
+    $sshConfig->auth_type = 'key';
+    $sshConfig->private_key = 'FAKE_SSH_PRIVATE_KEY_FOR_TESTS_ONLY';
+    $sshConfig->key_passphrase = null;
+
+    // Create server with SSH config relationship set
+    $server = new DatabaseServer;
+    $server->host = 'postgres.internal';
+    $server->port = 5432;
+    $server->database_type = 'postgres';
+    $server->ssh_config_id = 'temp';
+    $server->setRelation('sshConfig', $sshConfig);
+
+    // Mock the Process
+    $mockProcess = Mockery::mock(\Symfony\Component\Process\Process::class);
+    $mockProcess->shouldReceive('setTimeout')->once()->with(null);
+    $mockProcess->shouldReceive('start')->once();
+    $mockProcess->shouldReceive('isRunning')->andReturn(true);
+    $mockProcess->shouldReceive('stop')->andReturn(0);
+
+    // Create partial mock - don't mock createTunnelProcess to test key file creation
+    $service = Mockery::mock(SshTunnelService::class)->makePartial();
+    $service->shouldAllowMockingProtectedMethods();
+    $service->shouldReceive('allocateLocalPort')->once()->andReturn(54322);
+    $service->shouldReceive('createTunnelProcess')
+        ->once()
+        ->andReturnUsing(function ($command) use ($mockProcess) {
+            // Verify the command contains the key file path
+            expect($command)->toContain('-i');
+            expect($command)->toContain('ssh_key_');
+
+            return $mockProcess;
+        });
+    $service->shouldReceive('waitForTunnel')->once()->andReturn(true);
+
+    // Act
+    $result = $service->establish($server);
+
+    // Assert
+    expect($result['port'])->toBe(54322);
+
+    // Cleanup - this should also remove the temp key file
+    $service->close();
+
+    // Verify key file was cleaned up
+    $keyFiles = glob(sys_get_temp_dir().'/ssh_key_*');
+    expect($keyFiles)->toBeEmpty();
+});


### PR DESCRIPTION
## Summary

Add SSH tunnel support for database connections, enabling backups and restores for databases behind firewalls via bastion/jump servers.

## Changes

- Add SshTunnelService for tunnel lifecycle management using command-line ssh
- Support password and private key authentication methods
- Integrate tunneling into BackupTask, RestoreTask, and connection testing
- Add UI for SSH configuration with independent connection test button
- Encrypt sensitive fields (password, private_key, passphrase) at rest
- Mask SSH secrets in logs