### PR TITLE
feat: add snapshot file verification to detect missing backups

### DIFF
--- a/app/Console/Commands/VerifySnapshotFiles.php
+++ b/app/Console/Commands/VerifySnapshotFiles.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\VerifySnapshotFileJob;
+use Illuminate\Console\Command;
+
+class VerifySnapshotFiles extends Command
+{
+    protected $signature = 'snapshots:verify-files';
+
+    protected $description = 'Verify that backup files still exist on their storage volumes';
+
+    public function handle(): int
+    {
+        VerifySnapshotFileJob::dispatch();
+
+        $this->info('Snapshot file verification job dispatched.');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Jobs/VerifySnapshotFileJob.php
+++ b/app/Jobs/VerifySnapshotFileJob.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Snapshot;
+use App\Services\Backup\Filesystems\FilesystemProvider;
+use App\Services\FailureNotificationService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+class VerifySnapshotFileJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 3600;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public ?string $snapshotId = null
+    ) {
+        $this->onQueue('backups');
+    }
+
+    /** @var Collection<int, array{server: string, database: string, filename: string}> */
+    private Collection $newlyMissing;
+
+    public function handle(FilesystemProvider $filesystemProvider, FailureNotificationService $notificationService): void
+    {
+        $this->newlyMissing = collect();
+
+        if ($this->snapshotId) {
+            $this->verifySnapshot($filesystemProvider, $this->snapshotId);
+
+            return;
+        }
+
+        $snapshotIds = Snapshot::query()
+            ->whereNotNull('filename')
+            ->where('filename', '!=', '')
+            ->whereRelation('job', 'status', 'completed')
+            ->pluck('id');
+
+        foreach ($snapshotIds as $id) {
+            $this->verifySnapshot($filesystemProvider, $id);
+        }
+
+        if ($this->newlyMissing->isNotEmpty()) {
+            $notificationService->notifySnapshotsMissing($this->newlyMissing);
+        }
+    }
+
+    private function verifySnapshot(FilesystemProvider $filesystemProvider, string $snapshotId): void
+    {
+        $snapshot = Snapshot::with(['volume', 'databaseServer'])->find($snapshotId);
+
+        if (! $snapshot) {
+            return;
+        }
+
+        try {
+            $filesystem = $filesystemProvider->getForVolume($snapshot->volume);
+            $exists = $filesystem->fileExists($snapshot->filename);
+
+            $wasPreviouslyExisting = $snapshot->file_exists;
+
+            $snapshot->update([
+                'file_exists' => $exists,
+                'file_verified_at' => now(),
+            ]);
+
+            if (! $exists && $wasPreviouslyExisting) {
+                $this->newlyMissing->push([
+                    'server' => $snapshot->databaseServer->name ?? 'Unknown',
+                    'database' => $snapshot->database_name,
+                    'filename' => $snapshot->filename,
+                ]);
+            }
+        } catch (\Exception $e) {
+            Log::warning('Failed to verify snapshot file existence', [
+                'snapshot_id' => $snapshotId,
+                'filename' => $snapshot->filename,
+                'error' => $e->getMessage(),
+            ]);
+
+            // On transient errors, update verified_at but leave file_exists unchanged
+            $snapshot->update([
+                'file_verified_at' => now(),
+            ]);
+        }
+    }
+}

--- a/app/Livewire/BackupJob/Index.php
+++ b/app/Livewire/BackupJob/Index.php
@@ -34,6 +34,9 @@ class Index extends Component
     #[Url]
     public string $serverFilter = '';
 
+    #[Url]
+    public string $fileMissing = '';
+
     /** @var array<string, string> */
     public array $sortBy = ['column' => 'created_at', 'direction' => 'desc'];
 
@@ -86,6 +89,11 @@ class Index extends Component
         $this->resetPage();
     }
 
+    public function updatingFileMissing(): void
+    {
+        $this->resetPage();
+    }
+
     /**
      * @param  string|array<string, mixed>  $property
      */
@@ -98,7 +106,7 @@ class Index extends Component
 
     public function clear(): void
     {
-        $this->reset('search', 'statusFilter', 'typeFilter', 'serverFilter');
+        $this->reset('search', 'statusFilter', 'typeFilter', 'serverFilter', 'fileMissing');
         $this->resetPage();
         $this->success('Filters cleared.', position: 'toast-bottom');
     }
@@ -272,6 +280,7 @@ class Index extends Component
             statusFilter: $this->statusFilter !== '' ? [$this->statusFilter] : [],
             typeFilter: $this->typeFilter,
             serverFilter: $this->serverFilter,
