### PR TITLE
feat: add MongoDB database type support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,19 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
+      mongodb:
+        image: mongo:8
+        env:
+          MONGO_INITDB_ROOT_USERNAME: root
+          MONGO_INITDB_ROOT_PASSWORD: root
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd="mongosh --eval 'db.adminCommand({ping:1})' --quiet"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
       redis:
         image: redis:7
         ports:
@@ -53,12 +66,17 @@ jobs:
           php-version: 8.4
           tools: composer:v2
           coverage: pcov
-          extensions: pdo, pdo_mysql, pdo_pgsql
+          extensions: pdo, pdo_mysql, pdo_pgsql, mongodb
 
       - name: Install System Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y mysql-client postgresql-client redis-tools zstd p7zip-full
+          # Install MongoDB tools (mongodump, mongorestore)
+          wget -qO - https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg
+          echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+          sudo apt-get update
+          sudo apt-get install -y mongodb-database-tools
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -91,6 +109,7 @@ jobs:
           TEST_MYSQL_HOST: 127.0.0.1
           TEST_POSTGRES_HOST: 127.0.0.1
           TEST_REDIS_HOST: 127.0.0.1
+          TEST_MONGODB_HOST: 127.0.0.1
         run: |
           php artisan migrate --force
           php artisan test --parallel --coverage-clover=coverage.xml --log-junit junit.xml

--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -10,6 +10,7 @@ enum DatabaseType: string
     case POSTGRESQL = 'postgres';
     case SQLITE = 'sqlite';
     case REDIS = 'redis';
+    case MONGODB = 'mongodb';
 
     public function label(): string
     {
@@ -18,6 +19,7 @@ enum DatabaseType: string
             self::POSTGRESQL => 'PostgreSQL',
             self::SQLITE => 'SQLite',
             self::REDIS => 'Redis / Valkey',
+            self::MONGODB => 'MongoDB',
         };
     }
 
@@ -28,6 +30,7 @@ enum DatabaseType: string
             self::POSTGRESQL => 'devicon.postgresql',
             self::SQLITE => 'devicon.sqlite',
             self::REDIS => 'devicon.redis',
+            self::MONGODB => 'devicon.mongodb',
         };
     }
 
@@ -38,6 +41,7 @@ enum DatabaseType: string
             self::POSTGRESQL => 5432,
             self::SQLITE => 0,
             self::REDIS => 6379,
+            self::MONGODB => 27017,
         };
     }
 
@@ -62,6 +66,7 @@ enum DatabaseType: string
             ),
             self::SQLITE => "sqlite:{$host}",
             self::REDIS => throw new \RuntimeException('Redis does not support PDO connections'),
+            self::MONGODB => throw new \RuntimeException('MongoDB does not support PDO connections'),
         };
     }
 
