### PR TITLE
refactor: layered test architecture for database handlers

### DIFF
--- a/tests/Feature/Services/Backup/Databases/DatabaseFactoryTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Enums\DatabaseType;
+use App\Models\DatabaseServer;
+use App\Services\Backup\Databases\DatabaseFactory;
+use App\Services\Backup\Databases\MysqlDatabase;
+use App\Services\Backup\Databases\PostgresqlDatabase;
+use App\Services\Backup\Databases\SqliteDatabase;
+
+test('make returns correct handler for database type', function (DatabaseType $type, string $expectedClass) {
+    $factory = new DatabaseFactory;
+
+    expect($factory->make($type))->toBeInstanceOf($expectedClass);
+})->with([
+    'mysql' => [DatabaseType::MYSQL, MysqlDatabase::class],
+    'postgresql' => [DatabaseType::POSTGRESQL, PostgresqlDatabase::class],
+    'sqlite' => [DatabaseType::SQLITE, SqliteDatabase::class],
+]);
+
+test('makeForServer uses explicit host and port parameters', function () {
+    $server = DatabaseServer::factory()->create([
+        'database_type' => 'mysql',
+        'host' => 'private-db.internal',
+        'port' => 3306,
+        'username' => 'root',
+        'password' => 'secret',
+    ]);
+
+    $factory = new DatabaseFactory;
+
+    // Simulate SSH tunnel override: pass different host/port than model
+    $database = $factory->makeForServer($server, 'myapp', '127.0.0.1', 54321);
+
+    $command = $database->getDumpCommandLine('/tmp/test.sql');
+    expect($command)->toContain("--host='127.0.0.1'")
+        ->toContain("--port='54321'")
+        ->not->toContain('private-db.internal');
+});

--- a/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Services\Backup\Databases\MysqlDatabase;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function () {
+    $this->db = new MysqlDatabase;
+    $this->db->setConfig([
+        'host' => 'db.local',
+        'port' => 3306,
+        'user' => 'root',
+        'pass' => 'secret',
+        'database' => 'myapp',
+    ]);
+});
+
+test('getDumpCommandLine builds correct command', function (string $cliType, string $expectedCommand) {
+    config(['backup.mysql_cli_type' => $cliType]);
+
+    expect($this->db->getDumpCommandLine('/tmp/dump.sql'))->toBe($expectedCommand);
+})->with([
+    'mariadb' => ['mariadb', "mariadb-dump --single-transaction --routines --add-drop-table --complete-insert --hex-blob --quote-names --skip_ssl --host='db.local' --port='3306' --user='root' --password='secret' 'myapp' > '/tmp/dump.sql'"],
+    'mysql' => ['mysql', "mysqldump --single-transaction --routines --add-drop-table --complete-insert --hex-blob --quote-names --host='db.local' --port='3306' --user='root' --password='secret' 'myapp' > '/tmp/dump.sql'"],
+]);
+
+test('getRestoreCommandLine builds correct command', function (string $cliType, string $expectedCommand) {
+    config(['backup.mysql_cli_type' => $cliType]);
+
+    expect($this->db->getRestoreCommandLine('/tmp/restore.sql'))->toBe($expectedCommand);
+})->with([
+    'mariadb' => ['mariadb', "mariadb --host='db.local' --port='3306' --user='root' --password='secret' --skip_ssl 'myapp' -e 'source /tmp/restore.sql'"],
+    'mysql' => ['mysql', "mysql --host='db.local' --port='3306' --user='root' --password='secret' 'myapp' -e 'source /tmp/restore.sql'"],
+]);
+
+test('testConnection returns success when process succeeds', function () {
+    config(['backup.mysql_cli_type' => 'mariadb']);
+
+    Process::fake([
+        '*' => Process::result(output: 'Uptime: 12345'),
+    ]);
+
+    $result = $this->db->testConnection();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['message'])->toBe('Connection successful')
+        ->and($result['details'])->toHaveKey('ping_ms')
+        ->and($result['details']['output'])->toBe('Uptime: 12345');
+});
+
+test('testConnection returns failure when process fails', function () {
+    config(['backup.mysql_cli_type' => 'mariadb']);
+
+    Process::fake([
+        '*' => Process::result(exitCode: 1, errorOutput: 'Access denied for user'),
+    ]);
+
+    $result = $this->db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('Access denied');
+});

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use App\Services\Backup\Databases\PostgresqlDatabase;
+use Illuminate\Support\Facades\Process;
+
+beforeEach(function () {
+    $this->db = new PostgresqlDatabase;
+    $this->db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+    ]);
+});
+
+test('getDumpCommandLine builds correct pg_dump command', function () {
+    expect($this->db->getDumpCommandLine('/tmp/dump.sql'))
+        ->toBe("PGPASSWORD='pg_secret' pg_dump --clean --if-exists --no-owner --no-privileges --quote-all-identifiers --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/dump.sql'");
+});
+
+test('getRestoreCommandLine builds correct psql command', function () {
+    expect($this->db->getRestoreCommandLine('/tmp/restore.sql'))
+        ->toBe("PGPASSWORD='pg_secret' psql --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/restore.sql'");
+});
+
+test('testConnection returns success with version and SSL info', function () {
+    Process::fake([
+        '*version*' => Process::result(output: 'PostgreSQL 16.2'),
+        '*ssl*' => Process::result(output: 'yes'),
+    ]);
+
+    $result = $this->db->testConnection();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['message'])->toBe('Connection successful')
+        ->and($result['details'])->toHaveKey('ping_ms')
+        ->and($result['details']['output'])->toContain('PostgreSQL 16.2');
+});
+
+test('testConnection returns failure when process fails', function () {
+    Process::fake([
+        '*' => Process::result(exitCode: 1, errorOutput: 'connection refused'),
+    ]);
+
+    $result = $this->db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('connection refused');
+});