+            fileMissing: $this->fileMissing !== '',
             sortColumn: $this->sortBy['column'],
             sortDirection: $this->sortBy['direction']
         )->paginate(15);

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -22,6 +22,8 @@ use Illuminate\Support\Carbon;
  * @property string $volume_id
  * @property string $filename
  * @property int $file_size
+ * @property bool $file_exists
+ * @property Carbon|null $file_verified_at
  * @property string|null $checksum
  * @property Carbon $started_at
  * @property string $database_name
@@ -81,6 +83,8 @@ class Snapshot extends Model
         'volume_id',
         'filename',
         'file_size',
+        'file_exists',
+        'file_verified_at',
         'checksum',
         'started_at',
         'database_name',
@@ -96,6 +100,8 @@ class Snapshot extends Model
         return [
             'started_at' => 'datetime',
             'file_size' => 'integer',
+            'file_exists' => 'boolean',
+            'file_verified_at' => 'datetime',
             'database_type' => DatabaseType::class,
             'metadata' => 'array',
             'compression_type' => CompressionType::class,

--- a/app/Notifications/SnapshotsMissingNotification.php
+++ b/app/Notifications/SnapshotsMissingNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Support\Collection;
+
+class SnapshotsMissingNotification extends BaseFailedNotification
+{
+    private const MAX_LISTED = 10;
+
+    /**
+     * @param  Collection<int, array{server: string, database: string, filename: string}>  $missingSnapshots
+     */
+    public function __construct(
+        public Collection $missingSnapshots
+    ) {
+        parent::__construct(new \RuntimeException($this->fileList()));
+    }
+
+    public function getMessage(): FailedNotificationMessage
+    {
+        $count = $this->missingSnapshots->count();
+
+        return $this->message(
+            title: "⚠️ {$count} backup ".str('file')->plural($count).' missing',
+            body: "{$count} backup ".str('file')->plural($count).' could not be found on their storage volumes.',
+            actionText: '🔗 View Missing Files',
+            actionUrl: route('jobs.index', ['fileMissing' => '1']),
+            footerText: '🕐 '.now()->toDateTimeString(),
+            errorLabel: '📁 Missing Files',
+        );
+    }
+
+    private function fileList(): string
+    {
+        $lines = $this->missingSnapshots
+            ->take(self::MAX_LISTED)
+            ->map(fn (array $snapshot) => "{$snapshot['server']} / {$snapshot['database']} — {$snapshot['filename']}")
+            ->toArray();
+
+        if ($this->missingSnapshots->count() > self::MAX_LISTED) {
+            $remaining = $this->missingSnapshots->count() - self::MAX_LISTED;
+            $lines[] = "... and {$remaining} more";
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/app/Queries/BackupJobQuery.php
+++ b/app/Queries/BackupJobQuery.php
@@ -59,6 +59,7 @@ class BackupJobQuery
         array $statusFilter = [],
         string $typeFilter = 'all',
         string $serverFilter = '',
+        bool $fileMissing = false,
         string $sortColumn = 'created_at',
         string $sortDirection = 'desc'
     ): Builder {
@@ -87,6 +88,9 @@ class BackupJobQuery
             })
             ->when($serverFilter !== '', function (Builder $query) use ($serverFilter) {
                 self::applyServerFilter($query, $serverFilter);
+            })
+            ->when($fileMissing, function (Builder $query) {
+                $query->whereHas('snapshot', fn (Builder $q) => $q->whereRaw('file_exists = ?', [false]));
             });
 
         // Handle sorting

--- a/app/Services/Backup/BackupTask.php
+++ b/app/Services/Backup/BackupTask.php
@@ -99,6 +99,7 @@ class BackupTask
                 'filename' => $filename,
                 'file_size' => $fileSize,
                 'checksum' => $checksum,
+                'file_verified_at' => now(),
             ]);
 
             // Mark job as completed

--- a/app/Services/FailureNotificationService.php
+++ b/app/Services/FailureNotificationService.php
@@ -7,6 +7,8 @@ use App\Models\Snapshot;
 use App\Notifications\BackupFailedNotification;
 use App\Notifications\BaseFailedNotification;
 use App\Notifications\RestoreFailedNotification;
+use App\Notifications\SnapshotsMissingNotification;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification;
 
 class FailureNotificationService