@@ -74,8 +79,8 @@ enum DatabaseType: string
      */
     public function createPdo(DatabaseServer $server, ?string $database = null, int $timeout = 30): \PDO
     {
-        if ($this === self::REDIS) {
-            throw new \RuntimeException('Redis does not support PDO connections');
+        if (in_array($this, [self::REDIS, self::MONGODB], true)) {
+            throw new \RuntimeException("{$this->label()} does not support PDO connections");
         }
 
         $host = $server->host;
@@ -103,6 +108,7 @@ enum DatabaseType: string
         return match ($this) {
             self::SQLITE => 'db',
             self::REDIS => 'rdb',
+            self::MONGODB => 'archive',
             default => 'sql',
         };
     }

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -183,6 +183,7 @@ class DatabaseServer extends Model
         $server->username = $config['username'] ?? '';
         $server->password = $config['password'] ?? '';
         $server->database_names = $config['database_names'] ?? null;
+        $server->extra_config = $config['extra_config'] ?? null;
 
         if ($sshConfig !== null) {
             $server->ssh_config_id = 'temp';
@@ -214,6 +215,14 @@ class DatabaseServer extends Model
         }
 
         return "{$this->host}:{$this->port}";
+    }
+
+    /**
+     * Get a type-specific config value from extra_config.
+     */
+    public function getExtraConfig(string $key, mixed $default = null): mixed
+    {
+        return $this->extra_config[$key] ?? $default;
     }
 
     /**

--- a/app/Services/Backup/Databases/MongodbDatabase.php
+++ b/app/Services/Backup/Databases/MongodbDatabase.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace App\Services\Backup\Databases;
+
+use App\Models\BackupJob;
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
+use App\Support\Formatters;
+use MongoDB\Driver\Command;
+use MongoDB\Driver\Exception\Exception as MongoException;
+use MongoDB\Driver\Manager;
+
+class MongodbDatabase implements DatabaseInterface
+{
+    /** @var array<string, mixed> */
+    private array $config;
+
+    private const array EXCLUDED_DATABASES = [
+        'admin',
+        'local',
+        'config',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function setConfig(array $config): void
+    {
+        $this->config = $config;
+    }
+
+    public function dump(string $outputPath): DatabaseOperationResult
+    {
+        $parts = [
+            'mongodump',
+            ...$this->buildBaseArgs(),
+            ...$this->buildAuthFlags(),
+            '--db='.escapeshellarg($this->config['database']),
+            '--archive='.escapeshellarg($outputPath),
+        ];
+
+        return new DatabaseOperationResult(command: implode(' ', $parts));
+    }
+
+    public function restore(string $inputPath): DatabaseOperationResult
+    {
+        $sourceDb = $this->config['source_database'] ?? $this->config['database'];
+        $targetDb = $this->config['database'];
+
+        $parts = [
+            'mongorestore',
+            ...$this->buildBaseArgs(),
+            ...$this->buildAuthFlags(),
+            '--archive='.escapeshellarg($inputPath),
+            '--nsFrom='.escapeshellarg("{$sourceDb}.*"),
+            '--nsTo='.escapeshellarg("{$targetDb}.*"),
+            '--drop',
+        ];
+
+        return new DatabaseOperationResult(command: implode(' ', $parts));
+    }
+
+    public function prepareForRestore(string $schemaName, BackupJob $job): void
+    {
+        // MongoDB restore uses --drop flag to handle existing collections; no separate preparation needed
+    }
+
+    public function listDatabases(): array
+    {
+        $manager = $this->createManager();
+        $cursor = $manager->executeCommand('admin', new Command(['listDatabases' => 1]));
+        $response = $cursor->toArray()[0];
+
+        /** @var array<object{name: string}> $dbList */
+        $dbList = $response->databases;
+
+        $databases = array_map(
+            fn (object $db): string => $db->name,
+            $dbList,
+        );
+
+        return array_values(array_filter($databases, fn (string $db): bool => ! in_array($db, self::EXCLUDED_DATABASES)));
+    }
+
+    public function testConnection(): array
+    {
+        $startTime = microtime(true);
+
+        try {
+            $manager = $this->createManager();
+            $authDb = $this->authSource();
+            $cursor = $manager->executeCommand($authDb, new Command(['ping' => 1]));
+            $response = $cursor->toArray()[0];
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+
+            if (! isset($response->ok) || (int) $response->ok !== 1) {
+                return ['success' => false, 'message' => 'Unexpected response from MongoDB server', 'details' => []];
+            }
+
+            $serverInfo = ['dbms' => 'MongoDB'];
+
+            try {
+                $infoCursor = $manager->executeCommand($authDb, new Command(['buildInfo' => 1]));
+                $info = $infoCursor->toArray()[0];
+                if (isset($info->version)) {
+                    $serverInfo['dbms'] = 'MongoDB '.$info->version;
+                    $serverInfo['version'] = $info->version;
+                }
+            } catch (MongoException) {
+                // Non-critical
+            }
+
+            return [
+                'success' => true,
+                'message' => 'Connection successful',
+                'details' => [
+                    'ping_ms' => $durationMs,
+                    'output' => json_encode($serverInfo, JSON_PRETTY_PRINT),
+                ],
+            ];
+        } catch (MongoException $e) {
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+
+            if ($durationMs >= 9500) {
+                return [
+                    'success' => false,
+                    'message' => 'Connection timed out after '.Formatters::humanDuration($durationMs).'. Please check the host and port are correct and accessible.',
+                    'details' => [],
+                ];
+            }
+
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+                'details' => [],
+            ];
+        }
+    }
+
+    /**
+     * Build the base host/port arguments.
+     *
+     * @return array<string>
+     */
+    private function buildBaseArgs(): array
+    {
+        return [
+            '--host='.escapeshellarg($this->config['host']),
+            '--port='.escapeshellarg((string) $this->config['port']),
+        ];
+    }
+
+    /**
+     * Build authentication flags for MongoDB CLI tools.
+     *
+     * @return array<string>
+     */
+    private function buildAuthFlags(): array
+    {
+        $user = $this->config['user'] ?? '';
+        $pass = $this->config['pass'] ?? '';
+
+        if (empty($user) || empty($pass)) {
+            return [];
+        }
+
+        return [
+            '--username='.escapeshellarg($user),
+            '--password='.escapeshellarg($pass),
+            '--authenticationDatabase='.escapeshellarg($this->authSource()),
+        ];
+    }
+
+    /**
+     * Build a MongoDB connection URI.
+     */
+    public static function buildConnectionUri(string $host, int $port, string $user = '', string $pass = '', string $authSource = 'admin'): string
+    {
+        if (! empty($user) && ! empty($pass)) {
+            return sprintf(
+                'mongodb://%s:%s@%s:%d/?authSource=%s',
+                rawurlencode($user),
+                rawurlencode($pass),
+                $host,
+                $port,
+                rawurlencode($authSource),
+            );
+        }
+
+        return sprintf('mongodb://%s:%d', $host, $port);
+    }
+
+    private function authSource(): string
+    {
+        return $this->config['auth_source'] ?? 'admin';
+    }
+
+    /**
+     * Create MongoDB Manager instance.
+     * Note: No explicit return type due to Manager being final and unmockable in tests.
+     *
+     * @return Manager
+     */
+    protected function createManager()
+    {
+        $uri = self::buildConnectionUri(
+            $this->config['host'],
+            (int) $this->config['port'],
+            $this->config['user'] ?? '',
+            $this->config['pass'] ?? '',
+            $this->authSource(),
+        );
+
+        return new Manager($uri, [
+            'connectTimeoutMS' => 10000,
+            'serverSelectionTimeoutMS' => 10000,
+        ]);
+    }
+}

