### PR TITLE
Add SFTP support for remote SQLite backups

### DIFF
--- a/app/Livewire/DatabaseServer/RestoreModal.php
+++ b/app/Livewire/DatabaseServer/RestoreModal.php
@@ -98,10 +98,11 @@ class RestoreModal extends Component
     {
         $this->selectedSnapshotId = $snapshotId;
 
-        // Pre-fill schema name with original database name
-        $snapshot = Snapshot::find($snapshotId);
-        if ($snapshot) {
-            $this->schemaName = $snapshot->database_name;
+        // Pre-fill schema name: use target server's sqlite_path for SQLite, otherwise snapshot's database name
+        if ($this->targetServer?->database_type === DatabaseType::SQLITE && $this->targetServer->sqlite_path) {
+            $this->schemaName = $this->targetServer->sqlite_path;
+        } else {
+            $this->schemaName = Snapshot::findOrFail($snapshotId)->database_name;
         }
 
         // Load existing databases for autocomplete

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -158,6 +158,16 @@ class DatabaseServer extends Model
     }
 
     /**
+     * Check if this server requires SFTP file transfer for backups/restores.
+     * Only applies to SQLite servers accessed via SSH.
+     */
+    public function requiresSftpTransfer(): bool
+    {
+        return $this->database_type === DatabaseType::SQLITE
+            && $this->ssh_config_id !== null;
+    }
+
+    /**
      * Create a temporary DatabaseServer instance for connection testing.
      * This is not persisted to the database.
      *
@@ -206,11 +216,11 @@ class DatabaseServer extends Model
     }
 
     /**
-     * Get SSH tunnel display name if configured, null otherwise.
+     * Get SSH display name if configured (tunnel or SFTP), null otherwise.
      */
     public function getSshDisplayName(): ?string
     {
-        if (! $this->requiresSshTunnel() || $this->sshConfig === null) {
+        if ($this->ssh_config_id === null || $this->sshConfig === null) {
             return null;
         }
 

--- a/app/Services/Backup/Databases/DTO/DatabaseOperationLog.php
+++ b/app/Services/Backup/Databases/DTO/DatabaseOperationLog.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Services\Backup\Databases\DTO;
+
+class DatabaseOperationLog
+{
+    /**
+     * @param  array<string, mixed>|null  $context
+     */
+    public function __construct(
+        public readonly string $message,
+        public readonly string $level = 'info',
+        public readonly ?array $context = null,
+    ) {}
+}

--- a/app/Services/Backup/Databases/DTO/DatabaseOperationResult.php
+++ b/app/Services/Backup/Databases/DTO/DatabaseOperationResult.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Services\Backup\Databases\DTO;
+
+class DatabaseOperationResult
+{
+    public function __construct(
+        public readonly ?string $command = null,
+        public readonly ?DatabaseOperationLog $log = null,
+    ) {}
+}

--- a/app/Services/Backup/Databases/DatabaseInterface.php
+++ b/app/Services/Backup/Databases/DatabaseInterface.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Databases;
 
 use App\Models\BackupJob;
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
 
 interface DatabaseInterface
 {
@@ -11,9 +12,15 @@ interface DatabaseInterface
      */
     public function setConfig(array $config): void;
 
-    public function getDumpCommandLine(string $outputPath): string;
+    /**
+     * Dump the database to the given output path.
+     */
+    public function dump(string $outputPath): DatabaseOperationResult;
 
-    public function getRestoreCommandLine(string $inputPath): string;
+    /**
+     * Restore the database from the given input path.
+     */
+    public function restore(string $inputPath): DatabaseOperationResult;
 
     /**
      * Prepare the target database for restore (e.g. drop and recreate).

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -4,6 +4,7 @@ namespace App\Services\Backup\Databases;
 
 use App\Exceptions\Backup\ConnectionException;
 use App\Models\BackupJob;
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Support\Facades\Process;
@@ -29,9 +30,9 @@ class PostgresqlDatabase implements DatabaseInterface
         $this->config = $config;
     }
 
-    public function getDumpCommandLine(string $outputPath): string
+    public function dump(string $outputPath): DatabaseOperationResult
     {
-        return sprintf(
+        return new DatabaseOperationResult(command: sprintf(
             'PGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s %s -f %s',
             escapeshellarg($this->config['pass']),
             implode(' ', self::DUMP_OPTIONS),
@@ -40,12 +41,12 @@ class PostgresqlDatabase implements DatabaseInterface
             escapeshellarg($this->config['user']),
             escapeshellarg($this->config['database']),
             escapeshellarg($outputPath)
-        );
+        ));
     }
 
-    public function getRestoreCommandLine(string $inputPath): string
+    public function restore(string $inputPath): DatabaseOperationResult
     {
-        return sprintf(
+        return new DatabaseOperationResult(command: sprintf(
             'PGPASSWORD=%s psql --host=%s --port=%s --username=%s %s -f %s',
             escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['host']),
@@ -53,7 +54,7 @@ class PostgresqlDatabase implements DatabaseInterface
             escapeshellarg($this->config['user']),
             escapeshellarg($this->config['database']),
             escapeshellarg($inputPath)
-        );
+        ));
     }
 
     public function prepareForRestore(string $schemaName, BackupJob $job): void

--- a/app/Services/Backup/Databases/RedisDatabase.php
+++ b/app/Services/Backup/Databases/RedisDatabase.php
@@ -4,6 +4,7 @@ namespace App\Services\Backup\Databases;
 
 use App\Exceptions\Backup\UnsupportedDatabaseTypeException;
 use App\Models\BackupJob;
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
 use Illuminate\Support\Facades\Process;
@@ -21,15 +22,15 @@ class RedisDatabase implements DatabaseInterface
         $this->config = $config;
     }
 
-    public function getDumpCommandLine(string $outputPath): string
+    public function dump(string $outputPath): DatabaseOperationResult
     {
         $parts = $this->buildBaseCommand();
         $parts[] = '--rdb '.escapeshellarg($outputPath);
 
-        return implode(' ', $parts);
+        return new DatabaseOperationResult(command: implode(' ', $parts));
     }
 
-    public function getRestoreCommandLine(string $inputPath): string
+    public function restore(string $inputPath): DatabaseOperationResult
     {
         throw new UnsupportedDatabaseTypeException('redis');
     }

--- a/app/Services/Backup/Databases/SqliteDatabase.php
+++ b/app/Services/Backup/Databases/SqliteDatabase.php
@@ -2,12 +2,21 @@
 
 namespace App\Services\Backup\Databases;
 
+use App\Exceptions\Backup\DatabaseDumpException;
+use App\Exceptions\Backup\RestoreException;
 use App\Models\BackupJob;
+use App\Services\Backup\Databases\DTO\DatabaseOperationLog;
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
+use App\Services\Backup\Filesystems\SftpFilesystem;
 
 class SqliteDatabase implements DatabaseInterface
 {
     /** @var array<string, mixed> */
     private array $config;
+
+    public function __construct(
+        private readonly SftpFilesystem $sftpFilesystem = new SftpFilesystem,
+    ) {}
 
     /**
      * @param  array<string, mixed>  $config
@@ -17,19 +26,83 @@ class SqliteDatabase implements DatabaseInterface
         $this->config = $config;
     }
 
-    public function getDumpCommandLine(string $outputPath): string
+    public function dump(string $outputPath): DatabaseOperationResult
     {
-        return sprintf('cp %s %s', escapeshellarg($this->config['sqlite_path']), escapeshellarg($outputPath));
+        $sourcePath = $this->config['sqlite_path'];
+        $sshConfig = $this->config['ssh_config'] ?? null;
+
+        if ($sshConfig !== null) {
+            $filesystem = $this->sftpFilesystem->getFromSshConfig($sshConfig);
+            $source = $filesystem->readStream($sourcePath);
+
+            $dest = fopen($outputPath, 'wb');
+            if ($dest === false) {
+                fclose($source);
+                throw new DatabaseDumpException("Failed to open destination for writing: {$outputPath}");
+            }
+
+            try {
+                $bytes = stream_copy_to_stream($source, $dest);
+                if ($bytes === false || $bytes === 0) {
+                    throw new DatabaseDumpException("Failed to copy remote SQLite file {$sourcePath} to {$outputPath}");
+                }
+            } finally {
+                fclose($source);
+                fclose($dest);
+            }
+
+            return new DatabaseOperationResult(log: new DatabaseOperationLog(
+                'Downloaded SQLite database via SFTP',
+                'success',
+                ['host' => $sshConfig->host, 'path' => $sourcePath],
+            ));
+        }
+
+        if (! @copy($sourcePath, $outputPath)) {
+            throw new DatabaseDumpException("Failed to copy local SQLite file {$sourcePath} to {$outputPath}");
+        }
+
+        return new DatabaseOperationResult(log: new DatabaseOperationLog(
+            'Copied local SQLite database',
+            'success',
+            ['path' => $sourcePath],
+        ));
     }
 
-    public function getRestoreCommandLine(string $inputPath): string
+    public function restore(string $inputPath): DatabaseOperationResult
     {
-        return sprintf(
-            'cp %s %s && chmod 0640 %s',
-            escapeshellarg($inputPath),
-            escapeshellarg($this->config['sqlite_path']),
-            escapeshellarg($this->config['sqlite_path'])
-        );
+        $sshConfig = $this->config['ssh_config'] ?? null;
+
+        if ($sshConfig !== null) {
+            $filesystem = $this->sftpFilesystem->getFromSshConfig($sshConfig);
+            $stream = fopen($inputPath, 'rb');
+            if ($stream === false) {
+                throw new RestoreException("Failed to open file for reading: {$inputPath}");
+            }
+            try {
+                $filesystem->writeStream($this->config['sqlite_path'], $stream);
+            } finally {
+                fclose($stream);
+            }
+
+            return new DatabaseOperationResult(log: new DatabaseOperationLog(
+                'Uploaded SQLite database via SFTP',
+                'success',
+                ['host' => $sshConfig->host, 'path' => $this->config['sqlite_path']],
+            ));
+        }
+
+        $targetPath = $this->config['sqlite_path'];
+        if (! @copy($inputPath, $targetPath)) {
+            throw new RestoreException("Failed to copy SQLite file {$inputPath} to {$targetPath}");
+        }
+        chmod($targetPath, 0640);
+
+        return new DatabaseOperationResult(log: new DatabaseOperationLog(
+            'Restored local SQLite database',
+            'success',
+            ['path' => $this->config['sqlite_path']],
+        ));
     }
 
     public function prepareForRestore(string $schemaName, BackupJob $job): void

--- a/app/Services/Backup/Filesystems/SftpFilesystem.php
+++ b/app/Services/Backup/Filesystems/SftpFilesystem.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Backup\Filesystems;
 
+use App\Models\DatabaseServerSshConfig;
 use League\Flysystem\Filesystem;
 use League\Flysystem\PhpseclibV3\SftpAdapter;
 use League\Flysystem\PhpseclibV3\SftpConnectionProvider;
@@ -14,14 +15,16 @@ class SftpFilesystem implements FilesystemInterface
     }
 
     /**
-     * @param  array{host: string, username: string, password: string, port?: int, root?: string, timeout?: int}  $config
+     * @param  array{host: string, username: string, password?: string|null, private_key?: string|null, key_passphrase?: string|null, port?: int, root?: string, timeout?: int}  $config
      */
     public function get(array $config): Filesystem
     {
         $provider = new SftpConnectionProvider(
             host: $config['host'],
             username: $config['username'],
-            password: $config['password'],
+            password: $config['password'] ?? null,
+            privateKey: $config['private_key'] ?? null,
+            passphrase: $config['key_passphrase'] ?? null,
             port: (int) ($config['port'] ?? 22),
             timeout: (int) ($config['timeout'] ?? 10),
         );
@@ -31,5 +34,24 @@ class SftpFilesystem implements FilesystemInterface
         $adapter = new SftpAdapter($provider, $root);
 
         return new Filesystem($adapter);
+    }
+
+    /**
+     * Build a Flysystem Filesystem from a DatabaseServerSshConfig model.
+     * Convenience method to avoid duplicating SSH-to-SFTP config mapping.
+     */
+    public function getFromSshConfig(DatabaseServerSshConfig $sshConfig, string $root = '/'): Filesystem
+    {
+        $decrypted = $sshConfig->getDecrypted();
+
+        return $this->get([
+            'host' => $decrypted['host'],
+            'port' => $decrypted['port'],
+            'username' => $decrypted['username'],
+            'password' => $decrypted['password'],
+            'private_key' => $decrypted['private_key'],
+            'key_passphrase' => $decrypted['key_passphrase'],
+            'root' => $root,
+        ]);
     }
 }

--- a/app/Services/Backup/RestoreTask.php
+++ b/app/Services/Backup/RestoreTask.php
@@ -113,7 +113,14 @@ class RestoreTask
                 'source_database' => $snapshot->database_name,
                 'target_database' => $restore->schema_name,
             ]);
-            $this->shellProcessor->process($database->getRestoreCommandLine($workingFile));
+
+            $result = $database->restore($workingFile);
+            if ($result->command !== null) {
+                $this->shellProcessor->process($result->command);
+            }
+            if ($result->log !== null) {
+                $job->log($result->log->message, $result->log->level, $result->log->context ?? []);
+            }
 
             // Mark job as completed
             $job->markCompleted();

--- a/database/factories/DatabaseServerFactory.php
+++ b/database/factories/DatabaseServerFactory.php
@@ -50,6 +50,28 @@ class DatabaseServerFactory extends Factory
     }
 
     /**
+     * Configure the factory for remote SQLite (via SSH/SFTP).
+     *
+     * Note: Uses afterCreating() hook, so only works with create(), not make().
+     *
+     * @param  array<string, mixed>  $overrides
+     */
+    public function sqliteRemote(array $overrides = []): static
+    {
+        return $this->sqlite()->afterCreating(function ($databaseServer) use ($overrides) {
+            $sshConfig = DatabaseServerSshConfig::factory()->create(array_merge([
+                'host' => 'remote.example.com',
+                'port' => 22,
+                'username' => 'deploy',
+                'auth_type' => 'password',
+                'password' => 'ssh_password',
+            ], $overrides));
+
+            $databaseServer->update(['ssh_config_id' => $sshConfig->id]);
+        });
+    }
+
+    /**
      * Configure the factory for Redis database type.
      */
     public function redis(): static

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -52,7 +52,7 @@
                         wire:model="form.sqlite_path"
                         label="{{ __('Database File Path') }}"
                         placeholder="{{ __('e.g., /var/data/database.sqlite') }}"
