### PR TITLE
Fix: remove stale .7z archive before compression to prevent retry failures

### DIFF
--- a/app/Services/Backup/Compressors/BaseCompressor.php
+++ b/app/Services/Backup/Compressors/BaseCompressor.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Services\Backup\Compressors;
+
+use App\Services\Backup\ShellProcessor;
+
+abstract class BaseCompressor implements CompressorInterface
+{
+    public function __construct(
+        protected readonly ShellProcessor $shellProcessor,
+        private readonly int $level,
+        private readonly int $minLevel,
+        private readonly int $maxLevel
+    ) {}
+
+    public function compress(string $inputPath): string
+    {
+        $outputPath = $this->getCompressedPath($inputPath);
+
+        // Remove any leftover archive from a previous failed attempt.
+        // A corrupted file from a timed-out attempt can cause compressors to
+        // fail, hang indefinitely, or prompt for overwrite confirmation.
+        if (file_exists($outputPath) && ! unlink($outputPath)) {
+            throw new \RuntimeException("Failed to remove stale archive: {$outputPath}");
+        }
+
+        $this->shellProcessor->process($this->getCompressCommandLine($inputPath));
+
+        // Some compressors (gzip, zstd --rm) remove the original file automatically,
+        // but others (7z) do not. Clean up defensively to ensure consistent behavior.
+        if (file_exists($inputPath)) {
+            unlink($inputPath);
+        }
+
+        return $outputPath;
+    }
+
+    public function decompress(string $compressedFile): string
+    {
+        $this->shellProcessor->process($this->getDecompressCommandLine($compressedFile));
+
+        $decompressedFile = $this->getDecompressedPath($compressedFile);
+
+        if (! file_exists($decompressedFile)) {
+            throw new \RuntimeException('Decompression failed: output file not found');
+        }
+
+        return $decompressedFile;
+    }
+
+    public function getCompressedPath(string $inputPath): string
+    {
+        return $inputPath.'.'.$this->getExtension();
+    }
+
+    public function getDecompressedPath(string $inputPath): string
+    {
+        return preg_replace('/\.'.preg_quote($this->getExtension(), '/').'$/', '', $inputPath);
+    }
+
+    protected function getLevel(): int
+    {
+        return max($this->minLevel, min($this->maxLevel, $this->level));
+    }
+}

--- a/app/Services/Backup/Compressors/EncryptedCompressor.php
+++ b/app/Services/Backup/Compressors/EncryptedCompressor.php
@@ -8,37 +8,14 @@ use App\Services\Backup\ShellProcessor;
 /**
  * Compressor for AES-256 encrypted backups using 7-Zip.
  */
-class EncryptedCompressor implements CompressorInterface
+class EncryptedCompressor extends BaseCompressor
 {
-    private const MIN_LEVEL = 1;
-
-    private const MAX_LEVEL = 9;
-
     public function __construct(
-        private readonly ShellProcessor $shellProcessor,
-        private readonly int $level,
+        ShellProcessor $shellProcessor,
+        int $level,
         private readonly ?string $password = null
-    ) {}
-
-    public function compress(string $inputPath): string
-    {
-        $outputPath = $this->getCompressedPath($inputPath);
-
-        // Remove any leftover archive from a previous failed attempt.
-        // If 7z finds an existing .7z file, it tries to open and append to it.
-        // A corrupted file from a timed-out attempt causes 7z to fail or hang indefinitely.
-        if (file_exists($outputPath)) {
-            unlink($outputPath);
-        }
-
-        $this->shellProcessor->process($this->getCompressCommandLine($inputPath));
-
-        // 7z doesn't remove the original file, so we do it manually
-        if (file_exists($inputPath)) {
-            unlink($inputPath);
-        }
-
-        return $outputPath;
+    ) {
+        parent::__construct($shellProcessor, $level, minLevel: 1, maxLevel: 9);
     }
 
     public function decompress(string $compressedFile): string
@@ -57,12 +34,11 @@ class EncryptedCompressor implements CompressorInterface
 
     public function getCompressCommandLine(string $inputPath): string
     {
-        $level = $this->getLevel();
         $outputPath = $this->getCompressedPath($inputPath);
 
         // 7z a -t7z -mx={level} -mhe=on -p{password} output.7z input
         // -mhe=on encrypts headers (file names)
-        $command = sprintf('7z a -t7z -mx=%d -mhe=on', $level);
+        $command = sprintf('7z a -t7z -mx=%d -mhe=on', $this->getLevel());
 
         if ($this->password !== null) {
             $command .= sprintf(' -p%s', escapeshellarg($this->password));
@@ -90,11 +66,6 @@ class EncryptedCompressor implements CompressorInterface
         return $command;
     }
 
-    public function getCompressedPath(string $inputPath): string
-    {
-        return $inputPath.'.'.$this->getExtension();
-    }
-
     public function getDecompressedPath(string $inputPath): string
     {
         $targets = ['dump.sql', 'dump.db'];
@@ -108,10 +79,5 @@ class EncryptedCompressor implements CompressorInterface
         }
 
         throw new \RuntimeException('Decompression failed: output file not found');
-    }
-
-    private function getLevel(): int
-    {
-        return max(self::MIN_LEVEL, min(self::MAX_LEVEL, $this->level));
     }
 }

