### PR TITLE
fix: HTML entity encoding in description hint text

### DIFF
--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -23,7 +23,7 @@
                     wire:model="form.description"
                     label="{{ __('Description') }}"
                     placeholder="{{ __('Brief description of this database server') }}"
-                    hint="{{ __('Notes for your team about this server\'s purpose') }}"
+                    :hint="__('Notes for your team about this server\'s purpose')"
                     rows="2"
                 />
             </div>


### PR DESCRIPTION
## Summary
- Fixed the description field hint text showing `&#039;` instead of an apostrophe on the Create/Edit Database Server form
- Changed `hint="{{ }}"` to `:hint=""` (bound Blade attribute) to avoid double HTML-encoding

Closes #81