-                        hint="{{ __('Absolute path to the SQLite database file') }}"
+                        hint="{{ $form->ssh_enabled ? __('Absolute path on the remote SSH server') : __('Absolute path to the SQLite database file') }}"
                         type="text"
                         required
                     />
@@ -98,9 +98,7 @@
                     </div>
                 @endif
 
-                @if(!$form->isSqlite())
-                    @include('livewire.database-server._ssh-tunnel-config', ['form' => $form, 'isEdit' => $isEdit])
-                @endif
+                @include('livewire.database-server._ssh-tunnel-config', ['form' => $form, 'isEdit' => $isEdit])
 
                 <!-- Test Connection Button -->
                 <div class="flex flex-wrap items-center gap-2 pt-2">
@@ -154,6 +152,10 @@
                 @if($form->connectionTestSuccess && !empty($form->connectionTestDetails['ssh_tunnel']))
                     <x-alert class="alert-info mt-2" icon="o-server-stack">
                         {{ __('Connected via SSH tunnel through') }} {{ $form->connectionTestDetails['ssh_host'] }}
+                    </x-alert>
+                @elseif($form->connectionTestSuccess && !empty($form->connectionTestDetails['sftp']))
+                    <x-alert class="alert-info mt-2" icon="o-server-stack">
+                        {{ __('Connected via SFTP through') }} {{ $form->connectionTestDetails['ssh_host'] }}
                     </x-alert>
                 @endif
 

