### PR TITLE
Issues #122

### DIFF
--- a/docs/docs/self-hosting/configuration/notification.md
+++ b/docs/docs/self-hosting/configuration/notification.md
@@ -48,7 +48,7 @@ MAIL_FROM_NAME="Databasement"
 
 ---
 
-### No encryption (port 25)
+### Unencrypted SMTP / no forced encryption (port 25)
 
 ```bash
 MAIL_MAILER=smtp
@@ -83,6 +83,8 @@ Or with implicit TLS:
 MAIL_MAILER=smtp
 MAIL_URL=smtps://user:pass@smtp.example.com:465
 ```
+
+> **Note:** If your username or password contains special URI characters (e.g. `@`, `:`, `+`, `#`), percent-encode them in the DSN (e.g. `@` → `%40`).
 
 When `MAIL_URL` is defined, it overrides `MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`, and `MAIL_SCHEME`.
 


### PR DESCRIPTION
Implement encryption in mail.
Update documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded email configuration docs with explicit SMTP (STARTTLS on port 587), SMTPS (implicit TLS on port 465), and unencrypted (port 25) examples.
  * Added DSN-based configuration samples (MAIL_URL) and noted percent-encoding for special characters.
  * Clarified that DSN/scheme controls encryption behavior and overrides host/port/credentials; removed deprecated MAIL_ENCRYPTION guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->