--- a/app/Services/Backup/Compressors/GzipCompressor.php
+++ b/app/Services/Backup/Compressors/GzipCompressor.php
@@ -5,36 +5,11 @@ namespace App\Services\Backup\Compressors;
 use App\Enums\CompressionType;
 use App\Services\Backup\ShellProcessor;
 
-class GzipCompressor implements CompressorInterface
+class GzipCompressor extends BaseCompressor
 {
-    private const MIN_LEVEL = 1;
-
-    private const MAX_LEVEL = 9;
-
-    public function __construct(
-        private readonly ShellProcessor $shellProcessor,
-        private readonly int $level
-    ) {}
-
-    public function compress(string $inputPath): string
+    public function __construct(ShellProcessor $shellProcessor, int $level)
     {
-        $this->shellProcessor->process($this->getCompressCommandLine($inputPath));
-
-        return $this->getCompressedPath($inputPath);
-    }
-
-    public function decompress(string $compressedFile): string
-    {
-        $this->shellProcessor->process($this->getDecompressCommandLine($compressedFile));
-
-        // gzip -d removes .gz suffix from the file
-        $decompressedFile = $this->getDecompressedPath($compressedFile);
-
-        if (! file_exists($decompressedFile)) {
-            throw new \RuntimeException('Decompression failed: output file not found');
-        }
-
-        return $decompressedFile;
+        parent::__construct($shellProcessor, $level, minLevel: 1, maxLevel: 9);
     }
 
     public function getExtension(): string
@@ -44,28 +19,11 @@ class GzipCompressor implements CompressorInterface
 
     public function getCompressCommandLine(string $inputPath): string
     {
-        $level = $this->getLevel();
-
-        return sprintf('gzip -%d %s', $level, escapeshellarg($inputPath));
+        return sprintf('gzip -%d %s', $this->getLevel(), escapeshellarg($inputPath));
     }
 
     public function getDecompressCommandLine(string $outputPath): string
     {
         return 'gzip -d '.escapeshellarg($outputPath);
-    }
-
-    public function getCompressedPath(string $inputPath): string
-    {
-        return $inputPath.'.'.$this->getExtension();
-    }
-
-    public function getDecompressedPath(string $inputPath): string
-    {
-        return preg_replace('/\.'.preg_quote($this->getExtension(), '/').'$/', '', $inputPath);
-    }
-
-    private function getLevel(): int
-    {
-        return max(self::MIN_LEVEL, min(self::MAX_LEVEL, $this->level));
     }
 }

--- a/app/Services/Backup/Compressors/ZstdCompressor.php
+++ b/app/Services/Backup/Compressors/ZstdCompressor.php
@@ -5,35 +5,11 @@ namespace App\Services\Backup\Compressors;
 use App\Enums\CompressionType;
 use App\Services\Backup\ShellProcessor;
 