--- a/app/Services/Backup/RestoreTask.php
+++ b/app/Services/Backup/RestoreTask.php
@@ -105,6 +105,7 @@ class RestoreTask
                 $restore->schema_name,
                 $this->getConnectionHost($targetServer),
                 $this->getConnectionPort($targetServer),
+                $snapshot->database_name,
             );
 
             $this->prepareDatabase($database, $restore->schema_name, $job);

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "php": "^8.4",
         "ext-ftp": "*",
         "ext-pdo": "*",
+        "ext-mongodb": "*",
         "blade-ui-kit/blade-icons": "^1.8",
         "codeat3/blade-devicons": "^1.8",
         "dedoc/scramble": "^0.13.8",
@@ -31,6 +32,7 @@
         "league/flysystem-sftp-v3": "^3.31",
         "livewire/livewire": "^4.0",
         "lorisleiva/cron-translator": "^0.5.0",
+        "mongodb/mongodb": "^2.2",
         "owenvoke/blade-fontawesome": "^2.7",
         "robsontenorio/mary": "^2.4",
         "spatie/laravel-query-builder": "^6.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6aedb2f419c4d836553d838bb1b6528a",
+    "content-hash": "bd47588e3a7a4059a798cd6626458dfb",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3954,6 +3954,83 @@
                 }
             ],
             "time": "2026-02-06T08:35:37+00:00"
+        },
+        {
+            "name": "mongodb/mongodb",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mongodb/mongo-php-library.git",
+                "reference": "bbb13f969e37e047fd822527543df55fdc1c9298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/bbb13f969e37e047fd822527543df55fdc1c9298",
+                "reference": "bbb13f969e37e047fd822527543df55fdc1c9298",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "ext-mongodb": "^2.2",
+                "php": "^8.1",
+                "psr/log": "^1.1.4|^2|^3",
+                "symfony/polyfill-php85": "^1.32"
+            },
+            "replace": {
+                "mongodb/builder": "*"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0",
+                "phpunit/phpunit": "^10.5.35",
+                "rector/rector": "^2.3.4",
+                "squizlabs/php_codesniffer": "^3.7",
+                "vimeo/psalm": "~6.14.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "MongoDB\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Braun",
+                    "email": "andreas.braun@mongodb.com"
+                },
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com"
+                },
+                {
+                    "name": "Jérôme Tamarelle",
+                    "email": "jerome.tamarelle@mongodb.com"
+                }
+            ],
+            "description": "MongoDB driver library",
+            "homepage": "https://jira.mongodb.org/browse/PHPLIB",
+            "keywords": [
+                "database",
+                "driver",
+                "mongodb",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/mongodb/mongo-php-library/issues",
+                "source": "https://github.com/mongodb/mongo-php-library/tree/2.2.0"
+            },
+            "time": "2026-02-11T11:39:56+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/config/testing.php
+++ b/config/testing.php
@@ -36,5 +36,14 @@ return [
             'port' => env('TEST_REDIS_PORT', 6379),
             'password' => env('TEST_REDIS_PASSWORD', null),
         ],
