### PR TITLE
fix: pre-install FrankenPHP worker stub in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ ENV OCTANE_ENABLED="true"
 COPY --from=backend-build /app /app
 COPY --from=frontend-build /app/public/build /app/public/build
 
+# Copy FrankenPHP worker stub for Octane (file is gitignored, so we copy from vendor)
+RUN cp vendor/laravel/octane/src/Commands/stubs/frankenphp-worker.php public/
+
 RUN cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 RUN cp /usr/local/etc/php/php-custom-production.ini /usr/local/etc/php/conf.d/zz-php-custom-production.ini
 


### PR DESCRIPTION
## Summary

- Pre-install the `frankenphp-worker.php` file during Docker build by copying it from the vendor directory
- This fixes the permission denied error when running the container with `--user` flag

## Problem

The `frankenphp-worker.php` file is in `.gitignore`, so when we builds the image from a fresh git clone, the file doesn't exist. When Octane starts, it tries to create the file in `/app/public/`, but when running with `--user` flag, the non-root user doesn't have write permissions to that directory.

Error:
```
copy(/app/public/frankenphp-worker.php): Failed to open stream: Permission denied
```

## Solution

Copy the worker stub from `vendor/laravel/octane/src/Commands/stubs/frankenphp-worker.php` during the Docker build process, ensuring it's always present regardless of git clone state.

## Test plan

- [x] Removed `frankenphp-worker.php` locally
- [x] Built Docker image without the file → reproduced permission denied error
- [x] Applied fix to Dockerfile
- [x] Rebuilt Docker image → container starts successfully with `--user` flag

Fixes #73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to include a worker file for improved application handling in the deployed environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->