### PR TITLE
fix: cascade Volume deletion through Eloquent and add keep-files option

### DIFF
--- a/app/Livewire/BackupJob/Index.php
+++ b/app/Livewire/BackupJob/Index.php
@@ -50,6 +50,8 @@ class Index extends Component
 
     public bool $showDeleteModal = false;
 
+    public bool $keepFiles = false;
+
     public function mount(): void
     {
         // If a job ID is in the URL, validate and authorize before opening modal
@@ -253,6 +255,7 @@ class Index extends Component
         $this->authorize('delete', $snapshot);
 
         $this->deleteSnapshotId = $snapshotId;
+        $this->keepFiles = false;
         $this->showDeleteModal = true;
     }
 
@@ -266,6 +269,7 @@ class Index extends Component
 
         $this->authorize('delete', $snapshot);
 
+        $snapshot->skipFileCleanup = $this->keepFiles;
         $snapshot->delete();
         $this->deleteSnapshotId = null;
         $this->showDeleteModal = false;

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -38,6 +38,8 @@ class Index extends Component
 
     public int $deleteSnapshotCount = 0;
 
+    public bool $keepFiles = false;
+
     public function updatingSearch(): void
     {
         $this->resetPage();
@@ -81,6 +83,7 @@ class Index extends Component
 
         $this->deleteId = $id;
         $this->deleteSnapshotCount = $server->snapshots()->count();
+        $this->keepFiles = false;
         $this->showDeleteModal = true;
     }
 
@@ -94,6 +97,7 @@ class Index extends Component
 
         $this->authorize('delete', $server);
 
+        $server->skipFileCleanup = $this->keepFiles;
         $server->delete();
         $this->deleteId = null;
         $this->showDeleteModal = false;

--- a/app/Livewire/Volume/Index.php
+++ b/app/Livewire/Volume/Index.php
@@ -31,6 +31,8 @@ class Index extends Component
 
     public int $deleteSnapshotCount = 0;
 
+    public bool $keepFiles = false;
+
     public function updatingSearch(): void
     {
         $this->resetPage();
@@ -74,6 +76,7 @@ class Index extends Component
 
         $this->deleteId = $id;
         $this->deleteSnapshotCount = $volume->snapshots()->count();
+        $this->keepFiles = false;
         $this->showDeleteModal = true;
     }
 
@@ -87,6 +90,7 @@ class Index extends Component
 
         $this->authorize('delete', $volume);
 
+        $volume->skipFileCleanup = $this->keepFiles;
         $volume->delete();
         $this->deleteId = null;
         $this->showDeleteModal = false;

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -64,12 +64,15 @@ class DatabaseServer extends Model
 
     use HasUlids;
 