+
+        'mongodb' => [
+            'host' => env('TEST_MONGODB_HOST', 'mongodb'),
+            'port' => env('TEST_MONGODB_PORT', 27017),
+            'username' => env('TEST_MONGODB_USERNAME', 'root'),
+            'password' => env('TEST_MONGODB_PASSWORD', 'root'),
+            'database' => env('TEST_MONGODB_DATABASE', 'databasement_test'),
+            'auth_source' => env('TEST_MONGODB_AUTH_SOURCE', 'admin'),
+        ],
     ],
 ];

--- a/database/factories/DatabaseServerFactory.php
+++ b/database/factories/DatabaseServerFactory.php
@@ -88,6 +88,23 @@ class DatabaseServerFactory extends Factory
     }
 
     /**
+     * Configure the factory for MongoDB database type.
+     */
+    public function mongodb(): static
+    {
+        return $this->state(fn () => [
+            'name' => fake()->company().' MongoDB Server',
+            'database_type' => 'mongodb',
+            'host' => fake()->randomElement(['localhost', '127.0.0.1']),
+            'port' => 27017,
+            'username' => 'root',
+            'password' => 'root',
+            'database_names' => ['app'],
+            'extra_config' => ['auth_source' => 'admin'],
+        ]);
+    }
+
+    /**
      * Configure the factory with SSH tunnel using password authentication.
      *
      * Note: Uses afterCreating() hook, so only works with create(), not make().

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -94,8 +94,20 @@ class DatabaseSeeder extends Seeder
             'backup_all_databases' => true,
         ]);
 
+        // MongoDB server (from docker-compose)
+        $mongodb = DatabaseServer::create([
+            'name' => 'Local MongoDB',
+            'host' => 'mongodb',
+            'port' => 27017,
+            'database_type' => 'mongodb',
+            'username' => 'root',
+            'password' => 'root',
+            'backup_all_databases' => true,
+            'extra_config' => ['auth_source' => 'admin'],
+        ]);
+
         // Backup configurations
-        foreach ([$mysql, $postgres, $sqlite, $redis] as $server) {
+        foreach ([$mysql, $postgres, $sqlite, $redis, $mongodb] as $server) {
             Backup::create([
                 'database_server_id' => $server->id,
                 'volume_id' => $volume->id,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,22 @@ services:
       timeout: 5s
       retries: 5
 
+  mongodb:
+    image: mongo:8
+    container_name: databasement-mongodb
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb-data:/data/db
+    healthcheck:
+      test: [ "CMD", "mongosh", "--eval", "db.adminCommand('ping')", "--quiet" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   redis:
     image: redis:7
     container_name: databasement-redis
@@ -168,5 +184,6 @@ volumes:
   postgres-data:
   rustfs-data:
   sftp-data:
+  mongodb-data:
   redis-data:
   ftp-data:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -21,7 +21,8 @@ RUN install-php-extensions \
     opcache \
     pcov \
     ftp \
-    sockets
+    sockets \
+    mongodb
 
 COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 
@@ -38,6 +39,9 @@ RUN apk add --no-cache git \
         openssh-client \
         sshpass \
         redis
+
+# Install MongoDB tools (mongodump, mongorestore) from Alpine edge community repo
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community mongodb-tools
 
 COPY supervisord.conf /config/supervisord.conf
 COPY php-custom-production.ini /usr/local/etc/php/php-custom-production.ini

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -127,9 +127,9 @@ use App\Enums\DatabaseType;
                             <x-input
                                 wire:model="form.username"
                                 label="{{ __('Username') }}"
-                                placeholder="{{ $form->isRedis() ? __('Optional (for ACL-enabled servers)') : __('Database username') }}"
+                                placeholder="{{ $form->hasOptionalCredentials() ? __('Optional (for authenticated servers)') : __('Database username') }}"
                                 type="text"
-                                :required="!$form->isRedis()"
+                                :required="!$form->hasOptionalCredentials()"
                                 autocomplete="off"
                             />
 
@@ -137,10 +137,20 @@ use App\Enums\DatabaseType;
                                 wire:model="form.password"
                                 label="{{ __('Password') }}"
                                 placeholder="{{ $isEdit ? __('Leave blank to keep current') : __('Database password') }}"
-                                :required="!$isEdit && !$form->isRedis()"
+                                :required="!$isEdit && !$form->hasOptionalCredentials()"
                                 autocomplete="off"
                             />
                         </div>
+
+                        @if($form->isMongodb())
+                            <x-input
+                                wire:model="form.auth_source"
+                                label="{{ __('Authentication Database') }}"
+                                placeholder="admin"
+                                hint="{{ __('The database used to authenticate credentials (defaults to admin)') }}"
+                                type="text"
+                            />
+                        @endif
                     @endif
 
                     <!-- Test Connection Button -->

--- a/tests/Feature/Services/Backup/Databases/MongodbDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MongodbDatabaseTest.php
@@ -1,0 +1,164 @@
+<?php
+
+use App\Services\Backup\Databases\DTO\DatabaseOperationResult;
+use App\Services\Backup\Databases\MongodbDatabase;
+use MongoDB\Driver\Exception\ConnectionTimeoutException;
+
+beforeEach(function () {
+    $this->db = new MongodbDatabase;
+    $this->db->setConfig([
+        'host' => 'mongo.example.com',
+        'port' => 27017,
+        'user' => '',
+        'pass' => '',
+        'database' => 'mydb',
+        'auth_source' => 'admin',
+    ]);
+});
+
+function mockMongodbWithManager(object $manager): MongodbDatabase
+{
+    $db = Mockery::mock(MongodbDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldReceive('createManager')->andReturn($manager);
+    $db->setConfig([
+        'host' => 'mongo.example.com',
+        'port' => 27017,
+        'user' => 'root',
+        'pass' => 'secret',
+        'database' => 'mydb',
+        'auth_source' => 'admin',
+    ]);
+
+    return $db;
+}
+
+function fakeCursor(object $response): object
+{
+    return new class($response)
+    {
+        public function __construct(private readonly object $response) {}
+
+        /** @return array<object> */
+        public function toArray(): array
+        {
+            return [$this->response];
+        }
+    };
+}
+
+test('dump produces mongodump archive command', function () {
+    $result = $this->db->dump('/tmp/dump.archive');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe("mongodump --host='mongo.example.com' --port='27017' --db='mydb' --archive='/tmp/dump.archive'");
+});
+
+test('dump includes auth flags when credentials provided', function () {
+    $this->db->setConfig([
+        'host' => 'mongo.example.com',
+        'port' => 27017,
+        'user' => 'admin',
+        'pass' => 'secret',
+        'database' => 'mydb',
+        'auth_source' => 'admin',
+    ]);
+
+    $result = $this->db->dump('/tmp/dump.archive');
+
+    expect($result->command)->toBe("mongodump --host='mongo.example.com' --port='27017' --username='admin' --password='secret' --authenticationDatabase='admin' --db='mydb' --archive='/tmp/dump.archive'");
+});
+
+test('dump uses custom auth_source', function () {
+    $this->db->setConfig([
+        'host' => 'mongo.example.com',
+        'port' => 27017,
+        'user' => 'appuser',
+        'pass' => 'secret',
+        'database' => 'mydb',
+        'auth_source' => 'myAuthDb',
+    ]);
+
+    $result = $this->db->dump('/tmp/dump.archive');
+
+    expect($result->command)->toContain("--authenticationDatabase='myAuthDb'");
+});
+
+test('restore produces mongorestore command with namespace mapping', function () {
+    $this->db->setConfig([
+        'host' => 'mongo.example.com',
+        'port' => 27017,
+        'user' => 'admin',
+        'pass' => 'secret',
+        'database' => 'targetdb',
+        'auth_source' => 'admin',
+        'source_database' => 'sourcedb',
+    ]);
+
+    $result = $this->db->restore('/tmp/dump.archive');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe("mongorestore --host='mongo.example.com' --port='27017' --username='admin' --password='secret' --authenticationDatabase='admin' --archive='/tmp/dump.archive' --nsFrom='sourcedb.*' --nsTo='targetdb.*' --drop");
+});
+
+test('restore uses same database for nsFrom when source_database not set', function () {
+    $result = $this->db->restore('/tmp/dump.archive');
+
+    expect($result->command)->toContain("--nsFrom='mydb.*'")
+        ->and($result->command)->toContain("--nsTo='mydb.*'");
+});
+
+test('prepareForRestore is a no-op', function () {
+    $job = Mockery::mock(\App\Models\BackupJob::class);
+
+    expect(fn () => $this->db->prepareForRestore('mydb', $job))->not->toThrow(Exception::class);
+});
+
+test('listDatabases returns databases excluding system databases', function () {
+    $manager = Mockery::mock();
+    $manager->shouldReceive('executeCommand')
+        ->once()
+        ->withArgs(fn (string $db) => $db === 'admin')
+        ->andReturn(fakeCursor((object) [
+            'databases' => [
+                (object) ['name' => 'admin'],
+                (object) ['name' => 'local'],
+                (object) ['name' => 'config'],
+                (object) ['name' => 'app_db'],
+                (object) ['name' => 'analytics'],
+            ],
+        ]));
+
+    $db = mockMongodbWithManager($manager);
+
+    expect($db->listDatabases())->toBe(['app_db', 'analytics']);
+});
+
+test('testConnection returns success with version info', function () {
+    $manager = Mockery::mock();
+    $manager->shouldReceive('executeCommand')
+        ->twice()
+        ->andReturn(
+            fakeCursor((object) ['ok' => 1]),
+            fakeCursor((object) ['version' => '8.0.4']),
+        );
+
+    $db = mockMongodbWithManager($manager);
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['message'])->toBe('Connection successful')
+        ->and($result['details'])->toHaveKey('ping_ms')
+        ->and($result['details']['output'])->toContain('MongoDB 8.0.4');
+});
+
+test('testConnection returns failure on connection error', function () {
+    $manager = Mockery::mock();
+    $manager->shouldReceive('executeCommand')
+        ->andThrow(new ConnectionTimeoutException('No suitable servers found'));
+
+    $db = mockMongodbWithManager($manager);
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('No suitable servers found');
+});

