### PR TITLE
Refactor backup folder logic into AppConfig

### DIFF
--- a/app/Console/Commands/WaitForDatabase.php
+++ b/app/Console/Commands/WaitForDatabase.php
@@ -30,9 +30,6 @@ class WaitForDatabase extends Command
      */
     public function handle(Migrator $migrator): int
     {
-        // Stagger startup to avoid simultaneous connections from supervisord processes
-        usleep(random_int(0, 3_000_000));
-
         $this->info('Waiting for database connection...');
 
         $maxRetries = 60;
@@ -56,7 +53,7 @@ class WaitForDatabase extends Command
 
                         return 0;
                     }
-                    if (str_contains($e->getMessage(), 'Unknown database')) {
+                    if (str_contains($e->getMessage(), 'Unknown database') || preg_match('/database\s+"[^"]+"\s+does not exist/i', $e->getMessage())) {
                         $this->info('Database connection established! (Database not created yet).');
 
                         return 0;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -91,7 +91,6 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->registerNotificationServiceConfigs();
-        $this->ensureBackupTmpFolderExists();
         $this->registerOidcSocialiteProvider();
         $this->validateOAuthConfiguration();
 
@@ -131,15 +130,6 @@ class AppServiceProvider extends ServiceProvider
             if ($token) {
                 config([$servicesConfigKey => $token]);
             }
-        }
-    }
-
-    private function ensureBackupTmpFolderExists(): void
-    {
-        $backupTmpFolder = AppConfig::get('backup.working_directory');
-
-        if ($backupTmpFolder && ! is_dir($backupTmpFolder)) {
-            mkdir($backupTmpFolder, 0755, true);
         }
     }
 

--- a/app/Services/AppConfigService.php
+++ b/app/Services/AppConfigService.php
@@ -75,7 +75,7 @@ class AppConfigService
 
         $schema = self::CONFIG[$key];
 
-        $row = AppConfig::updateOrCreate(
+        AppConfig::updateOrCreate(
             ['id' => $key],
             [
                 'value' => AppConfig::prepareValue($value, $schema['is_sensitive']),
@@ -83,5 +83,14 @@ class AppConfigService
                 'is_sensitive' => $schema['is_sensitive'],
             ]
         );
+    }
+
+    public function ensureBackupTmpFolderExists(): void
+    {
+        $backupTmpFolder = self::get('backup.working_directory');
+
+        if ($backupTmpFolder && ! is_dir($backupTmpFolder)) {
+            mkdir($backupTmpFolder, 0755, true);
+        }
     }
 }

--- a/app/Services/Backup/BackupTask.php
+++ b/app/Services/Backup/BackupTask.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup;
 
 use App\Enums\DatabaseType;
+use App\Facades\AppConfig;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\Snapshot;
@@ -43,6 +44,7 @@ class BackupTask
         $job = $snapshot->job;
         $isSqlite = $databaseServer->database_type === DatabaseType::SQLITE;
         try {
+            AppConfig::ensureBackupTmpFolderExists();
             $this->setLogger($job);
             $compressor = $this->compressorFactory->make();
             $workingDirectory = FilesystemSupport::createWorkingDirectory('backup', $snapshot->id);

--- a/app/Services/Backup/RestoreTask.php
+++ b/app/Services/Backup/RestoreTask.php
@@ -6,6 +6,7 @@ use App\Enums\DatabaseType;
 use App\Exceptions\Backup\ConnectionException;
 use App\Exceptions\Backup\RestoreException;
 use App\Exceptions\Backup\UnsupportedDatabaseTypeException;
+use App\Facades\AppConfig;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\Restore;
@@ -49,6 +50,7 @@ class RestoreTask
         $snapshot = $restore->snapshot;
         $job = $restore->job;
         try {
+            AppConfig::ensureBackupTmpFolderExists();
             $this->validateCompatibility($targetServer, $snapshot);
             $this->shellProcessor->setLogger($job);
             $workingDirectory = FilesystemSupport::createWorkingDirectory('restore', $restore->id);

--- a/docker/php/supervisord.conf
+++ b/docker/php/supervisord.conf
@@ -1,8 +1,18 @@
+[unix_http_server]
+file=/tmp/supervisor.sock
+chmod=0766
+
 [supervisord]
 nodaemon=true
 user=%(ENV_SUPERVISOR_USER)s
 logfile=/tmp/supervisord.log
 pidfile=/tmp/supervisord.pid
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
 
 [program:frankenphp]
 command=/usr/local/bin/start-frankenphp.sh

--- a/tests/Feature/Console/WaitForDatabaseTest.php
+++ b/tests/Feature/Console/WaitForDatabaseTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+
+use function Pest\Laravel\artisan;
+
+it('succeeds when database connection works', function (): void {
+    artisan('db:wait')
+        ->assertExitCode(0);
+});
+
+it('succeeds with --allow-missing-db when MySQL database does not exist', function (): void {
+    DB::shouldReceive('connection->getPdo')
+        ->andThrow(new \Exception('SQLSTATE[HY000] [1049] Unknown database \'missing_db\''));
+    DB::shouldReceive('connection->getDriverName')
+        ->andReturn('mysql');
+
+    artisan('db:wait', ['--allow-missing-db' => true])
+        ->assertExitCode(0);
+});
+
+it('succeeds with --allow-missing-db when PostgreSQL database does not exist', function (): void {
+    DB::shouldReceive('connection->getPdo')
+        ->andThrow(new \Exception('SQLSTATE[08006] [7] connection to server failed: FATAL:  database "missing_db" does not exist'));
+    DB::shouldReceive('connection->getDriverName')
+        ->andReturn('pgsql');
+
+    artisan('db:wait', ['--allow-missing-db' => true])
+        ->assertExitCode(0);
+});
+
+it('succeeds with --allow-missing-db when SQLite database file is missing', function (): void {
+    DB::shouldReceive('connection->getPdo')
+        ->andThrow(new \Exception('Database file at path [/data/database.sqlite] does not exist.'));
+    DB::shouldReceive('connection->getDriverName')
+        ->andReturn('sqlite');
+
+    artisan('db:wait', ['--allow-missing-db' => true])
+        ->assertExitCode(0);
+});
+
+it('succeeds with --check-migrations when all migrations have been run', function (): void {
+    artisan('db:wait', ['--check-migrations' => true])
+        ->assertExitCode(0);
+});


### PR DESCRIPTION
## Summary

Fix reliability issues in `db:wait` command, move backup temp folder creation to point-of-use, and fix scheduler restart from PHP.

## Changes

- Move `ensureBackupTmpFolderExists` from AppServiceProvider boot to AppConfig, called from BackupTask/RestoreTask
- Detect PostgreSQL missing-database errors in `db:wait --allow-missing-db` using strict regex
- Fix supervisorctl socket/config and use Laravel Process facade for testable scheduler restart
- Show warning toast (not success) when scheduler restart fails
- Add tests for `db:wait` command and scheduler restart failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database setup detection with faster initial connection attempts and better handling of missing databases.
  * Scheduler restart operations now properly report success or failure with appropriate user feedback.

* **Chores**
  * Enhanced backup initialization with pre-flight directory validation.
  * Reorganized backup configuration logic for improved maintainability.

* **Tests**
  * Added comprehensive test coverage for database setup and scheduler operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->