@@ -19,6 +21,14 @@ class FailureNotificationService
     public function notifyRestoreFailed(Restore $restore, \Throwable $exception): void
     {
         $this->send(new RestoreFailedNotification($restore, $exception));
+    }
+
+    /**
+     * @param  Collection<int, array{server: string, database: string, filename: string}>  $missingSnapshots
+     */
+    public function notifySnapshotsMissing(Collection $missingSnapshots): void
+    {
+        $this->send(new SnapshotsMissingNotification($missingSnapshots));
     }
 
     private function send(BaseFailedNotification $notification): void

--- a/config/backup.php
+++ b/config/backup.php
@@ -108,4 +108,17 @@ return [
     */
 
     'cleanup_cron' => env('BACKUP_CLEANUP_CRON', '0 4 * * *'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Snapshot File Verification
+    |--------------------------------------------------------------------------
+    |
+    | Enable scheduled verification of backup files on their storage volumes.
+    | When enabled, the scheduler checks that snapshot files still exist.
+    |
+    */
+
+    'verify_files' => env('BACKUP_VERIFY_FILES', true),
+    'verify_files_cron' => env('BACKUP_VERIFY_FILES_CRON', '0 5 * * *'),
 ];

--- a/database/factories/SnapshotFactory.php
+++ b/database/factories/SnapshotFactory.php
@@ -88,6 +88,28 @@ class SnapshotFactory extends Factory
     }
 
     /**
+     * Set the snapshot file as missing.
+     */
+    public function fileMissing(): static
+    {
+        return $this->state(fn () => [
+            'file_exists' => false,
+            'file_verified_at' => now(),
+        ]);
+    }
+
+    /**
+     * Set the snapshot file as verified (exists).
+     */
+    public function fileVerified(): static
+    {
+        return $this->state(fn () => [
+            'file_exists' => true,
+            'file_verified_at' => now(),
+        ]);
+    }
+
+    /**
      * Create a snapshot with a real file in the volume.
      */
     public function withFile(?string $content = null): static

--- a/database/migrations/2026_02_06_093140_add_file_verification_to_snapshots_table.php
+++ b/database/migrations/2026_02_06_093140_add_file_verification_to_snapshots_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->boolean('file_exists')->default(true)->after('file_size')->index();
+            $table->timestamp('file_verified_at')->nullable()->after('file_exists');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->dropColumn(['file_exists', 'file_verified_at']);
+        });
+    }
+};

--- a/docs/docs/self-hosting/configuration/backup.md
+++ b/docs/docs/self-hosting/configuration/backup.md
@@ -20,6 +20,8 @@ Configure backup behavior, schedules, compression, and storage settings.
 | `BACKUP_DAILY_CRON`        | Cron schedule for daily backups                           | `0 2 * * *` (2:00 AM)        |
 | `BACKUP_WEEKLY_CRON`       | Cron schedule for weekly backups                          | `0 3 * * 0` (Sunday 3:00 AM) |
 | `BACKUP_CLEANUP_CRON`      | Cron schedule for snapshot cleanup                        | `0 4 * * *` (4:00 AM)        |
+| `BACKUP_VERIFY_FILES`      | Enable scheduled file verification                        | `true`                       |
+| `BACKUP_VERIFY_FILES_CRON` | Cron schedule for file verification                       | `0 5 * * *` (5:00 AM)        |
 
 ## Compression Options
 

--- a/docs/docs/user-guide/snapshots.md
+++ b/docs/docs/user-guide/snapshots.md
@@ -6,6 +6,14 @@ sidebar_position: 4
 
 Snapshots are the backup files created when you backup a database. They contain all the data needed to restore your database to a specific point in time.
 
+## File Verification
+
+Databasement verifies daily that backup files still exist on their storage volumes. Missing files are surfaced on the dashboard and in the jobs index with a "File missing" warning.
+
+You can also trigger verification manually from the dashboard.
+
+See [Backup Configuration](/self-hosting/configuration/backup) for `BACKUP_VERIFY_FILES` and `BACKUP_VERIFY_FILES_CRON` settings.
+
 ## Restore Process
 
 When you restore a snapshot, Databasement:

--- a/resources/views/livewire/backup-job/_filters.blade.php
+++ b/resources/views/livewire/backup-job/_filters.blade.php
@@ -1,6 +1,6 @@
 @php
     $isDesktop = $variant === 'desktop';
-    $hasFilters = $search || $statusFilter !== '' || $typeFilter !== '' || $serverFilter !== '';
+    $hasFilters = $search || $statusFilter !== '' || $typeFilter !== '' || $serverFilter !== '' || $fileMissing !== '';
 @endphp
 
 @if($isDesktop)
