### PR TITLE
fix: use notification class name as webhook event identifier

### DIFF
--- a/app/Notifications/BaseFailedNotification.php
+++ b/app/Notifications/BaseFailedNotification.php
@@ -137,6 +137,6 @@ abstract class BaseFailedNotification extends Notification
      */
     public function toWebhook(object $notifiable): array
     {
-        return $this->getMessage()->toWebhook();
+        return $this->getMessage()->toWebhook(class_basename($this));
     }
 }

--- a/app/Notifications/Channels/WebhookChannel.php
+++ b/app/Notifications/Channels/WebhookChannel.php
@@ -20,15 +20,8 @@ class WebhookChannel
             return;
         }
 
-        $headers = [
-            'X-Webhook-Event' => class_basename($notification),
-        ];
-
         $secret = AppConfig::get('notifications.webhook.secret');
-
-        if ($secret) {
-            $headers['X-Webhook-Token'] = $secret;
-        }
+        $headers = $secret ? ['X-Webhook-Token' => $secret] : [];
 
         $response = Http::timeout(10)->withHeaders($headers)->post($url, $payload);
 

--- a/app/Notifications/FailedNotificationMessage.php
+++ b/app/Notifications/FailedNotificationMessage.php
@@ -146,10 +146,10 @@ class FailedNotificationMessage
     /**
      * @return array{event: string, title: string, body: string, fields: array<string, string>, error: string, action_url: string, timestamp: string}
      */
-    public function toWebhook(): array
+    public function toWebhook(string $event): array
     {
         return [
-            'event' => 'notification.failed',
+            'event' => $event,
             'title' => $this->title,
             'body' => $this->body,
             'fields' => $this->fields,

--- a/docs/docs/self-hosting/configuration/notification.md
+++ b/docs/docs/self-hosting/configuration/notification.md
@@ -111,7 +111,7 @@ Notifications are sent as `POST` requests with a JSON body:
 
 ```json
 {
-  "event": "notification.failed",
+  "event": "BackupFailedNotification",
   "title": "Backup Failed: Production DB",
   "body": "A backup job has failed.",
   "fields": {
@@ -129,7 +129,6 @@ Notifications are sent as `POST` requests with a JSON body:
 | Header | Description |
 |--------|-------------|
 | `Content-Type` | `application/json` |
-| `X-Webhook-Event` | Notification class name (e.g., `BackupFailedNotification`) |
 | `X-Webhook-Token` | The configured secret (only if a secret is configured) |
 
 ### Tip: Using with Apprise

--- a/tests/Feature/Notifications/FailureNotificationTest.php
+++ b/tests/Feature/Notifications/FailureNotificationTest.php
@@ -237,7 +237,7 @@ test('notification renders channel correctly', function (Closure $assert) {
     'webhook' => [function (BackupFailedNotification $notification) {
         $webhook = $notification->toWebhook((object) []);
         expect($webhook)->toBeArray()
-            ->and($webhook['event'])->toBe('notification.failed')
+            ->and($webhook['event'])->toBe('BackupFailedNotification')
             ->and($webhook['title'])->toContain('Backup Failed')
             ->and($webhook['error'])->toBe('Test error')
             ->and($webhook['action_url'])->toBeString()
@@ -272,7 +272,7 @@ test('custom channel sends HTTP request', function (string $channelClass, array 
         ['notifications.webhook.url' => 'https://webhook.example.com/hook', 'notifications.webhook.secret' => 'my-secret'],
         fn (Request $request) => $request->url() === 'https://webhook.example.com/hook'
             && $request->hasHeader('X-Webhook-Token', 'my-secret')
-            && $request->hasHeader('X-Webhook-Event', 'BackupFailedNotification')
+            && $request['event'] === 'BackupFailedNotification'
             && str_contains($request['title'], 'Backup Failed'),
     ],
 ]);


### PR DESCRIPTION
## Summary

- Use the notification class name (e.g. `BackupFailedNotification`) as the webhook `event` field instead of the hardcoded `notification.failed`
- Remove the redundant `X-Webhook-Event` header — the event is already in the JSON body
- Pass the event name through the proper delegation chain (`BaseFailedNotification` → `FailedNotificationMessage`)

## Test plan

- [x] Existing webhook rendering test asserts `event` equals `BackupFailedNotification`
- [x] HTTP request test asserts `event` field in payload
- [x] All 476 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated webhook notification delivery to include event type information in the payload body instead of HTTP headers, providing clearer event identification for webhook consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->