### PR TITLE
Fix dump flags position and improve UI

### DIFF
--- a/app/Services/Backup/Databases/MysqlDatabase.php
+++ b/app/Services/Backup/Databases/MysqlDatabase.php
@@ -63,20 +63,23 @@ class MysqlDatabase implements DatabaseInterface
             $options[] = '--skip_ssl';
         }
 
+        $extraFlags = '';
+        if (! empty($this->config['dump_flags'])) {
+            $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+        }
+
+        // Flags must come before the database name; mysqldump treats anything after it as table names
         $command = sprintf(
-            '%s %s --host=%s --port=%s --user=%s --password=%s %s',
+            '%s %s --host=%s --port=%s --user=%s --password=%s%s %s',
             self::CLI_BINARIES[$this->getMysqlCliType()]['dump'],
             implode(' ', $options),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
             escapeshellarg($this->config['user']),
             escapeshellarg($this->config['pass']),
+            $extraFlags,
             escapeshellarg($this->config['database']),
         );
-
-        if (! empty($this->config['dump_flags'])) {
-            $command .= ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
-        }
 
         $command .= ' > '.escapeshellarg($outputPath);
 

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -39,19 +39,22 @@ class PostgresqlDatabase implements DatabaseInterface
 
     public function dump(string $outputPath): DatabaseOperationResult
     {
+        $extraFlags = '';
+        if (! empty($this->config['dump_flags'])) {
+            $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+        }
+
+        // Flags must come before the database name (last positional argument)
         $command = sprintf(
-            'PGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s %s',
+            'PGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s%s %s',
             escapeshellarg($this->config['pass']),
             implode(' ', self::DUMP_OPTIONS),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
             escapeshellarg($this->config['user']),
+            $extraFlags,
             escapeshellarg($this->config['database']),
         );
-
-        if (! empty($this->config['dump_flags'])) {
-            $command .= ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
-        }
 
         $command .= ' -f '.escapeshellarg($outputPath);
 

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -213,7 +213,7 @@ use App\Enums\DatabaseType;
                     @endif
 
                     @if($form->supportsDumpFlags())
-                        <x-collapse>
+                        <x-collapse class="mt-2" :open="!empty($form->dump_flags)">
                             <x-slot:heading>
                                 <x-icon name="o-command-line" class="w-4 h-4" />
                                 {{ __('Dump Command Configuration') }}
@@ -229,7 +229,7 @@ use App\Enums\DatabaseType;
 
                                 @php $dumpPreview = $form->getDumpCommandPreview() @endphp
                                 @if($dumpPreview)
-                                    <p class="text-xs font-medium text-base-content/60">{{ __('Command preview') }}</p>
+                                    <x-badge :value="__('Command preview')" class="badge-primary badge-soft "/>
                                     <div class="mockup-code text-xs">
                                         <pre data-prefix="$"><code>{{ $dumpPreview }}</code></pre>
                                     </div>

--- a/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
@@ -42,7 +42,8 @@ test('dump includes extra dump flags', function () {
 
     $result = $db->dump('/tmp/dump.sql');
 
-    expect($result->command)->toContain("'--no-tablespaces' '--column-statistics=0'")
+    // Flags must appear before the database name (mysqldump treats post-db args as table names)
+    expect($result->command)->toContain("'--no-tablespaces' '--column-statistics=0' 'myapp'")
         ->and($result->command)->toEndWith("> '/tmp/dump.sql'");
 });
 

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -35,7 +35,8 @@ test('dump includes extra dump flags', function () {
 
     $result = $db->dump('/tmp/dump.sql');
 
-    expect($result->command)->toContain("'--exclude-table=large_logs'")
+    // Flags must appear before the database name (last positional argument)
+    expect($result->command)->toContain("'--exclude-table=large_logs' 'myapp'")
         ->and($result->command)->toEndWith("-f '/tmp/dump.sql'");
 });
 

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -157,6 +157,40 @@ test('postgresql prepareForRestore drops and recreates existing database', funct
         ->and($loggedCommands)->toContain("CREATE DATABASE \"{$safe}\"");
 });
 
+test('backup with extra dump flags succeeds', function (string $type, string $flag) {
+    // Create models with dump flags in extra_config
+    $this->volume = IntegrationTestHelpers::createVolume($type);
+    $this->databaseServer = IntegrationTestHelpers::createDatabaseServer($type);
+    $this->databaseServer->update([
+        'extra_config' => array_merge(
+            $this->databaseServer->extra_config ?? [],
+            ['dump_flags' => $flag],
+        ),
+    ]);
+    $this->backup = IntegrationTestHelpers::createBackup($this->databaseServer, $this->volume);
+    $this->databaseServer->load('backup.volume');
+
+    // Load test data
+    IntegrationTestHelpers::loadTestData($type, $this->databaseServer);
+
+    // Run backup — this would fail if flags are mispositioned (e.g., after the database name)
+    $snapshots = $this->backupJobFactory->createSnapshots(
+        server: $this->databaseServer,
+        method: 'manual',
+    );
+    $this->snapshot = $snapshots[0];
+    ProcessBackupJob::dispatchSync($this->snapshot->id);
+    $this->snapshot->refresh();
+    $this->snapshot->load('job');
+
+    expect($this->snapshot->job->status)->toBe('completed')
+        ->and($this->snapshot->file_size)->toBeGreaterThan(0);
+})->with([
+    'mysql with --verbose' => ['mysql', '--verbose'],
+    'postgres with --verbose' => ['postgres', '--verbose'],
+    'mongodb with --verbose' => ['mongodb', '--verbose'],
+]);
+
 test('sqlite backup and restore workflow', function () {
     // Create a test SQLite database with some data (use unique names for parallel testing)
     $backupDir = AppConfig::get('backup.working_directory');


### PR DESCRIPTION
## Summary
- **Bug fix**: Move extra dump flags before the database name in MySQL/MariaDB and PostgreSQL dump commands — `mysqldump`/`mariadb-dump` treat anything after the database name as table names, causing flags like `--verbose` to be misinterpreted
- **UI improvement**: Auto-open the dump flags collapse when flags are set, use badge for command preview label, fix stray parenthesis in Blade template
- **Integration tests**: Add end-to-end tests verifying dump flags work with real MySQL, PostgreSQL, and MongoDB databases using `--verbose`

## Test plan
- [x] Unit tests verify flags are positioned before the database name in command strings
- [x] Integration tests confirm `--verbose` flag works end-to-end with MySQL, PostgreSQL, and MongoDB
- [x] All 755 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect positioning of dump flags in MySQL and PostgreSQL backup commands

* **Improvements**
  * Dump configuration section now auto-expands when custom flags are configured
  * Command preview display updated with new styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->