### PR TITLE
fix: remove in-memory cache from AppConfigService

### DIFF
--- a/app/Facades/AppConfig.php
+++ b/app/Facades/AppConfig.php
@@ -7,7 +7,6 @@ use Illuminate\Support\Facades\Facade;
 /**
  * @method static mixed get(string $key, mixed $default = null)
  * @method static void set(string $key, mixed $value)
- * @method static void flush()
  *
  * @see \App\Services\AppConfigService
  */

--- a/app/Services/AppConfigService.php
+++ b/app/Services/AppConfigService.php
@@ -6,9 +6,6 @@ use App\Models\AppConfig;
 
 class AppConfigService
 {
-    /** @var array<string, mixed> */
-    private array $cache = [];
-
     /**
      * Config key definitions: type, sensitivity, and default value.
      *
@@ -46,22 +43,15 @@ class AppConfigService
     /**
      * Get a config value by key.
      *
-     * Checks in-memory cache first, then DB, then falls back to CONFIG defaults.
+     * Checks DB first, then falls back to CONFIG defaults.
      */
     public function get(string $key, mixed $default = null): mixed
     {
-        if (array_key_exists($key, $this->cache)) {
-            return $this->cache[$key];
-        }
-
         try {
             $row = AppConfig::find($key);
 
             if ($row) {
-                $value = $row->getCastedValue();
-                $this->cache[$key] = $value;
-
-                return $value;
+                return $row->getCastedValue();
             }
         } catch (\Throwable) {
             // Table may not exist yet (pre-migration) — fall through to defaults
@@ -95,15 +85,5 @@ class AppConfigService
                 'is_sensitive' => $schema['is_sensitive'],
             ]
         );
-
-        $this->cache[$key] = $row->getCastedValue();
-    }
-
-    /**
-     * Clear the in-memory cache.
-     */
-    public function flush(): void
-    {
-        $this->cache = [];
     }
 }

--- a/tests/Feature/AppConfigTest.php
+++ b/tests/Feature/AppConfigTest.php
@@ -32,7 +32,7 @@ test('get returns default values', function () {
         ->and(AppConfig::get('notifications.enabled'))->toBeFalse();
 });
 
-test('set persists and updates cache', function () {
+test('set persists values', function () {
     AppConfig::set('backup.compression', 'zstd');
 
     expect(AppConfig::get('backup.compression'))->toBe('zstd');
@@ -86,31 +86,24 @@ test('set handles null for nullable fields', function () {
     expect($row->value)->toBeNull();
 });
 
-test('flush clears cache', function () {
-    // Prime cache
+test('get reads fresh values from database', function () {
     AppConfig::get('backup.compression');
 
-    // Update DB directly (bypassing cache)
+    // Update DB directly
     AppConfigModel::where('id', 'backup.compression')->update(['value' => 'zstd']);
 
-    // Cache still returns old value
-    expect(AppConfig::get('backup.compression'))->toBe('gzip');
-
-    // After flush, returns updated value
-    AppConfig::flush();
+    // Returns updated value immediately
     expect(AppConfig::get('backup.compression'))->toBe('zstd');
 });
 
 test('get returns explicit default when row is missing', function () {
     AppConfigModel::where('id', 'backup.compression')->delete();
-    AppConfig::flush();
 
     expect(AppConfig::get('backup.compression', 'gzip'))->toBe('gzip');
 });
 
 test('get falls back to CONFIG defaults when row is missing', function () {
     AppConfigModel::where('id', 'backup.compression')->delete();
-    AppConfig::flush();
 
     expect(AppConfig::get('backup.compression'))->toBe('gzip');
 });

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -86,7 +86,6 @@ test('saving notification config persists values for selected channels', functio
 test('deselecting a channel nulls its values on save', function () {
     AppConfig::set('notifications.mail.to', 'old@example.com');
     AppConfig::set('notifications.slack.webhook_url', 'https://hooks.slack.com/old');
-    AppConfig::flush();
 
     Livewire::actingAs(User::factory()->create(['role' => 'admin']))
         ->test(Index::class)
@@ -278,7 +277,6 @@ test('deselecting new channels nulls their values on save', function () {
     AppConfig::set('notifications.gotify.token', 'token');
     AppConfig::set('notifications.webhook.url', 'https://webhook.example.com');
     AppConfig::set('notifications.webhook.secret', 'secret');
-    AppConfig::flush();
 
     Livewire::actingAs(User::factory()->create(['role' => 'admin']))
         ->test(Index::class)
@@ -300,7 +298,6 @@ test('form pre-selects channel when config exists', function (array $setup, stri
     foreach ($setup as $key => $value) {
         AppConfig::set($key, $value);
     }
-    AppConfig::flush();
 
     $component = Livewire::actingAs(User::factory()->create(['role' => 'admin']))
         ->test(Index::class);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -34,9 +34,6 @@ pest()->extend(Tests\TestCase::class)
 */
 
 afterEach(function () {
-    // Flush AppConfig cache between tests
-    AppConfig::flush();
-
     // Clean up backup working directory (preserves the directory itself)
     $workingDirectory = AppConfig::get('backup.working_directory');
     if ($workingDirectory && is_dir($workingDirectory)) {


### PR DESCRIPTION
## Summary

- Remove the in-memory cache from `AppConfigService` that caused the queue worker to use stale configuration values

## Problem

`AppConfigService` is registered as a singleton and maintained an in-memory `$cache` array. The queue worker is a long-lived process that persists this singleton across all jobs. When a user changed a config value (e.g. switching compression from gzip to zstd) via the web UI, the database was updated but the queue worker's cached value was never refreshed — so backup jobs continued using the old compression method until the worker was manually restarted.

## Solution

Removed the in-memory cache entirely. Each `get()` call now reads directly from the database via `AppConfig::find($key)`, which is a simple primary key lookup with negligible overhead. This ensures the queue worker (and Octane workers) always read fresh config values.

## Test plan

- [x] Updated `AppConfigTest` — replaced cache-specific tests with a test that verifies fresh DB reads
- [x] Removed all `AppConfig::flush()` calls from tests (no longer needed)
- [x] All 476 tests pass
- [x] PHPStan clean, Pint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed in-memory caching from the configuration service; configuration values now query the database directly on each retrieval, eliminating explicit cache invalidation operations and ensuring immediate consistency with stored values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->