@@ -33,6 +33,11 @@
         :options="$statusOptions"
         class="!select-sm w-32"
     />
+    <label class="flex items-center gap-1.5 cursor-pointer text-sm text-warning">
+        <input type="checkbox" class="checkbox checkbox-warning checkbox-xs" wire:model.live="fileMissing" value="1" @checked($fileMissing !== '') />
+        <x-icon name="o-exclamation-triangle" class="w-4 h-4" />
+        {{ __('Missing') }}
+    </label>
     @if($hasFilters)
         <x-button
             icon="o-x-mark"
@@ -83,6 +88,11 @@
                 :options="$statusOptions"
                 class="!select-sm w-32"
             />
+            <label class="flex items-center gap-1.5 cursor-pointer text-sm text-warning">
+                <input type="checkbox" class="checkbox checkbox-warning checkbox-xs" wire:model.live="fileMissing" value="1" @checked($fileMissing !== '') />
+                <x-icon name="o-exclamation-triangle" class="w-4 h-4" />
+                {{ __('Missing') }}
+            </label>
             @if($hasFilters)
                 <x-button
                     icon="o-x-mark"
@@ -117,6 +127,11 @@
             wire:model.live="statusFilter"
             :options="$statusOptions"
         />
+        <label class="flex items-center gap-2 cursor-pointer text-sm text-warning">
+            <input type="checkbox" class="checkbox checkbox-warning checkbox-sm" wire:model.live="fileMissing" value="1" @checked($fileMissing !== '') />
+            <x-icon name="o-exclamation-triangle" class="w-4 h-4" />
+            {{ __('File missing') }}
+        </label>
         @if($hasFilters)
             <x-button
                 label="{{ __('Clear filters') }}"

--- a/resources/views/livewire/backup-job/_logs-modal.blade.php
+++ b/resources/views/livewire/backup-job/_logs-modal.blade.php
@@ -60,6 +60,18 @@
                     </div>
                 </div>
 
+                {{-- File missing warning --}}
+                @if($snapshot && !$snapshot->file_exists)
+                    <x-alert class="alert-warning" icon="o-exclamation-triangle">
+                        {{ __('Backup file is missing from volume') }}
+                        @if($snapshot->file_verified_at)
+                            <span class="text-base-content/70">
+                                — {{ __('checked') }} {{ \App\Support\Formatters::humanDate($snapshot->file_verified_at) }} ({{ $snapshot->file_verified_at->diffForHumans() }})
+                            </span>
+                        @endif
+                    </x-alert>
+                @endif
+
                 {{-- Compression and Volume badges --}}
                 @if($snapshot)
                     <div class="flex flex-wrap items-center gap-2 pt-1">

--- a/resources/views/livewire/backup-job/index.blade.php
+++ b/resources/views/livewire/backup-job/index.blade.php
@@ -21,10 +21,12 @@
 
     <!-- TABLE -->
     <x-card shadow>
-        <x-table :headers="$headers" :rows="$jobs" :sort-by="$sortBy" with-pagination>
+        <x-table :headers="$headers" :rows="$jobs" :sort-by="$sortBy" with-pagination
+            :row-decoration="['bg-warning/5' => fn($job) => $job->snapshot && !$job->snapshot->file_exists]"
+        >
             <x-slot:empty>
                 <div class="text-center text-base-content/50 py-8">
-                    @if($search || $statusFilter !== '' || $typeFilter !== '' || $serverFilter !== '')
+                    @if($search || $statusFilter !== '' || $typeFilter !== '' || $serverFilter !== '' || $fileMissing !== '')
                         {{ __('No jobs found matching your filters.') }}
                     @else
                         {{ __('No jobs yet. Backups and restores will appear here.') }}
@@ -87,7 +89,27 @@
                 @else
                     <x-badge value="{{ __('Pending') }}" class="badge-info" />
                 @endif
-
+                @if($job->snapshot && !$job->snapshot->file_exists)
+                    <x-popover>
+                        <x-slot:trigger>
+                            <div class="flex items-center gap-1 text-warning text-xs mt-1">
+                                <x-icon name="o-exclamation-triangle" class="w-3.5 h-3.5" />
+                                {{ __('File missing') }}
+                            </div>
+                        </x-slot:trigger>
+                        <x-slot:content>
+                            <div class="text-xs space-y-1">
+                                <div class="font-semibold text-warning">{{ __('Backup file not found on volume') }}</div>
+                                @if($job->snapshot->file_verified_at)
+                                    <div class="text-base-content/70">
+                                        {{ __('Checked') }}: {{ \App\Support\Formatters::humanDate($job->snapshot->file_verified_at) }}
+                                        ({{ $job->snapshot->file_verified_at->diffForHumans() }})
+                                    </div>
+                                @endif
+                            </div>
+                        </x-slot:content>
+                    </x-popover>
+                @endif
             @endscope
 
             @scope('cell_duration_ms', $job)

