### PR TITLE
Fix: respect backups_enabled flag in schedule runs and UI

### DIFF
--- a/app/Livewire/Configuration/Index.php
+++ b/app/Livewire/Configuration/Index.php
@@ -11,6 +11,7 @@ use App\Models\Snapshot;
 use App\Services\Backup\TriggerBackupAction;
 use App\Services\FailureNotificationService;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Validation\Rule;
@@ -292,12 +293,17 @@ class Index extends Component
     {
         abort_unless(auth()->user()->isAdmin(), Response::HTTP_FORBIDDEN);
 
-        $schedule = BackupSchedule::with('backups.databaseServer.backup.volume')->findOrFail($scheduleId);
+        $schedule = BackupSchedule::findOrFail($scheduleId);
+
+        $backups = $schedule->backups()
+            ->whereRelation('databaseServer', 'backups_enabled', true)
+            ->with('databaseServer.backup.volume')
+            ->get();
 
         $totalSnapshots = 0;
         $errors = [];
 
-        foreach ($schedule->backups as $backup) {
+        foreach ($backups as $backup) {
             try {
                 $userId = auth()->id();
                 $result = $action->execute($backup->databaseServer, is_int($userId) ? $userId : null);
@@ -320,13 +326,20 @@ class Index extends Component
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Collection<int, BackupSchedule>
+     * @return Collection<int, BackupSchedule>
      */
     #[Computed]
-    public function backupSchedules(): \Illuminate\Database\Eloquent\Collection
+    public function backupSchedules(): Collection
     {
-        return BackupSchedule::withCount('backups')
-            ->with('backups.databaseServer:id,name')
+        return BackupSchedule::withCount([
+            'backups as backups_count' => function ($query) {
+                $query->whereRelation('databaseServer', 'backups_enabled', true);
+            },
+            'backups as total_backups_count',
+        ])
+            ->with(['backups' => function ($query) {
+                $query->whereRelation('databaseServer', 'backups_enabled', true);
+            }, 'backups.databaseServer:id,name'])
             ->orderBy('name')
             ->get();
     }

--- a/resources/views/livewire/configuration/index.blade.php
+++ b/resources/views/livewire/configuration/index.blade.php
@@ -82,7 +82,7 @@
                                         <x-button icon="o-play" class="btn-ghost btn-sm" wire:click="runSchedule('{{ $schedule->id }}')" spinner="runSchedule('{{ $schedule->id }}')" tooltip-left="{{ __('Run now') }}" />
                                     @endif
                                     <x-button icon="o-pencil-square" class="btn-ghost btn-sm" wire:click="openScheduleModal('{{ $schedule->id }}')" tooltip-left="{{ __('Edit') }}" />
-                                    @if ($schedule->backups_count > 0)
+                                    @if ($schedule->total_backups_count > 0)
                                         <x-popover>
                                             <x-slot:trigger>
                                                 <x-button icon="o-trash" class="btn-ghost btn-sm opacity-40" disabled />

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -123,7 +123,12 @@
             @endscope
 
             @scope('cell_backup', $server)
-                @if($server->backup)
+                @if(!$server->backups_enabled)
+                    <span class="badge badge-warning badge-soft badge-xs gap-1">
+                        <x-icon name="o-no-symbol" class="w-3 h-3" />
+                        {{ __('Disabled') }}
+                    </span>
+                @elseif($server->backup)
                     <div class="table-cell-primary flex items-center gap-1.5">
                         <x-volume-type-icon :type="$server->backup->volume->type" class="w-4 h-4 text-base-content/70" />
                         {{ $server->backup->volume->name }}

--- a/tests/Feature/ConfigurationTest.php
+++ b/tests/Feature/ConfigurationTest.php
@@ -7,6 +7,7 @@ use App\Jobs\VerifySnapshotFileJob;
 use App\Livewire\Configuration\Index;
 use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
+use App\Models\Snapshot;
 use App\Models\User;
 use App\Notifications\BackupFailedNotification;
 use App\Services\FailureNotificationService;
@@ -216,7 +217,7 @@ test('sendTestNotification handles notification failure gracefully', function ()
 
     $mock = Mockery::mock(FailureNotificationService::class);
     $mock->shouldReceive('getNotificationRoutes')->andReturn(['mail' => 'admin@example.com']);
-    $mock->shouldReceive('notifyBackupFailed')->andThrow(new \RuntimeException('SMTP connection failed'));
+    $mock->shouldReceive('notifyBackupFailed')->andThrow(new RuntimeException('SMTP connection failed'));
     app()->instance(FailureNotificationService::class, $mock);
 
     Livewire::actingAs(User::factory()->create(['role' => 'admin']))
@@ -462,6 +463,28 @@ test('admin can run a schedule to trigger backups for all its servers', function
         ->call('runSchedule', $schedule->id);
 
     Queue::assertPushed(ProcessBackupJob::class);
+});
+
+test('running a schedule skips servers with backups disabled', function () {
+    Queue::fake();
+
+    $schedule = BackupSchedule::factory()->create();
+    $enabledServer = DatabaseServer::factory()->create(['database_names' => ['app'], 'backups_enabled' => true]);
+    $disabledServer = DatabaseServer::factory()->create(['database_names' => ['app'], 'backups_enabled' => false]);
+    $enabledServer->backup->update(['backup_schedule_id' => $schedule->id]);
+    $disabledServer->backup->update(['backup_schedule_id' => $schedule->id]);
+
+    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+        ->test(Index::class)
+        ->call('runSchedule', $schedule->id);
+
+    Queue::assertPushed(ProcessBackupJob::class, function ($job) use ($enabledServer) {
+        return Snapshot::find($job->snapshotId)->database_server_id === $enabledServer->id;
+    });
+
+    Queue::assertNotPushed(ProcessBackupJob::class, function ($job) use ($disabledServer) {
+        return Snapshot::find($job->snapshotId)->database_server_id === $disabledServer->id;
+    });
 });
 
 test('non-admin cannot run a schedule', function () {


### PR DESCRIPTION
## Summary

- Filter out servers with `backups_enabled = false` when manually running a schedule via `runSchedule()`, matching the existing behavior in `RunScheduledBackups` command
- Filter disabled servers from backup schedule server counts and popover lists on the Configuration page
- Show a "Disabled" badge in the backup column on the database servers index when backups are disabled

## Test plan

- [x] Added test: running a schedule skips servers with backups disabled
- [x] All 715 existing tests pass
- [x] PHPStan clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backup scheduling now skips servers with backups disabled so jobs are only enqueued for enabled servers.

* **New Features**
  * Database server view shows a "Disabled" badge when backups are not enabled.
  * Backup schedules list and actions now reflect updated backup counts for clearer in-use and delete behaviors.

* **Tests**
  * Added a test to verify schedules skip servers with backups disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->