+    public bool $skipFileCleanup = false;
+
     protected static function booted(): void
     {
         // Delete snapshots through Eloquent to trigger their deleting events
-        // (which clean up associated BackupJobs and Restores)
+        // (which clean up associated BackupJobs, Restores, and backup files)
         static::deleting(function (DatabaseServer $server) {
             foreach ($server->snapshots as $snapshot) {
+                $snapshot->skipFileCleanup = $server->skipFileCleanup;
                 $snapshot->delete();
             }
         });

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -76,6 +76,8 @@ class Snapshot extends Model
 
     use HasUlids;
 
+    public bool $skipFileCleanup = false;
+
     protected $fillable = [
         'backup_job_id',
         'database_server_id',
@@ -175,7 +177,9 @@ class Snapshot extends Model
     {
         // Delete the backup file, associated restores and job when snapshot is deleted
         static::deleting(function (Snapshot $snapshot) {
-            $snapshot->deleteBackupFile();
+            if (! $snapshot->skipFileCleanup) {
+                $snapshot->deleteBackupFile();
+            }
 
             // Delete restores first (this triggers their booted method to delete their jobs)
             foreach ($snapshot->restores as $restore) {

--- a/app/Models/Volume.php
+++ b/app/Models/Volume.php
@@ -45,6 +45,20 @@ class Volume extends Model
 
     use HasUlids;
 
+    public bool $skipFileCleanup = false;
+
+    protected static function booted(): void
+    {
+        // Delete snapshots through Eloquent to trigger their deleting events
+        // (which clean up associated BackupJobs, Restores, and backup files)
+        static::deleting(function (Volume $volume) {
+            foreach ($volume->snapshots as $snapshot) {
+                $snapshot->skipFileCleanup = $volume->skipFileCleanup;
+                $snapshot->delete();
+            }
+        });
+    }
+
     protected $fillable = [
         'name',
         'type',

--- a/lang/es.json
+++ b/lang/es.json
@@ -278,6 +278,7 @@
     "Job not found: ": "Trabajo no encontrado: ",
     "Jobs": "Trabajos",
     "Jobs Activity": "Actividad de los trabajos",
+    "Keep backup files on storage (only delete database records)": "Conservar los archivos de backup en el almacenamiento (solo eliminar los registros de la base de datos)",
     "Jobs Status": "Estado de los trabajos",
     "Job Timeout": "Tiempo de espera del trabajo",
     "Job Tries": "Intentos de trabajo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -278,6 +278,7 @@
     "Job not found: ": "Tâche introuvable : ",
     "Jobs": "Tâches",
     "Jobs Activity": "Activité des tâches",
+    "Keep backup files on storage (only delete database records)": "Conserver les fichiers de backup sur le stockage (supprimer uniquement les enregistrements de la base de données)",
     "Jobs Status": "État des tâches",
     "Job Timeout": "Délai d’expiration des tâches",
     "Job Tries": "Nombre de tentatives",

--- a/resources/views/components/delete-confirmation-modal.blade.php
+++ b/resources/views/components/delete-confirmation-modal.blade.php
@@ -1,10 +1,25 @@
-@props(['title', 'message', 'onConfirm', 'onCancel'])
+@props(['title', 'message', 'onConfirm', 'showKeepFiles' => false, 'snapshotCount' => 0])
 
-<x-modal wire:model="showDeleteModal" title="{{ $title }}" class="backdrop-blur">
+<x-modal wire:model="showDeleteModal" :title="$title" class="backdrop-blur">
     <p>{{ $message }}</p>
 
+    @if($snapshotCount > 0)
+        <x-alert icon="o-exclamation-triangle" class="alert-warning mt-4">
+            {{ trans_choice(':count snapshot will also be deleted.|:count snapshots will also be deleted.', $snapshotCount, ['count' => $snapshotCount]) }}
+        </x-alert>
+    @endif
+
+    @if($showKeepFiles)
+        <label class="flex items-start gap-3 mt-4 cursor-pointer">
+            <input type="checkbox" wire:model="keepFiles" class="checkbox checkbox-sm mt-0.5" />
+            <span class="text-sm">{{ __('Keep backup files on storage (only delete database records)') }}</span>
+        </label>
+    @endif
+
+    {{ $slot }}
+
     <x-slot:actions>
-        <x-button label="{{ __('Cancel') }}" @click="$wire.showDeleteModal = false" />
-        <x-button label="{{ __('Delete') }}" class="btn-error" wire:click="{{ $onConfirm }}" />
+        <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
+        <x-button :label="__('Delete')" class="btn-error" wire:click="{{ $onConfirm }}" />
     </x-slot:actions>
 </x-modal>

--- a/resources/views/livewire/backup-job/index.blade.php
+++ b/resources/views/livewire/backup-job/index.blade.php
@@ -170,13 +170,10 @@
     @include('livewire.backup-job._logs-modal')
 
     <!-- DELETE CONFIRMATION MODAL -->
-    <x-modal wire:model="showDeleteModal" title="{{ __('Delete Snapshot') }}" separator>
-        <div class="py-4">
-            {{ __('Are you sure you want to delete this snapshot? The backup file will be permanently removed.') }}
-        </div>
-        <x-slot:actions>
-            <x-button label="{{ __('Cancel') }}" @click="$wire.showDeleteModal = false" />
-            <x-button label="{{ __('Delete') }}" class="btn-error" wire:click="deleteSnapshot" spinner />
-        </x-slot:actions>
-    </x-modal>
+    <x-delete-confirmation-modal
+        :title="__('Delete Snapshot')"
+        :message="__('Are you sure you want to delete this snapshot? The backup file will be permanently removed.')"
+        onConfirm="deleteSnapshot"
+        :showKeepFiles="true"
+    />
 </div>

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -213,20 +213,13 @@
     </x-card>
 
     <!-- DELETE CONFIRMATION MODAL -->
-    <x-modal wire:model="showDeleteModal" :title="__('Delete Database Server')" class="backdrop-blur">
-        <p>{{ __('Are you sure you want to delete this database server? This action cannot be undone.') }}</p>
-
-        @if($deleteSnapshotCount > 0)
-            <x-alert icon="o-exclamation-triangle" class="alert-warning mt-4">
-                {{ trans_choice(':count snapshot will also be deleted.|:count snapshots will also be deleted.', $deleteSnapshotCount, ['count' => $deleteSnapshotCount]) }}
-            </x-alert>
-        @endif
-
-        <x-slot:actions>
-            <x-button label="{{ __('Cancel') }}" @click="$wire.showDeleteModal = false" />
-            <x-button label="{{ __('Delete') }}" class="btn-error" wire:click="delete" />
-        </x-slot:actions>
-    </x-modal>
+    <x-delete-confirmation-modal
+        :title="__('Delete Database Server')"
+        :message="__('Are you sure you want to delete this database server? This action cannot be undone.')"
+        onConfirm="delete"
+        :showKeepFiles="$deleteSnapshotCount > 0"
+        :snapshotCount="$deleteSnapshotCount"
+    />
 
     <!-- RESTORE MODAL -->
     <livewire:database-server.restore-modal />

--- a/resources/views/livewire/volume/index.blade.php
+++ b/resources/views/livewire/volume/index.blade.php
@@ -102,18 +102,11 @@
     </x-card>
 
     <!-- DELETE CONFIRMATION MODAL -->
-    <x-modal wire:model="showDeleteModal" :title="__('Delete Volume')" class="backdrop-blur">
-        <p>{{ __('Are you sure you want to delete this volume? This action cannot be undone.') }}</p>
-
-        @if($deleteSnapshotCount > 0)
-            <x-alert icon="o-exclamation-triangle" class="alert-warning mt-4">
-                {{ trans_choice(':count snapshot will also be deleted.|:count snapshots will also be deleted.', $deleteSnapshotCount, ['count' => $deleteSnapshotCount]) }}
-            </x-alert>
-        @endif
-
-        <x-slot:actions>
-            <x-button label="{{ __('Cancel') }}" @click="$wire.showDeleteModal = false" />
-            <x-button label="{{ __('Delete') }}" class="btn-error" wire:click="delete" />
-        </x-slot:actions>
-    </x-modal>
+    <x-delete-confirmation-modal
+        :title="__('Delete Volume')"
+        :message="__('Are you sure you want to delete this volume? This action cannot be undone.')"
+        onConfirm="delete"
+        :showKeepFiles="$deleteSnapshotCount > 0"
+        :snapshotCount="$deleteSnapshotCount"
+    />
 </div>


### PR DESCRIPTION
## Summary

- **Bug fix**: Volume deletion previously relied on DB-level `onDelete('cascade')` for snapshots, bypassing Eloquent's `Snapshot::deleting()` event. This left orphaned BackupJobs (showing "Type: Unknown" in the Jobs view) and didn't clean up backup files from storage. Added `booted()` deleting event to Volume model (same pattern as DatabaseServer).
- **Feature**: Added a "Keep backup files on storage" checkbox to delete confirmation modals for Volume, DatabaseServer, and Snapshot. Uses a transient `$skipFileCleanup` property that propagates through the cascade chain.
- **Refactor**: Consolidated three inline delete modals into a shared `<x-delete-confirmation-modal>` Blade component with `showKeepFiles` and `snapshotCount` props. Backward-compatible with existing User/Index usage.
- Added fr/es translations for the new checkbox label.

## Test plan

- [x] Volume cascade deletion test: delete volume → assert snapshot, BackupJob, Restore all deleted + file removed
- [x] Volume keepFiles test: delete with keepFiles=true → assert DB records deleted, file preserved
- [x] Existing snapshot cascade test (BackupJob/IndexTest) serves as regression for default behavior
- [x] PHPStan passes, 612 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to preserve backup files on storage when deleting records
  * Enhanced delete confirmation modal with snapshot count warning and "keep files" control

* **Documentation**
  * Added Spanish and French translations for the file-preservation option

* **Tests**
  * Added test coverage for cascade deletion and keep-files behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->