--- a/tests/Feature/Services/Backup/RestoreTaskTest.php
+++ b/tests/Feature/Services/Backup/RestoreTaskTest.php
@@ -284,7 +284,8 @@ test('run establishes SSH tunnel when target server requires it', function () {
             Mockery::on(fn ($server) => $server->id === $targetServer->id),
             'restored_db',
             '127.0.0.1',
-            54321
+            54321,
+            'sourcedb',
         )
         ->andReturn($mockHandler);
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -124,7 +124,7 @@ function createDatabaseServer(array $attributes = []): \App\Models\DatabaseServe
 |
 */
 
-dataset('database types', ['mysql', 'postgres', 'sqlite', 'redis']);
+dataset('database types', ['mysql', 'postgres', 'sqlite', 'redis', 'mongodb']);
 
 dataset('database server configs', [
     'mysql' => [[
@@ -149,6 +149,12 @@ dataset('database server configs', [
         'name' => 'Redis Server',
         'host' => 'redis.example.com',
         'port' => 6379,
+    ]],
+    'mongodb' => [[
+        'type' => 'mongodb',
+        'name' => 'MongoDB Server',
+        'host' => 'mongodb.example.com',
+        'port' => 27017,
     ]],
 ]);
 


### PR DESCRIPTION
## Summary

Add MongoDB as a new database type for backup and restore operations.

## Changes

- Add `MONGODB` enum case and `MongodbDatabase` handler implementing `DatabaseInterface`
- Use `mongodump`/`mongorestore` CLI tools with `--archive` format and `--nsFrom`/`--nsTo` namespace remapping for cross-database restore
- Use PHP `mongodb` extension for connection testing and database listing
- Store `auth_source` in `extra_config` JSON column (defaults to `admin`)
- Add MongoDB 8 service to Docker Compose and CI workflow
- Install `mongodb-tools` and `mongodb/mongodb` composer package
- Add unit tests, integration backup/restore tests, and MongoDB test helpers

## Test plan

- [x] 562 tests passing (including MongoDB integration backup/restore)
- [x] PHPStan clean (0 errors)
- [x] Pint clean
- [ ] Verify MongoDB backup/restore via UI at localhost:2226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MongoDB database server support with backup, restore, and connection testing capabilities.
  * MongoDB authentication database configuration for non-standard authentication scenarios.

* **Tests**
  * Added comprehensive test coverage for MongoDB backup and restore workflows.

* **Chores**
  * Integrated MongoDB service into CI/CD pipeline and local Docker environment.
  * Installed MongoDB PHP driver and command-line tools for backup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->