### PR TITLE
Improve database seeder with realistic dev data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install start test test-sequential test-mysql test-postgres test-filter test-filter-mysql test-filter-postgres test-coverage test-coverage-filter backup-test lint-check lint-fix lint migrate migrate-fresh db-seed setup clean import-db docs docs-build
+.PHONY: help install start test test-sequential test-mysql test-postgres test-filter test-filter-mysql test-filter-postgres test-coverage test-coverage-filter backup-test lint-check lint-fix lint migrate migrate-fresh migrate-fresh-seed db-seed setup clean import-db docs docs-build
 
 # Colors for output
 GREEN  := \033[0;32m
@@ -93,6 +93,15 @@ docs-build: ## Build documentation for production (Docusaurus)
 	cd docs && $(NPM_EXEC) install && $(NPM_EXEC) run build
 
 ##@ Database
+
+migrate-fresh: ## Drop all tables and re-migrate
+	$(PHP_ARTISAN) migrate:fresh
+
+migrate-fresh-seed: ## Drop all tables, re-migrate and seed
+	$(PHP_ARTISAN) migrate:fresh --seed
+
+db-seed: ## Run database seeders
+	$(PHP_ARTISAN) db:seed
 
 import-db: ## Import a gzipped SQL dump into local MySQL (usage: make import-db FILE=/path/to/dump.sql.gz)
 	@if [ -z "$(FILE)" ]; then \

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,11 @@
 
 namespace Database\Seeders;
 
+use App\Models\Backup;
+use App\Models\BackupSchedule;
+use App\Models\DatabaseServer;
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Models\Volume;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +16,138 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        // Users (all with password "password", no 2FA)
+        User::factory()->withoutTwoFactor()->create([
+            'name' => 'Admin User',
+            'email' => 'admin@example.com',
+            'role' => User::ROLE_ADMIN,
         ]);
+
+        User::factory()->withoutTwoFactor()->create([
+            'name' => 'Member User',
+            'email' => 'member@example.com',
+            'role' => User::ROLE_MEMBER,
+        ]);
+
+        User::factory()->withoutTwoFactor()->create([
+            'name' => 'Viewer User',
+            'email' => 'viewer@example.com',
+            'role' => User::ROLE_VIEWER,
+        ]);
+
+        // Shared volume and schedule
+        $volume = Volume::create([
+            'name' => 'Local Backups',
+            'type' => 'local',
+            'config' => ['path' => '/data/backups'],
+        ]);
+
+        $dailySchedule = BackupSchedule::firstOrCreate(
+            ['name' => 'Daily'],
+            ['expression' => '0 2 * * *'],
+        );
+
+        // MySQL server (from docker-compose)
+        $mysql = DatabaseServer::create([
+            'name' => 'Local MySQL',
+            'host' => 'mysql',
+            'port' => 3306,
+            'database_type' => 'mysql',
+            'username' => 'root',
+            'password' => 'root',
+            'backup_all_databases' => true,
+        ]);
+
+        // PostgreSQL server (from docker-compose)
+        $postgres = DatabaseServer::create([
+            'name' => 'Local PostgreSQL',
+            'host' => 'postgres',
+            'port' => 5432,
+            'database_type' => 'postgres',
+            'username' => 'root',
+            'password' => 'root',
+            'backup_all_databases' => true,
+        ]);
+
+        // SQLite server
+        $sqlitePath = '/data/sample.sqlite';
+        $this->createSqliteDatabase($sqlitePath);
+
+        $sqlite = DatabaseServer::create([
+            'name' => 'Local SQLite',
+            'database_type' => 'sqlite',
+            'sqlite_path' => $sqlitePath,
+            'host' => '',
+            'port' => 0,
+            'username' => '',
+            'password' => '',
+        ]);
+
+        // Backup configurations
+        foreach ([$mysql, $postgres, $sqlite] as $server) {
+            Backup::create([
+                'database_server_id' => $server->id,
+                'volume_id' => $volume->id,
+                'backup_schedule_id' => $dailySchedule->id,
+                'retention_policy' => Backup::RETENTION_DAYS,
+                'retention_days' => 30,
+            ]);
+        }
+    }
+
+    /**
+     * Create a sample SQLite database with some tables and data.
+     */
+    private function createSqliteDatabase(string $path): void
+    {
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        if (file_exists($path)) {
+            unlink($path);
+        }
+
+        $pdo = new \PDO("sqlite:{$path}");
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS products (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            price REAL NOT NULL,
+            stock INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $pdo->exec('CREATE TABLE IF NOT EXISTS orders (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            product_id INTEGER NOT NULL REFERENCES products(id),
+            quantity INTEGER NOT NULL,
+            total REAL NOT NULL,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $stmt = $pdo->prepare('INSERT INTO products (name, price, stock) VALUES (?, ?, ?)');
+        $products = [
+            ['Widget A', 9.99, 150],
+            ['Widget B', 24.99, 75],
+            ['Gadget Pro', 49.99, 30],
+            ['Mega Bundle', 99.99, 10],
+        ];
+        foreach ($products as $product) {
+            $stmt->execute($product);
+        }
+
+        $stmt = $pdo->prepare('INSERT INTO orders (product_id, quantity, total) VALUES (?, ?, ?)');
+        $orders = [
+            [1, 2, 19.98],
+            [2, 1, 24.99],
+            [3, 3, 149.97],
+            [1, 5, 49.95],
+        ];
+        foreach ($orders as $order) {
+            $stmt->execute($order);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Seed 3 users with distinct roles: admin (`admin@example.com`), member (`member@example.com`), viewer (`viewer@example.com`) — all with password `password`, no 2FA
- Add 3 database servers matching docker-compose: Local MySQL, Local PostgreSQL, and Local SQLite (with sample `products` and `orders` tables)
- Create a shared "Local Backups" volume and daily backup configurations for all servers
- Add missing Makefile targets: `make migrate-fresh`, `make migrate-fresh-seed`, `make db-seed`

## Test plan
- [x] `make migrate-fresh-seed` runs without errors
- [x] All 485 tests pass
- [x] PHPStan passes
- [x] Lint passes
- [x] Can log in with any seeded user without 2FA prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands for streamlined database setup: fresh migrations and seeding.
  * Included sample user accounts and local test database instances for development.

* **Improvements**
  * Enhanced database import with input validation, clearer usage messaging, and better error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->