--- a/resources/views/livewire/dashboard/stats-cards.blade.php
+++ b/resources/views/livewire/dashboard/stats-cards.blade.php
@@ -14,14 +14,45 @@
     @else
         {{-- Total Snapshots --}}
         <x-card>
-            <div class="flex items-center gap-4">
-                <div class="w-12 h-12 rounded-lg bg-primary/10 flex items-center justify-center">
-                    <x-icon name="o-camera" class="w-6 h-6 text-primary" />
+            <div class="space-y-3">
+                {{-- Header: label + verify button --}}
+                <div class="flex items-center justify-between">
+                    <h3 class="text-xs font-semibold uppercase tracking-wider text-base-content/50">{{ __('Snapshots') }}</h3>
+                    <x-button
+                        icon="o-arrow-path"
+                        label="{{ __('Verify') }}"
+                        wire:click="verifyFiles"
+                        spinner
+                        class="btn-ghost btn-xs text-base-content/60"
+                    />
                 </div>
-                <div>
-                    <div class="text-sm text-base-content/70">{{ __('Total Snapshots') }}</div>
-                    <div class="text-2xl font-bold">{{ number_format($totalSnapshots) }}</div>
+
+                {{-- Count + status badge --}}
+                <div class="flex items-end justify-between">
+                    <div class="flex items-baseline gap-1.5">
+                        <span class="text-3xl font-bold tabular-nums">{{ number_format($totalSnapshots) }}</span>
+                        <span class="text-sm text-base-content/40">{{ __('snapshots') }}</span>
+                    </div>
+
+                    @if($missingSnapshots > 0)
+                        <a href="{{ route('jobs.index', ['fileMissing' => '1']) }}" class="badge badge-warning badge-sm gap-1 py-2.5 hover:brightness-95 transition-all" wire:navigate>
+                            <x-icon name="o-exclamation-triangle" class="w-3.5 h-3.5" />
+                            {{ $missingSnapshots }} {{ __('missing') }}
+                            <x-icon name="o-chevron-right" class="w-3 h-3 opacity-60" />
+                        </a>
+                    @elseif($verifiedSnapshots > 0 && $verifiedSnapshots === $totalSnapshots)
+                        <span class="badge badge-success badge-sm gap-1 py-2.5">
+                            <x-icon name="o-check-circle" class="w-3.5 h-3.5" />
+                            {{ __('All verified') }}
+                        </span>
+                    @elseif($totalSnapshots > 0)
+                        <span class="badge badge-ghost badge-sm gap-1 py-2.5">
+                            <x-icon name="o-clock" class="w-3.5 h-3.5" />
+                            {{ $verifiedSnapshots }}/{{ $totalSnapshots }}
+                        </span>
+                    @endif
                 </div>
+
             </div>
         </x-card>
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -16,3 +16,8 @@ Schedule::command('backups:run weekly')->cron(config('backup.weekly_cron'));
 
 // Cleanup expired snapshots (default: every day at 4:00 AM)
 Schedule::command('snapshots:cleanup')->cron(config('backup.cleanup_cron'));
+
+// Verify snapshot files exist on volumes (default: every day at 5:00 AM)
+Schedule::command('snapshots:verify-files')
+    ->cron(config('backup.verify_files_cron'))
+    ->when(fn () => config('backup.verify_files'));

--- a/tests/Feature/Console/VerifySnapshotFilesTest.php
+++ b/tests/Feature/Console/VerifySnapshotFilesTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Jobs\VerifySnapshotFileJob;
+use Illuminate\Support\Facades\Queue;
+
+test('dispatches a single verification job', function () {
+    Queue::fake();
+
+    $this->artisan('snapshots:verify-files')
+        ->expectsOutput('Snapshot file verification job dispatched.')
+        ->assertExitCode(0);
+
+    Queue::assertPushed(VerifySnapshotFileJob::class, 1);
+    Queue::assertPushed(VerifySnapshotFileJob::class, fn ($job) => $job->snapshotId === null);
+});