-class ZstdCompressor implements CompressorInterface
+class ZstdCompressor extends BaseCompressor
 {
-    private const MIN_LEVEL = 1;
-
-    private const MAX_LEVEL = 19;
-
-    public function __construct(
-        private readonly ShellProcessor $shellProcessor,
-        private readonly int $level
-    ) {}
-
-    public function compress(string $inputPath): string
+    public function __construct(ShellProcessor $shellProcessor, int $level)
     {
-        $this->shellProcessor->process($this->getCompressCommandLine($inputPath));
-
-        return $this->getCompressedPath($inputPath);
-    }
-
-    public function decompress(string $compressedFile): string
-    {
-        $this->shellProcessor->process($this->getDecompressCommandLine($compressedFile));
-
-        $decompressedFile = $this->getDecompressedPath($compressedFile);
-
-        if (! file_exists($decompressedFile)) {
-            throw new \RuntimeException('Decompression failed: output file not found');
-        }
-
-        return $decompressedFile;
+        parent::__construct($shellProcessor, $level, minLevel: 1, maxLevel: 19);
     }
 
     public function getExtension(): string
@@ -43,30 +19,13 @@ class ZstdCompressor implements CompressorInterface
 
     public function getCompressCommandLine(string $inputPath): string
     {
-        $level = $this->getLevel();
-
         // --rm removes the original file after compression (like gzip does by default)
-        return sprintf('zstd -%d --rm %s', $level, escapeshellarg($inputPath));
+        return sprintf('zstd -%d --rm %s', $this->getLevel(), escapeshellarg($inputPath));
     }
 
     public function getDecompressCommandLine(string $outputPath): string
     {
         // -d decompress, --rm removes the compressed file after decompression
         return sprintf('zstd -d --rm %s', escapeshellarg($outputPath));
-    }
-
-    public function getCompressedPath(string $inputPath): string
-    {
-        return $inputPath.'.'.$this->getExtension();
-    }
-
-    public function getDecompressedPath(string $inputPath): string
-    {
-        return preg_replace('/\.'.preg_quote($this->getExtension(), '/').'$/', '', $inputPath);
-    }
-
-    private function getLevel(): int
-    {
-        return max(self::MIN_LEVEL, min(self::MAX_LEVEL, $this->level));
     }
 }

--- a/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
+++ b/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
@@ -47,3 +47,20 @@ test('encrypted compressor executes compress and returns correct path', function
 
     unlink($compressedPath);
 });
+
+test('encrypted compressor removes stale archive before compressing', function () {
+    $testFile = '/tmp/test_stale_dump.sql';
+    $stalePath = $testFile.'.7z';
+
+    file_put_contents($testFile, 'test data');
+    file_put_contents($stalePath, 'corrupted archive');
+
+    $factory = new CompressorFactory($this->shellProcessor);
+    $compressor = $factory->make(CompressionType::ENCRYPTED);
+    $compressedPath = $compressor->compress($testFile);
+
+    // The stale content should have been replaced by a valid 7z archive
+    expect(file_get_contents($compressedPath))->not->toBe('corrupted archive');
+
+    unlink($compressedPath);
+});


### PR DESCRIPTION
## Summary

- Deletes any pre-existing `.7z` output file before running 7z compression
- Prevents cascading failures when a backup job times out mid-compression and is retried

## Context

Relates to #146

When a backup job times out during 7z archive creation (e.g., for very large databases), a partial/corrupted `.7z` file is left behind. On retry, `7z a` detects this file and tries to **open and append to it** instead of creating a fresh archive. This causes:

1. **Retry 1-2**: Immediate failure — `Cannot open the file as [7z] archive` / `Is not archive`
2. **Retry 3**: 7z hangs indefinitely trying to read/decrypt corrupted encrypted headers (`-mhe=on`)

The fix ensures any leftover `.7z` file is removed before compression starts, so retries always begin with a clean slate.

> **Note**: This fix addresses the retry failure/hang. Users with very large databases may also need to increase the backup job timeout (default: 2 hours) via Settings > Configuration.

## Test plan

- [x] Existing `EncryptedCompressor` tests pass (5 tests, 9 assertions)
- [x] Full test suite passes (710 tests)
- [x] PHPStan clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by removing stale archives before compression and ensuring leftover files are cleaned up.
  * More consistent compression/decompression results and error handling.

* **New Features**
  * Standardized compression workflow across formats for predictable behavior.

* **Tests**
  * Added test verifying stale-archive removal before creating new backups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->