### PR TITLE
Unify database operations behind DatabaseFactory

### DIFF
--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -78,6 +78,17 @@ enum DatabaseType: string
     }
 
     /**
+     * Get the file extension used for database dumps.
+     */
+    public function dumpExtension(): string
+    {
+        return match ($this) {
+            self::SQLITE => 'db',
+            default => 'sql',
+        };
+    }
+
+    /**
      * @return array<array{id: string, name: string}>
      */
     public static function toSelectOptions(): array

--- a/app/Facades/DatabaseConnectionTester.php
+++ b/app/Facades/DatabaseConnectionTester.php
@@ -5,7 +5,7 @@ namespace App\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static array<string, mixed> test(array<string, mixed> $config, \App\Models\DatabaseServerSshConfig|null $sshConfig = null)
+ * @method static array<string, mixed> test(\App\Models\DatabaseServer $server)
  *
  * @see \App\Services\DatabaseConnectionTester
  */

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -748,14 +748,16 @@ class DatabaseServerForm extends Form
             ? $this->buildSshConfigForTest()
             : null;
 
-        $result = DatabaseConnectionTester::test([
+        $server = DatabaseServer::forConnectionTest([
             'database_type' => $this->database_type,
             'host' => $this->isSqlite() ? $this->sqlite_path : $this->host,
             'port' => $this->port,
             'username' => $this->username,
             'password' => $password,
-            'database_name' => null,
+            'sqlite_path' => $this->isSqlite() ? $this->sqlite_path : null,
         ], $sshConfig);
+
+        $result = DatabaseConnectionTester::test($server);
 
         $this->connectionTestSuccess = $result['success'];
         $this->connectionTestMessage = $result['message'];
@@ -788,7 +790,7 @@ class DatabaseServerForm extends Form
         }
 
         $sshConfig = $this->buildSshConfigForTest();
-        $result = SshTunnelService::testConnection($sshConfig);
+        $result = app(SshTunnelService::class)->testConnection($sshConfig);
 
         $this->sshTestSuccess = $result['success'];
         $this->sshTestMessage = $result['message'];

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -171,6 +171,7 @@ class DatabaseServer extends Model
         $server->database_type = $config['database_type'] ?? 'mysql';
         $server->username = $config['username'] ?? '';
         $server->password = $config['password'] ?? '';
+        $server->sqlite_path = $config['sqlite_path'] ?? null;
 
         if ($sshConfig !== null) {
             $server->ssh_config_id = 'temp';

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,15 +6,12 @@ use App\Facades\AppConfig;
 use App\Services\AppConfigService;
 use App\Services\Backup\CompressorFactory;
 use App\Services\Backup\CompressorInterface;
-use App\Services\Backup\Databases\MysqlDatabase;
-use App\Services\Backup\Databases\PostgresqlDatabase;
 use App\Services\Backup\Filesystems\Awss3Filesystem;
 use App\Services\Backup\Filesystems\FilesystemProvider;
 use App\Services\Backup\Filesystems\FtpFilesystem;
 use App\Services\Backup\Filesystems\LocalFilesystem;
 use App\Services\Backup\Filesystems\SftpFilesystem;
 use App\Services\Backup\ShellProcessor;
-use App\Services\DatabaseConnectionTester;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
@@ -32,15 +29,11 @@ class AppServiceProvider extends ServiceProvider
         $this->registerOAuthServicesConfig();
 
         $this->app->singleton(AppConfigService::class);
-        $this->app->singleton(DatabaseConnectionTester::class);
         $this->app->singleton(ShellProcessor::class);
         $this->app->singleton(CompressorFactory::class);
         $this->app->singleton(CompressorInterface::class, function ($app) {
             return $app->make(CompressorFactory::class)->make();
         });
-        $this->app->singleton(MysqlDatabase::class);
-        $this->app->singleton(PostgresqlDatabase::class);
-
         // Register FilesystemProvider with configuration
         $this->app->singleton(FilesystemProvider::class, function ($app) {
             $provider = new FilesystemProvider([]);

--- a/app/Services/Backup/Concerns/UsesSshTunnel.php
+++ b/app/Services/Backup/Concerns/UsesSshTunnel.php
@@ -56,7 +56,7 @@ trait UsesSshTunnel
      */
     protected function getConnectionHost(DatabaseServer $server): string
     {
-        return $this->tunnelEndpoint['host'] ?? $server->host;
+        return $this->tunnelEndpoint['host'] ?? $server->host ?? '';
     }
 
     /**

--- a/app/Services/Backup/Databases/DatabaseFactory.php
+++ b/app/Services/Backup/Databases/DatabaseFactory.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services\Backup\Databases;
+
+use App\Enums\DatabaseType;
+use App\Models\DatabaseServer;
+
+class DatabaseFactory
+{
+    /**
+     * Create a database interface instance for the given type.
+     */
+    public function make(DatabaseType $type): DatabaseInterface
+    {
+        return match ($type) {
+            DatabaseType::MYSQL => new MysqlDatabase,
+            DatabaseType::POSTGRESQL => new PostgresqlDatabase,
+            DatabaseType::SQLITE => new SqliteDatabase,
+        };
+    }
+
+    /**
+     * Create a configured database interface instance.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function makeConfigured(DatabaseType $type, array $config): DatabaseInterface
+    {
+        $database = $this->make($type);
+        $database->setConfig($config);
+
+        return $database;
+    }
+
+    /**
+     * Create a configured database interface from a server model.
+     *
+     * Host and port are passed explicitly to support SSH tunnel overrides.
+     */
+    public function makeForServer(DatabaseServer $server, string $databaseName, string $host, int $port): DatabaseInterface
+    {
+        if ($server->database_type === DatabaseType::SQLITE) {
+            $config = ['sqlite_path' => $server->sqlite_path];
+        } else {
+            $config = [
+                'host' => $host,
+                'port' => $port,
+                'user' => $server->username,
+                'pass' => $server->getDecryptedPassword(),
+                'database' => $databaseName,
+            ];
+        }
+
+        return $this->makeConfigured($server->database_type, $config);
+    }
+}

--- a/app/Services/Backup/Databases/DatabaseInterface.php
+++ b/app/Services/Backup/Databases/DatabaseInterface.php
@@ -2,10 +2,10 @@
 
 namespace App\Services\Backup\Databases;
 
+use App\Models\BackupJob;
+
 interface DatabaseInterface
 {
-    public function handles(mixed $type): bool;
-
     /**
      * @param  array<string, mixed>  $config
      */
@@ -14,4 +14,16 @@ interface DatabaseInterface
     public function getDumpCommandLine(string $outputPath): string;
 
     public function getRestoreCommandLine(string $inputPath): string;
+
+    /**
+     * Prepare the target database for restore (e.g. drop and recreate).
+     */
+    public function prepareForRestore(string $schemaName, BackupJob $job): void;
+
+    /**
+     * Test the database connection.
+     *
+     * @return array{success: bool, message: string, details: array<string, mixed>}
+     */
+    public function testConnection(): array;
 }

--- a/app/Services/Backup/Databases/SqliteDatabase.php
+++ b/app/Services/Backup/Databases/SqliteDatabase.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Services\Backup\Databases;
+
+use App\Models\BackupJob;
+
+class SqliteDatabase implements DatabaseInterface
+{
+    /** @var array<string, mixed> */
+    private array $config;
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function setConfig(array $config): void
+    {
+        $this->config = $config;
+    }
+
+    public function getDumpCommandLine(string $outputPath): string
+    {
+        return sprintf('cp %s %s', escapeshellarg($this->config['sqlite_path']), escapeshellarg($outputPath));
+    }
+
+    public function getRestoreCommandLine(string $inputPath): string
+    {
+        return sprintf(
+            'cp %s %s && chmod 0640 %s',
+            escapeshellarg($inputPath),
+            escapeshellarg($this->config['sqlite_path']),
+            escapeshellarg($this->config['sqlite_path'])
+        );
+    }
+
+    public function prepareForRestore(string $schemaName, BackupJob $job): void
+    {
+        // SQLite doesn't need database preparation — the file is replaced during restore
+    }
+
+    public function testConnection(): array
+    {
+        $path = $this->config['sqlite_path'] ?? '';
+
+        if (empty($path)) {
+            return ['success' => false, 'message' => 'Database path is required.', 'details' => []];
+        }
+
+        if (! file_exists($path)) {
+            return ['success' => false, 'message' => 'Database file does not exist: '.$path, 'details' => []];
+        }
+
+        if (! is_readable($path)) {
+            return ['success' => false, 'message' => 'Database file is not readable: '.$path, 'details' => []];
+        }
+
+        if (! is_file($path)) {
+            return ['success' => false, 'message' => 'Path is not a file: '.$path, 'details' => []];
+        }
+
+        try {
+            $pdo = new \PDO("sqlite:{$path}", null, null, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+
+            $pdo->query('SELECT 1 FROM sqlite_master LIMIT 1');
+
+            $stmt = $pdo->query('SELECT sqlite_version()');
+            $version = $stmt ? $stmt->fetchColumn() : 'unknown';
+
+            $fileSize = filesize($path);
+
+            return [
+                'success' => true,
+                'message' => 'Connection successful',
+                'details' => [
+                    'output' => json_encode(['dbms' => "SQLite {$version}", 'file_size' => $fileSize, 'path' => $path], JSON_PRETTY_PRINT),
+                ],
+            ];
+        } catch (\PDOException $e) {
+            return ['success' => false, 'message' => 'Invalid SQLite database file: '.$e->getMessage(), 'details' => []];
+        }
+    }
+}

--- a/app/Services/SshTunnelService.php
+++ b/app/Services/SshTunnelService.php
@@ -97,13 +97,11 @@ class SshTunnelService
      *
      * @return array{success: bool, message: string, details: array<string, mixed>}
      */
-    public static function testConnection(DatabaseServerSshConfig $sshConfig): array
+    public function testConnection(DatabaseServerSshConfig $sshConfig): array
     {
-        $instance = new self;
-
         try {
             $decrypted = $sshConfig->getDecrypted();
-            $command = $instance->buildTestCommand($decrypted);
+            $command = $this->buildTestCommand($decrypted);
 
             $process = Process::fromShellCommandLine($command);
             $process->setTimeout(self::CONNECTION_TIMEOUT_SECONDS);
@@ -117,7 +115,7 @@ class SshTunnelService
 
                 return [
                     'success' => false,
-                    'message' => $instance->sanitizeError($errorOutput) ?: 'SSH connection failed',
+                    'message' => $this->sanitizeError($errorOutput) ?: 'SSH connection failed',
                     'details' => [],
                 ];
             }
@@ -130,7 +128,7 @@ class SshTunnelService
                 ],
             ];
         } finally {
-            $instance->cleanupTempFiles();
+            $this->cleanupTempFiles();
         }
     }
 

--- a/tests/Feature/Services/Backup/BackupTaskTest.php
+++ b/tests/Feature/Services/Backup/BackupTaskTest.php
@@ -10,8 +10,7 @@ use App\Services\Backup\BackupJobFactory;
 use App\Services\Backup\BackupTask;
 use App\Services\Backup\CompressorFactory;
 use App\Services\Backup\DatabaseListService;
-use App\Services\Backup\Databases\MysqlDatabase;
-use App\Services\Backup\Databases\PostgresqlDatabase;
+use App\Services\Backup\Databases\DatabaseFactory;
 use App\Services\Backup\Filesystems\FilesystemProvider;
 use App\Services\SshTunnelService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,9 +20,7 @@ use Tests\Support\TestShellProcessor;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    // Use REAL services for command building
-    $this->mysqlDatabase = new MysqlDatabase;  // ✓ Real command building
-    $this->postgresqlDatabase = new PostgresqlDatabase;  // ✓ Real command building
+    $this->databaseFactory = new DatabaseFactory;  // ✓ Real factory for command building
     $this->shellProcessor = new TestShellProcessor;  // ✓ Captures commands without executing
     $this->compressorFactory = new CompressorFactory($this->shellProcessor);  // ✓ Real path manipulation
 
@@ -35,8 +32,7 @@ beforeEach(function () {
 
     // Create the BackupTask instance
     $this->backupTask = new BackupTask(
-        $this->mysqlDatabase,
-        $this->postgresqlDatabase,
+        $this->databaseFactory,
         $this->shellProcessor,
         $this->filesystemProvider,
         $this->compressorFactory,
@@ -196,8 +192,7 @@ test('run throws exception when backup command failed', function () {
 
     // Create BackupTask with mocked shell processor
     $backupTask = new BackupTask(
-        $this->mysqlDatabase,
-        $this->postgresqlDatabase,
+        $this->databaseFactory,
         $shellProcessor,
         $this->filesystemProvider,
         $this->compressorFactory,
@@ -380,8 +375,7 @@ test('run establishes SSH tunnel when server requires it', function () {
 
     // Create BackupTask with configured SSH mock
     $backupTask = new BackupTask(
-        $this->mysqlDatabase,
-        $this->postgresqlDatabase,
+        $this->databaseFactory,
         $this->shellProcessor,
         $this->filesystemProvider,
         $this->compressorFactory,

--- a/tests/Feature/Services/SshTunnelServiceTest.php
+++ b/tests/Feature/Services/SshTunnelServiceTest.php
@@ -31,7 +31,7 @@ test('testConnection returns error for invalid config', function (array $config)
         $sshConfig->$key = $value;
     }
 
-    $result = SshTunnelService::testConnection($sshConfig);
+    $result = app(SshTunnelService::class)->testConnection($sshConfig);
 
     expect($result['success'])->toBeFalse()
         ->and($result['message'])->not->toBeEmpty();
@@ -61,7 +61,7 @@ test('testConnection cleans up key file after test', function () {
     $sshConfig->private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest_key\n-----END OPENSSH PRIVATE KEY-----";
     $sshConfig->key_passphrase = null;
 
-    $result = SshTunnelService::testConnection($sshConfig);
+    $result = app(SshTunnelService::class)->testConnection($sshConfig);
 
     // Test should fail but that's expected - we're testing cleanup
     expect($result['success'])->toBeFalse();
@@ -80,7 +80,7 @@ test('testConnection handles key with passphrase', function () {
     $sshConfig->private_key = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest_key\n-----END OPENSSH PRIVATE KEY-----";
     $sshConfig->key_passphrase = 'secret_passphrase';
 
-    $result = SshTunnelService::testConnection($sshConfig);
+    $result = app(SshTunnelService::class)->testConnection($sshConfig);
 
     // Test should fail but that's expected - we're verifying the code path doesn't throw
     expect($result['success'])->toBeFalse();


### PR DESCRIPTION
## Summary

- Introduce `DatabaseFactory` to centralize database handler creation, eliminating duplicated type-dispatch logic across `BackupTask`, `RestoreTask`, and `DatabaseConnectionTester`
- Add `SqliteDatabase` implementing `DatabaseInterface` for full SQLite backup/restore support
- Move connection testing into database classes (`testConnection()` on `DatabaseInterface`)
- Simplify `DatabaseConnectionTester` to delegate to `DatabaseFactory::makeForServer()`
- Harden shell commands with `escapeshellarg`
- Add integration test for PostgreSQL `prepareForRestore` existing-db branch

## Changes

- New `DatabaseFactory` with `make()`, `makeConfigured()`, and `makeForServer()` methods
- New `SqliteDatabase` implementing `DatabaseInterface`
- `DatabaseInterface` expanded with `testConnection()` and `prepareForRestore()` methods
- `BackupTask` and `RestoreTask` simplified to use `DatabaseFactory` instead of per-type dispatch
- `DatabaseConnectionTester` reduced from ~280 to ~90 lines by delegating to factory
- `MysqlDatabase` uses `CLI_BINARIES` class constant; `getRestoreCommandLine` properly escapes input path
- Updated `CLAUDE.md` "Adding a New Database Type" section to reflect new architecture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-class SQLite backup & restore support with file-based restore and validation.
  * Enum-based extension selection for consistent dump filenames.

* **Improvements**
  * Richer, unified connection testing with structured results and SSH tunnel handling as instance behavior.
  * Consistent dump/restore command selection and filename extension across databases.

* **Refactor**
  * Centralized database handling behind a factory + interface to simplify adding new types.

* **Tests**
  * Added/updated integration and feature tests for backups, restores, and connection testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->