### PR TITLE
feat: add additional sha docker image tag on docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,7 +105,9 @@ jobs:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: davidcrty/databasement:${{ needs.build-base-image.outputs.tag }}
+          tags: |
+            davidcrty/databasement:${{ needs.build-base-image.outputs.tag }}
+            davidcrty/databasement:sha-${{ github.sha }}
           build-args: |
             APP_COMMIT_HASH=${{ github.sha }}
             BASE_IMAGE=davidcrty/databasement-php:${{ needs.build-base-image.outputs.base_image_tag }}


### PR DESCRIPTION
# Add SHA-based Docker image tagging

Adds an additional commit SHA tag to Docker images built in CI to enable pinning specific versions in local setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Docker image tagging was expanded to publish both the existing branch/tag-based tag and an additional commit SHA-based tag. This provides clearer, immutable references for builds, making it easier to pull or reference the exact image produced by a specific commit for debugging, rollbacks, or deployment traceability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->