--- a/tests/Feature/Services/Backup/Databases/SqliteDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/SqliteDatabaseTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Services\Backup\Databases\SqliteDatabase;
+
+beforeEach(function () {
+    $this->db = new SqliteDatabase;
+    $this->db->setConfig(['sqlite_path' => '/data/app.sqlite']);
+});
+
+test('getDumpCommandLine produces cp command', function () {
+    expect($this->db->getDumpCommandLine('/tmp/dump.db'))
+        ->toBe("cp '/data/app.sqlite' '/tmp/dump.db'");
+});
+
+test('getRestoreCommandLine produces cp and chmod command', function () {
+    expect($this->db->getRestoreCommandLine('/tmp/restore.db'))
+        ->toBe("cp '/tmp/restore.db' '/data/app.sqlite' && chmod 0640 '/data/app.sqlite'");
+});
+
+test('prepareForRestore is a no-op', function () {
+    $job = Mockery::mock(\App\Models\BackupJob::class);
+    $job->shouldNotReceive('logCommand');
+
+    $this->db->prepareForRestore('app.sqlite', $job);
+});
+
+test('testConnection returns success for valid SQLite file', function () {
+    $tempFile = tempnam(sys_get_temp_dir(), 'sqlite_test_');
+
+    $pdo = new PDO("sqlite:{$tempFile}");
+    $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY)');
+    $pdo = null;
+
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => $tempFile]);
+
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['message'])->toBe('Connection successful')
+        ->and($result['details']['output'])->toContain('SQLite');
+
+    unlink($tempFile);
+});
+
+test('testConnection returns error for empty path', function () {
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => '']);
+
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('required');
+});
+
+test('testConnection returns error for non-existent file', function () {
+    $result = $this->db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('does not exist');
+});
+
+test('testConnection returns error for directory path', function () {
+    $tempDir = sys_get_temp_dir().'/sqlite_test_dir_'.uniqid();
+    mkdir($tempDir);
+
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => $tempDir]);
+
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('not a file');
+
+    rmdir($tempDir);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -102,6 +102,18 @@ function weeklySchedule(): \App\Models\BackupSchedule
     );
 }
 
+/**
+ * Create a DatabaseServer with its associated Backup and Volume via factory.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function createDatabaseServer(array $attributes = []): \App\Models\DatabaseServer
+{
+    return \App\Models\DatabaseServer::factory()
+        ->create($attributes)
+        ->load('backup.volume');
+}
+
 /*
 |--------------------------------------------------------------------------
 | Datasets


### PR DESCRIPTION
## Summary

Introduce a layered test architecture for database handlers following the `DatabaseFactory` refactoring.

## Changes

- Add isolated handler tests for `MysqlDatabase`, `PostgresqlDatabase`, `SqliteDatabase`, and `DatabaseFactory` in `tests/Feature/Services/Backup/Databases/`
- Simplify `BackupTaskTest` and `RestoreTaskTest` by mocking `DatabaseFactory` to test orchestration only
- Add delegation test to `DatabaseConnectionTesterTest` verifying correct database names per type
- Extract shared `createDatabaseServer()` helper using factory to `tests/Pest.php`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for MySQL, PostgreSQL, and SQLite backup/restore behavior.
  * Improved isolation by replacing concrete dependencies with mocks/fakes for database handlers, SSH tunneling, and filesystem interactions.
  * Shifted assertions from low-level command strings to end-to-end orchestration and job-status verification (metadata like status, filename, size, checksum).
  * Added test helpers and datasets to streamline creating database server fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->