--- a/tests/Feature/Dashboard/StatsCardsTest.php
+++ b/tests/Feature/Dashboard/StatsCardsTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use App\Jobs\VerifySnapshotFileJob;
 use App\Livewire\Dashboard\StatsCards;
 use App\Models\DatabaseServer;
 use App\Models\User;
 use App\Services\Backup\BackupJobFactory;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 
 test('stats cards calculates correct totals', function () {
@@ -31,6 +34,51 @@ test('stats cards calculates correct totals', function () {
         ->assertSet('successRate', 75.0); // 3 out of 4 = 75%
 });
 
+test('stats cards shows missing snapshots count', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['test_db']]);
+
+    // Create 2 snapshots with missing files
+    for ($i = 0; $i < 2; $i++) {
+        $snapshots = $factory->createSnapshots($server, 'manual', $user->id);
+        $snapshots[0]->update(['file_exists' => false, 'file_verified_at' => now()]);
+        $snapshots[0]->job->markCompleted();
+    }
+
+    // Create 1 normal snapshot
+    $snapshots = $factory->createSnapshots($server, 'manual', $user->id);
+    $snapshots[0]->job->markCompleted();
+
+    Livewire::actingAs($user)
+        ->test(StatsCards::class)
+        ->call('load')
+        ->assertSet('missingSnapshots', 2)
+        ->assertSee('2 missing');
+});
+
+test('stats cards shows all verified when no snapshots are missing', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['test_db']]);
+
+    // Create 2 verified snapshots (file exists)
+    for ($i = 0; $i < 2; $i++) {
+        $snapshots = $factory->createSnapshots($server, 'manual', $user->id);
+        $snapshots[0]->update(['file_exists' => true, 'file_verified_at' => now()]);
+        $snapshots[0]->job->markCompleted();
+    }
+
+    Livewire::actingAs($user)
+        ->test(StatsCards::class)
+        ->call('load')
+        ->assertSet('verifiedSnapshots', 2)
+        ->assertSet('missingSnapshots', 0)
+        ->assertSee('All verified');
+});
+
 test('stats cards shows running jobs count', function () {
     $user = User::factory()->create();
     $factory = app(BackupJobFactory::class);
@@ -47,4 +95,31 @@ test('stats cards shows running jobs count', function () {
         ->test(StatsCards::class)
         ->call('load')
         ->assertSet('runningJobs', 2);
+});
+
+test('verify files button dispatches verification job', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(StatsCards::class)
+        ->call('verifyFiles');
+
+    Queue::assertPushed(VerifySnapshotFileJob::class, 1);
+    Queue::assertPushed(VerifySnapshotFileJob::class, fn ($job) => $job->snapshotId === null);
+});
+
+test('verify files button prevents rapid re-dispatch via cache lock', function () {
+    Queue::fake();
+
+    $user = User::factory()->create();
+
+    Cache::lock('verify-snapshot-files', 300)->get();
+
+    Livewire::actingAs($user)
+        ->test(StatsCards::class)
+        ->call('verifyFiles');
+
+    Queue::assertNothingPushed();
 });

--- a/tests/Feature/Jobs/VerifySnapshotFileJobTest.php
+++ b/tests/Feature/Jobs/VerifySnapshotFileJobTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Jobs\VerifySnapshotFileJob;
+use App\Models\DatabaseServer;
+use App\Models\Snapshot;
+use App\Notifications\SnapshotsMissingNotification;
+use App\Services\Backup\BackupJobFactory;
+use App\Services\Backup\Filesystems\FilesystemProvider;
+use Illuminate\Support\Facades\Notification;
+use League\Flysystem\Filesystem;
+
+test('sets file_exists to true when file exists on volume', function () {
+    $snapshot = Snapshot::factory()->create();
+
+    $mockFilesystem = Mockery::mock(Filesystem::class);
+    $mockFilesystem->shouldReceive('fileExists')
+        ->with($snapshot->filename)
+        ->once()
+        ->andReturn(true);
+
+    $mockProvider = Mockery::mock(FilesystemProvider::class);
+    $mockProvider->shouldReceive('getForVolume')
+        ->once()
+        ->andReturn($mockFilesystem);
+
+    (new VerifySnapshotFileJob($snapshot->id))->handle($mockProvider, app(\App\Services\FailureNotificationService::class));
+
+    $snapshot->refresh();
+    expect($snapshot->file_exists)->toBeTrue()
+        ->and($snapshot->file_verified_at)->not->toBeNull();
+});
+
+test('sets file_exists to false when file is missing from volume', function () {
+    $snapshot = Snapshot::factory()->create();
+
+    $mockFilesystem = Mockery::mock(Filesystem::class);
+    $mockFilesystem->shouldReceive('fileExists')
+        ->with($snapshot->filename)
+        ->once()
+        ->andReturn(false);
+
+    $mockProvider = Mockery::mock(FilesystemProvider::class);
+    $mockProvider->shouldReceive('getForVolume')
+        ->once()
+        ->andReturn($mockFilesystem);
+
+    (new VerifySnapshotFileJob($snapshot->id))->handle($mockProvider, app(\App\Services\FailureNotificationService::class));
+
+    $snapshot->refresh();
+    expect($snapshot->file_exists)->toBeFalse()
+        ->and($snapshot->file_verified_at)->not->toBeNull();
+});
+
+test('handles filesystem errors gracefully without changing file_exists', function () {
+    $snapshot = Snapshot::factory()->create(['file_exists' => true]);
+
+    $mockProvider = Mockery::mock(FilesystemProvider::class);
+    $mockProvider->shouldReceive('getForVolume')
+        ->once()
+        ->andThrow(new \Exception('Connection timeout'));
+
+    (new VerifySnapshotFileJob($snapshot->id))->handle($mockProvider, app(\App\Services\FailureNotificationService::class));
+
+    $snapshot->refresh();
+    expect($snapshot->file_exists)->toBeTrue()
+        ->and($snapshot->file_verified_at)->not->toBeNull();
+});
+
+test('skips gracefully when snapshot does not exist', function () {
+    $mockProvider = Mockery::mock(FilesystemProvider::class);
+    $mockProvider->shouldNotReceive('getForVolume');
+
+    (new VerifySnapshotFileJob('non-existent-id'))->handle($mockProvider, app(\App\Services\FailureNotificationService::class));
+});
+
+test('verifies all completed snapshots when no snapshotId provided', function () {
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['db1', 'db2']]);
+    $snapshots = $factory->createSnapshots($server, 'manual');
+
+    // Set filenames and mark completed
+    foreach ($snapshots as $snapshot) {
+        $snapshot->update(['filename' => fake()->slug().'.sql.gz']);
+        $snapshot->job->markCompleted();
+    }
+
+    // Create a snapshot with no filename — should be skipped
+    $skippedSnapshots = $factory->createSnapshots($server, 'manual');
+    $skippedSnapshots[0]->job->markCompleted();
+
+    $mockFilesystem = Mockery::mock(Filesystem::class);
+    $mockFilesystem->shouldReceive('fileExists')->times(2)->andReturn(true);
+
+    $mockProvider = Mockery::mock(FilesystemProvider::class);
+    $mockProvider->shouldReceive('getForVolume')->times(2)->andReturn($mockFilesystem);
+
+    (new VerifySnapshotFileJob)->handle($mockProvider, app(\App\Services\FailureNotificationService::class));
+
+    foreach ($snapshots as $snapshot) {
+        $snapshot->refresh();
+        expect($snapshot->file_exists)->toBeTrue()
+            ->and($snapshot->file_verified_at)->not->toBeNull();
+    }
+
+    // Skipped snapshot should remain unverified
+    $skippedSnapshots[0]->refresh();
+    expect($skippedSnapshots[0]->file_verified_at)->toBeNull();
+});
+
+test('sends notification when newly missing files are detected in bulk mode', function () {
+    config([
+        'notifications.enabled' => true,
+        'notifications.mail.to' => 'admin@example.com',
+    ]);
+
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['prod_db']]);
+    $snapshots = $factory->createSnapshots($server, 'manual');
+    $snapshot = $snapshots[0];
+    $snapshot->update(['filename' => 'backup.sql.gz', 'file_exists' => true]);
+    $snapshot->job->markCompleted();
+
+    $mockFilesystem = Mockery::mock(Filesystem::class);
+    $mockFilesystem->shouldReceive('fileExists')->once()->andReturn(false);
+
+    $mockProvider = Mockery::mock(FilesystemProvider::class);
+    $mockProvider->shouldReceive('getForVolume')->once()->andReturn($mockFilesystem);
+
+    (new VerifySnapshotFileJob)->handle($mockProvider, app(\App\Services\FailureNotificationService::class));
+
+    Notification::assertSentOnDemand(
+        SnapshotsMissingNotification::class,
+        fn ($notification) => $notification->missingSnapshots->count() === 1
+            && $notification->missingSnapshots->first()['filename'] === 'backup.sql.gz'
+    );
+});
+
+test('does not send notification when no new files are missing', function () {
+    config([
+        'notifications.enabled' => true,
+        'notifications.mail.to' => 'admin@example.com',
+    ]);
+
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['prod_db']]);
+    $snapshots = $factory->createSnapshots($server, 'manual');
+    $snapshot = $snapshots[0];
+    // Already marked as missing — not newly missing
+    $snapshot->update(['filename' => 'backup.sql.gz', 'file_exists' => false]);
+    $snapshot->job->markCompleted();
+
+    $mockFilesystem = Mockery::mock(Filesystem::class);
+    $mockFilesystem->shouldReceive('fileExists')->once()->andReturn(false);
+
+    $mockProvider = Mockery::mock(FilesystemProvider::class);
+    $mockProvider->shouldReceive('getForVolume')->once()->andReturn($mockFilesystem);
+
+    (new VerifySnapshotFileJob)->handle($mockProvider, app(\App\Services\FailureNotificationService::class));
+
+    Notification::assertNothingSent();
+});

