### PR TITLE
Redirect login to registration if no users exist

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -77,7 +77,13 @@ class FortifyServiceProvider extends ServiceProvider
      */
     private function configureViews(): void
     {
-        Fortify::loginView(fn () => view('livewire.auth.login'));
+        Fortify::loginView(function () {
+            if (User::count() === 0) {
+                return redirect()->route('register');
+            }
+
+            return view('livewire.auth.login');
+        });
         Fortify::twoFactorChallengeView(fn () => view('livewire.auth.two-factor-challenge'));
         Fortify::confirmPasswordView(function () {
             // OAuth-only users have no password to confirm

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -19,6 +19,10 @@
             <x-alert class="alert-error" icon="o-exclamation-circle">{{ session('error') }}</x-alert>
         @endif
 
+        @error('email')
+            <x-alert class="alert-error" icon="o-exclamation-circle">{{ $message }}</x-alert>
+        @enderror
+
         <x-form method="POST" action="{{ route('login.store') }}" class="flex flex-col gap-6">
             @csrf
 

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -5,9 +5,17 @@ use App\Models\User;
 use Laravel\Fortify\Features;
 
 test('login screen can be rendered', function () {
+    User::factory()->create();
+
     $response = $this->get(route('login'));
 
     $response->assertStatus(200);
+});
+
+test('login redirects to register when no users exist', function () {
+    $response = $this->get(route('login'));
+
+    $response->assertRedirect(route('register'));
 });
 
 test('users can authenticate using the login screen', function () {


### PR DESCRIPTION
### Summary

This pull request introduces a feature to redirect users attempting to access the login page to the registration page if no users exist in the system.

### Changes Made

- Modified `FortifyServiceProvider` to redirect login attempts to the registration page when there are no existing users.
- Added a feature test to verify the login-to-registration redirection functionality.
- Ensured email validation errors are displayed correctly on the login page.

### Checklist

- [ ] Tests have been added or adjusted as necessary.
- [ ] Documentation has been updated (if required).
- [ ] Code changes are covered with tests.
- [ ] CI/CD pipelines have been checked for successful run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login page now redirects to registration when no users exist in the system, enabling streamlined first-time setup.

* **Bug Fixes**
  * Added validation error display for email field on the login page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->