### PR TITLE
fix: resolve Discord notification driver

### DIFF
--- a/app/Notifications/BaseFailedNotification.php
+++ b/app/Notifications/BaseFailedNotification.php
@@ -7,6 +7,7 @@ use App\Notifications\Channels\WebhookChannel;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Notifications\Slack\SlackMessage;
+use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
 use NotificationChannels\Pushover\PushoverChannel;
 use NotificationChannels\Pushover\PushoverMessage;
@@ -23,7 +24,7 @@ abstract class BaseFailedNotification extends Notification
     private const array CHANNEL_MAP = [
         'mail' => 'mail',
         'slack' => 'slack',
-        'discord' => 'discord',
+        'discord' => DiscordChannel::class,
         'telegram' => TelegramChannel::class,
         'pushover' => PushoverChannel::class,
         'gotify' => GotifyChannel::class,

--- a/tests/Feature/Notifications/FailureNotificationTest.php
+++ b/tests/Feature/Notifications/FailureNotificationTest.php
@@ -17,6 +17,7 @@ use Illuminate\Notifications\Slack\SlackMessage;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
+use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
 use NotificationChannels\Pushover\PushoverChannel;
 use NotificationChannels\Pushover\PushoverMessage;
@@ -125,7 +126,7 @@ test('notification is sent to channel when configured', function (string $config
     );
 })->with([
     'slack' => ['notifications.slack.webhook_url', 'https://hooks.slack.com/services/test', 'slack', 'slack'],
-    'discord' => ['notifications.discord.channel_id', '123456789012345678', 'discord', 'discord'],
+    'discord' => ['notifications.discord.channel_id', '123456789012345678', DiscordChannel::class, 'discord'],
     'telegram' => ['notifications.telegram.chat_id', '123456', TelegramChannel::class, 'telegram'],
     'pushover' => ['notifications.pushover.user_key', 'user-key-123', PushoverChannel::class, 'pushover'],
     'gotify' => ['notifications.gotify.url', 'https://gotify.example.com', GotifyChannel::class, 'gotify'],
@@ -200,7 +201,7 @@ test('via method returns channels based on configured routes', function () {
     expect($channels)->toBe([
         'mail',
         'slack',
-        'discord',
+        DiscordChannel::class,
         TelegramChannel::class,
         PushoverChannel::class,
         GotifyChannel::class,


### PR DESCRIPTION
## Summary
- Fixed "Driver [discord] not supported" error when sending Discord notifications
- The `CHANNEL_MAP` in `BaseFailedNotification` mapped `'discord'` to the string `'discord'`, but unlike `'mail'` and `'slack'` (built-in Laravel drivers), the `laravel-notification-channels/discord` package provides a class-based channel that must be referenced as `DiscordChannel::class`
- Updated test expectations to match the new channel resolution

Closes #190

## Test plan
- [x] All 816 existing tests pass
- [x] PHPStan static analysis passes
- [x] Pint formatting passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal structure of notification channel mapping for enhanced maintainability.

* **Tests**
  * Updated notification tests to ensure proper Discord channel handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->