--- a/tests/Feature/Notifications/FailureNotificationTest.php
+++ b/tests/Feature/Notifications/FailureNotificationTest.php
@@ -6,6 +6,7 @@ use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Notifications\BackupFailedNotification;
 use App\Notifications\RestoreFailedNotification;
+use App\Notifications\SnapshotsMissingNotification;
 use App\Services\Backup\BackupJobFactory;
 use App\Services\FailureNotificationService;
 use Illuminate\Support\Facades\Notification;
@@ -212,6 +213,41 @@ test('ProcessBackupJob sends notification when backup fails', function () {
         fn (BackupFailedNotification $n) => $n->snapshot->id === $snapshot->id
             && $n->exception->getMessage() === 'Access denied for user'
     );
+});
+
+test('SnapshotsMissingNotification renders mail, slack and discord correctly', function () {
+    $missingSnapshots = collect([
+        ['server' => 'Prod DB', 'database' => 'myapp', 'filename' => 'backup-1.sql.gz'],
+        ['server' => 'Prod DB', 'database' => 'users', 'filename' => 'backup-2.sql.gz'],
+    ]);
+
+    $notification = new SnapshotsMissingNotification($missingSnapshots);
+
+    $mail = $notification->toMail((object) []);
+    $slack = $notification->toSlack((object) []);
+    $discord = $notification->toDiscord((object) []);
+
+    expect($mail->subject)->toContain('2 backup files missing')
+        ->and($mail->viewData['errorMessage'])->toContain('Prod DB / myapp')
+        ->and($mail->viewData['errorMessage'])->toContain('backup-1.sql.gz')
+        ->and($slack)->toBeInstanceOf(\Illuminate\Notifications\Slack\SlackMessage::class)
+        ->and($discord)->toBeInstanceOf(\NotificationChannels\Discord\DiscordMessage::class);
+});
+
+test('SnapshotsMissingNotification truncates file list beyond 10 items', function () {
+    $missingSnapshots = collect(range(1, 12))->map(fn ($i) => [
+        'server' => "Server {$i}",
+        'database' => "db_{$i}",
+        'filename' => "backup-{$i}.sql.gz",
+    ]);
+
+    $notification = new SnapshotsMissingNotification($missingSnapshots);
+
+    $mail = $notification->toMail((object) []);
+
+    expect($mail->viewData['errorMessage'])->toContain('backup-10.sql.gz')
+        ->and($mail->viewData['errorMessage'])->not->toContain('backup-11.sql.gz')
+        ->and($mail->viewData['errorMessage'])->toContain('... and 2 more');
 });
 
 test('ProcessRestoreJob sends notification when restore fails', function () {


### PR DESCRIPTION
## Summary

Add scheduled verification that backup files still exist on their storage volumes, with dashboard visibility and notifications when files go missing.

## Changes

- `VerifySnapshotFileJob` checks file existence via `FilesystemProvider`, with cache lock to prevent duplicate runs
- `snapshots:verify-files` Artisan command, scheduled daily at 5 AM (configurable via `BACKUP_VERIFY_FILES_CRON`)
- Dashboard card redesigned with status badges, manual verify button, and clickable missing-files link
- Jobs index gains "Missing" filter, row warnings, and log modal alert
- `SnapshotsMissingNotification` sent when previously-existing files go missing (mail, Slack, Discord)
- Fresh backups automatically marked as verified at creation time

Ref #51