--- a/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
+++ b/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
@@ -15,7 +15,7 @@
             wire:model.live="form.ssh_enabled"
             class="toggle-primary"
         />
-        <span class="font-medium">{{ __('Use SSH Tunnel') }}</span>
+        <span class="font-medium">{{ $form->isSqlite() ? __('Access via SSH (SFTP)') : __('Use SSH Tunnel') }}</span>
     </label>
 
     <!-- SSH Configuration Form (shown only when enabled) -->

--- a/tests/Feature/DatabaseServer/RestoreModalTest.php
+++ b/tests/Feature/DatabaseServer/RestoreModalTest.php
@@ -188,6 +188,20 @@ test('can search and filter snapshots', function () {
         ->assertDontSee('orders_db');
 });
 
+test('sqlite restore pre-fills schema name with target server sqlite_path', function () {
+    $targetServer = DatabaseServer::factory()->sqlite()->create([
+        'sqlite_path' => '/data/production.sqlite',
+    ]);
+
+    $sourceServer = DatabaseServer::factory()->sqlite()->create();
+    $snapshot = Snapshot::factory()->forServer($sourceServer)->withFile()->create();
+
+    Livewire::test(RestoreModal::class)
+        ->dispatch('open-restore-modal', targetServerId: $targetServer->id)
+        ->call('selectSnapshot', $snapshot->id)
+        ->assertSet('schemaName', '/data/production.sqlite');
+});
+
 test('redis restore shows manual instructions modal', function () {
     $targetServer = DatabaseServer::factory()->create([
         'database_type' => 'redis',

--- a/tests/Feature/Services/Backup/Databases/DatabaseFactoryTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseFactoryTest.php
@@ -33,8 +33,8 @@ test('makeForServer uses explicit host and port parameters', function () {
     // Simulate SSH tunnel override: pass different host/port than model
     $database = $factory->makeForServer($server, 'myapp', '127.0.0.1', 54321);
 
-    $command = $database->getDumpCommandLine('/tmp/test.sql');
-    expect($command)->toContain("--host='127.0.0.1'")
+    $result = $database->dump('/tmp/test.sql');
+    expect($result->command)->toContain("--host='127.0.0.1'")
         ->toContain("--port='54321'")
         ->not->toContain('private-db.internal');
 });

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
 use App\Services\Backup\Databases\PostgresqlDatabase;
 use Illuminate\Support\Facades\Process;
 
@@ -14,14 +15,18 @@ beforeEach(function () {
     ]);
 });
 
-test('getDumpCommandLine builds correct pg_dump command', function () {
-    expect($this->db->getDumpCommandLine('/tmp/dump.sql'))
-        ->toBe("PGPASSWORD='pg_secret' pg_dump --clean --if-exists --no-owner --no-privileges --quote-all-identifiers --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/dump.sql'");
+test('dump builds correct pg_dump command', function () {
+    $result = $this->db->dump('/tmp/dump.sql');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe("PGPASSWORD='pg_secret' pg_dump --clean --if-exists --no-owner --no-privileges --quote-all-identifiers --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/dump.sql'");
 });
 
-test('getRestoreCommandLine builds correct psql command', function () {
-    expect($this->db->getRestoreCommandLine('/tmp/restore.sql'))
-        ->toBe("PGPASSWORD='pg_secret' psql --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/restore.sql'");
+test('restore builds correct psql command', function () {
+    $result = $this->db->restore('/tmp/restore.sql');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe("PGPASSWORD='pg_secret' psql --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/restore.sql'");
 });
 
 test('testConnection returns success with version and SSL info', function () {

--- a/tests/Feature/Services/Backup/Databases/SqliteDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/SqliteDatabaseTest.php
@@ -1,31 +1,168 @@
 <?php
 
+use App\Exceptions\Backup\DatabaseDumpException;
+use App\Exceptions\Backup\RestoreException;
+use App\Models\DatabaseServerSshConfig;
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
 use App\Services\Backup\Databases\SqliteDatabase;
+use App\Services\Backup\Filesystems\SftpFilesystem;
+use League\Flysystem\Filesystem;
 
 beforeEach(function () {
-    $this->db = new SqliteDatabase;
-    $this->db->setConfig(['sqlite_path' => '/data/app.sqlite']);
+    $this->tempDir = sys_get_temp_dir().'/sqlite-db-test-'.uniqid();
+    mkdir($this->tempDir, 0777, true);
 });
 
-test('getDumpCommandLine produces cp command', function () {
-    expect($this->db->getDumpCommandLine('/tmp/dump.db'))
-        ->toBe("cp '/data/app.sqlite' '/tmp/dump.db'");
+test('dump copies local file', function () {
+    $sourceFile = $this->tempDir.'/source.sqlite';
+    file_put_contents($sourceFile, 'SQLite data');
+
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => $sourceFile]);
+
+    $outputPath = $this->tempDir.'/dump.db';
+    $result = $db->dump($outputPath);
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBeNull()
+        ->and($result->log->message)->toBe('Copied local SQLite database')
+        ->and($result->log->context)->toBe(['path' => $sourceFile])
+        ->and(file_get_contents($outputPath))->toBe('SQLite data');
 });
 
-test('getRestoreCommandLine produces cp and chmod command', function () {
-    expect($this->db->getRestoreCommandLine('/tmp/restore.db'))
-        ->toBe("cp '/tmp/restore.db' '/data/app.sqlite' && chmod 0640 '/data/app.sqlite'");
+test('dump downloads remote file via SFTP', function () {
+    $sshConfig = DatabaseServerSshConfig::factory()->create([
+        'host' => 'remote.example.com',
+    ]);
+
+    $stream = fopen('php://memory', 'r+');
+    fwrite($stream, 'remote SQLite data');
+    rewind($stream);
+
+    $mockRemoteFs = Mockery::mock(Filesystem::class);
+    $mockRemoteFs->shouldReceive('readStream')
+        ->once()
+        ->with('/data/remote.sqlite')
+        ->andReturn($stream);
+
+    $mockSftp = Mockery::mock(SftpFilesystem::class);
+    $mockSftp->shouldReceive('getFromSshConfig')
+        ->once()
+        ->with(Mockery::on(fn ($config) => $config->host === 'remote.example.com'))
+        ->andReturn($mockRemoteFs);
+
+    $db = new SqliteDatabase($mockSftp);
+    $db->setConfig(['sqlite_path' => '/data/remote.sqlite', 'ssh_config' => $sshConfig]);
+
+    $outputPath = $this->tempDir.'/dump.db';
+    $result = $db->dump($outputPath);
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBeNull()
+        ->and($result->log->message)->toBe('Downloaded SQLite database via SFTP')
+        ->and($result->log->context)->toBe(['host' => 'remote.example.com', 'path' => '/data/remote.sqlite'])
+        ->and(file_get_contents($outputPath))->toBe('remote SQLite data');
 });
+
+test('dump throws on local copy failure', function () {
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => '/nonexistent/source.sqlite']);
+
+    $db->dump($this->tempDir.'/dump.db');
+})->throws(DatabaseDumpException::class, 'Failed to copy local SQLite file /nonexistent/source.sqlite');
+
+test('dump throws when remote stream copy returns zero bytes', function () {
+    $sshConfig = DatabaseServerSshConfig::factory()->create([
+        'host' => 'remote.example.com',
+    ]);
+
+    // Return an empty stream (0 bytes)
+    $stream = fopen('php://memory', 'r+');
+
+    $mockRemoteFs = Mockery::mock(Filesystem::class);
+    $mockRemoteFs->shouldReceive('readStream')
+        ->once()
+        ->with('/data/remote.sqlite')
+        ->andReturn($stream);
+
+    $mockSftp = Mockery::mock(SftpFilesystem::class);
+    $mockSftp->shouldReceive('getFromSshConfig')
+        ->once()
+        ->andReturn($mockRemoteFs);
+
+    $db = new SqliteDatabase($mockSftp);
+    $db->setConfig(['sqlite_path' => '/data/remote.sqlite', 'ssh_config' => $sshConfig]);
+
+    $db->dump($this->tempDir.'/dump.db');
+})->throws(DatabaseDumpException::class, 'Failed to copy remote SQLite file /data/remote.sqlite');
+
+test('restore copies local file and sets permissions', function () {
+    $targetFile = $this->tempDir.'/target.sqlite';
+    $inputFile = $this->tempDir.'/input.db';
+    file_put_contents($inputFile, 'restored data');
+
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => $targetFile]);
+
+    $result = $db->restore($inputFile);
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBeNull()
+        ->and($result->log->message)->toBe('Restored local SQLite database')
+        ->and(file_get_contents($targetFile))->toBe('restored data');
+});
+
+test('restore uploads remote file via SFTP', function () {
+    $sshConfig = DatabaseServerSshConfig::factory()->create([
+        'host' => 'remote.example.com',
+    ]);
+
+    $mockRemoteFs = Mockery::mock(Filesystem::class);
+    $mockRemoteFs->shouldReceive('writeStream')
+        ->once()
+        ->with('/data/remote.sqlite', Mockery::type('resource'));
+
+    $mockSftp = Mockery::mock(SftpFilesystem::class);
+    $mockSftp->shouldReceive('getFromSshConfig')
+        ->once()
+        ->with(Mockery::on(fn ($config) => $config->host === 'remote.example.com'))
+        ->andReturn($mockRemoteFs);
+
+    $db = new SqliteDatabase($mockSftp);
+    $db->setConfig(['sqlite_path' => '/data/remote.sqlite', 'ssh_config' => $sshConfig]);
+
+    $inputFile = $this->tempDir.'/input.db';
+    file_put_contents($inputFile, 'restored data');
+
+    $result = $db->restore($inputFile);
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBeNull()
+        ->and($result->log->message)->toBe('Uploaded SQLite database via SFTP')
+        ->and($result->log->context)->toBe(['host' => 'remote.example.com', 'path' => '/data/remote.sqlite']);
+});
+
+test('restore throws on local copy failure', function () {
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => '/nonexistent/target.sqlite']);
+
+    $inputFile = $this->tempDir.'/input.db';
+    file_put_contents($inputFile, 'restored data');
+
+    $db->restore($inputFile);
+})->throws(RestoreException::class, 'Failed to copy SQLite file');
 
 test('prepareForRestore is a no-op', function () {
     $job = Mockery::mock(\App\Models\BackupJob::class);
     $job->shouldNotReceive('logCommand');
 
-    $this->db->prepareForRestore('app.sqlite', $job);
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => '/data/app.sqlite']);
+    $db->prepareForRestore('app.sqlite', $job);
 });
 
 test('testConnection returns success for valid SQLite file', function () {
-    $tempFile = tempnam(sys_get_temp_dir(), 'sqlite_test_');
+    $tempFile = $this->tempDir.'/test.sqlite';
 
     $pdo = new PDO("sqlite:{$tempFile}");
     $pdo->exec('CREATE TABLE test (id INTEGER PRIMARY KEY)');
@@ -39,8 +176,6 @@ test('testConnection returns success for valid SQLite file', function () {
     expect($result['success'])->toBeTrue()
         ->and($result['message'])->toBe('Connection successful')
         ->and($result['details']['output'])->toContain('SQLite');
-
-    unlink($tempFile);
 });
 
 test('testConnection returns error for empty path', function () {
@@ -54,14 +189,17 @@ test('testConnection returns error for empty path', function () {
 });
 
 test('testConnection returns error for non-existent file', function () {
-    $result = $this->db->testConnection();
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => '/data/app.sqlite']);
+
+    $result = $db->testConnection();
 
     expect($result['success'])->toBeFalse()
         ->and($result['message'])->toContain('does not exist');
 });
 
 test('testConnection returns error for directory path', function () {
-    $tempDir = sys_get_temp_dir().'/sqlite_test_dir_'.uniqid();
+    $tempDir = $this->tempDir.'/subdir';
     mkdir($tempDir);
 
     $db = new SqliteDatabase;
@@ -71,6 +209,4 @@ test('testConnection returns error for directory path', function () {
 
     expect($result['success'])->toBeFalse()
         ->and($result['message'])->toContain('not a file');
-
-    rmdir($tempDir);
 });

--- a/tests/Feature/Volume/VolumeTest.php
+++ b/tests/Feature/Volume/VolumeTest.php
@@ -294,8 +294,6 @@ describe('connection testing', function () {
             ->call('testConnection')
             ->assertSet('form.connectionTestSuccess', true)
             ->assertSet('form.connectionTestMessage', 'Connection successful!');
-
-        rmdir($tempDir);
     });
 
     test('can test connection on edit using persisted password', function () {

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -221,10 +221,6 @@ test('sqlite backup and restore workflow', function () {
     expect((int) $result['count'])->toBe(3);
 
     $targetServer->delete();
-
-    // Cleanup SQLite test files
-    @unlink($sourceSqlitePath);
-    @unlink($restoredSqlitePath);
 });
 
 test('redis backup workflow', function () {

--- a/tests/Integration/DatabaseConnectionTesterTest.php
+++ b/tests/Integration/DatabaseConnectionTesterTest.php
@@ -40,9 +40,7 @@ test('connection succeeds', function (string $databaseType) {
         ->and($result['message'])->toBe('Connection successful');
 
     // Cleanup
-    if ($databaseType === 'sqlite') {
-        unlink($config['host']);
-    } elseif ($databaseType !== 'redis') {
+    if ($databaseType !== 'sqlite' && $databaseType !== 'redis') {
         IntegrationTestHelpers::dropDatabase($databaseType, $server, $config['database']);
         $server->delete();
     }
@@ -121,8 +119,6 @@ test('sqlite connection fails with invalid sqlite file', function () {
 
     expect($result['success'])->toBeFalse()
         ->and($result['message'])->toContain('Invalid SQLite database file');
-
-    unlink($invalidPath);
 });
 
 test('redis connection fails with wrong port', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -48,6 +48,7 @@ afterEach(function () {
         '/volume-test-*',        // VolumeFactory
         '/backup-task-test-*',   // BackupTaskTest
         '/restore-task-test-*',  // RestoreTaskTest
+        '/sqlite-db-test-*',    // SqliteDatabaseTest
     ];
 
     foreach ($patterns as $pattern) {


### PR DESCRIPTION
## Summary

Add SSH/SFTP support for remote SQLite database backups and restores, with unified database operation DTOs and robust error handling.

## Changes

- SSH/SFTP-based dump/restore using Flysystem streams for memory-efficient file transfers
- SFTP connection testing with host info in results
- Unify database operations with DTOs (`DatabaseOperationResult`, `DatabaseOperationLog`) for type safety and logging
- Pre-fill restore modal destination with target server's `sqlite_path` for SQLite
- Robust error handling with `DatabaseDumpException`/`RestoreException` for all SQLite I/O failures
- SSH config UI visible for SQLite servers with adapted labels and path hints
- Remove redundant test cleanup already handled by global `afterEach`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH/SFTP support for remote SQLite backups and restores, with SFTP-based transfer and operation results including optional command logs.
  * Connection tests now perform SFTP checks for remote SQLite and return detailed success/error info.

* **UI**
  * SSH config shown for SQLite with label "Access via SSH (SFTP)"; path hints adapt for remote vs local.
  * Restore modal pre-fills schema/path for SQLite targets when selecting a snapshot.

* **Bug Fixes**
  * Connection test alerts show SFTP connection details when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->