### PR TITLE
fix: add missing closeLogs method to dashboard LatestJobs

### DIFF
--- a/app/Livewire/Dashboard/LatestJobs.php
+++ b/app/Livewire/Dashboard/LatestJobs.php
@@ -42,6 +42,12 @@ class LatestJobs extends Component
         $this->showLogsModal = true;
     }
 
+    public function closeLogs(): void
+    {
+        $this->showLogsModal = false;
+        $this->selectedJobId = null;
+    }
+
     public function getSelectedJobProperty(): ?BackupJob
     {
         if (! $this->selectedJobId) {

--- a/tests/Feature/Dashboard/LatestJobsTest.php
+++ b/tests/Feature/Dashboard/LatestJobsTest.php
@@ -52,3 +52,28 @@ test('latest jobs can filter by status', function () {
         ->assertDontSee('Completed Server')
         ->assertSee('Failed Server');
 });
+
+test('latest jobs can open and close logs modal', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create([
+        'name' => 'Test Server',
+        'database_names' => ['test_db'],
+    ]);
+
+    $snapshots = $factory->createSnapshots($server, 'manual', $user->id);
+    $job = $snapshots[0]->job;
+
+    Livewire::actingAs($user)
+        ->test(LatestJobs::class)
+        ->call('load')
+        ->assertSet('showLogsModal', false)
+        ->assertSet('selectedJobId', null)
+        ->call('viewLogs', $job->id)
+        ->assertSet('showLogsModal', true)
+        ->assertSet('selectedJobId', $job->id)
+        ->call('closeLogs')
+        ->assertSet('showLogsModal', false)
+        ->assertSet('selectedJobId', null);
+});


### PR DESCRIPTION
## Summary
- Add missing `closeLogs()` method to `LatestJobs` component
- The dashboard's logs modal calls `$wire.closeLogs()` on close, but the method was missing
- This caused a `MethodNotFoundException` when closing the modal

## Test plan
- [x] Added test to verify modal open/close behavior
- [x] Test fails without fix, passes with fix
- [x] All existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can close the logs modal in the dashboard's Latest Jobs section; closing hides the modal and clears the selected job state.

* **Tests**
  * Added test coverage verifying the logs modal can be opened and closed and that state is properly reset after dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->