### PR TITLE
feat: add OIDC group-based role mapping

### DIFF
--- a/.env
+++ b/.env
@@ -112,3 +112,15 @@ OAUTH_OIDC_CLIENT_ID=
 OAUTH_OIDC_CLIENT_SECRET=
 OAUTH_OIDC_BASE_URL=
 OAUTH_OIDC_LABEL=SSO
+# OAUTH_OIDC_SCOPES=groups              # Extra scopes to request (comma-separated)
+
+# --------------------------------------------
+# OIDC Group-Based Role Mapping (optional)
+# Map OIDC group claims to Databasement roles.
+# When at least one ROLE_MAP is set, mapping is active.
+# --------------------------------------------
+# OAUTH_OIDC_ROLE_CLAIM=groups           # JWT claim containing groups (default: groups)
+# OAUTH_OIDC_ROLE_MAP_ADMIN=             # IdP groups that map to admin (comma-separated)
+# OAUTH_OIDC_ROLE_MAP_MEMBER=            # IdP groups that map to member (comma-separated)
+# OAUTH_OIDC_ROLE_MAP_VIEWER=            # IdP groups that map to viewer (comma-separated)
+# OAUTH_OIDC_ROLE_STRICT=false           # Deny login when no group matches

--- a/app/Http/Controllers/Web/OAuthController.php
+++ b/app/Http/Controllers/Web/OAuthController.php
@@ -26,9 +26,14 @@ class OAuthController extends Controller
 
         $driver = $this->getDriver($provider);
 
-        // For OIDC, we need to set scopes
+        // Set OIDC scopes including any extra scopes (e.g. "groups" for role mapping).
+        // The method_exists guard is needed because scopes() is not on the Provider contract.
         if ($provider === 'oidc' && method_exists($driver, 'scopes')) {
-            $driver->scopes(['openid', 'profile', 'email']);
+            $scopes = ['openid', 'profile', 'email', ...array_filter(
+                array_map('trim', explode(',', config('oauth.providers.oidc.extra_scopes', '')))
+            )];
+
+            $driver->scopes($scopes);
         }
 
         return $driver->redirect();
@@ -94,13 +99,6 @@ class OAuthController extends Controller
      */
     private function getDriver(string $provider): \Laravel\Socialite\Contracts\Provider
     {
-        // Map internal provider names to Socialite driver names
-        $driverMap = [
-            'oidc' => 'oidc',
-        ];
-
-        $driver = $driverMap[$provider] ?? $provider;
-
-        return Socialite::driver($driver);
+        return Socialite::driver($provider);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -73,14 +73,8 @@ class AppServiceProvider extends ServiceProvider
                 $serviceConfig['host'] = $provider['host'];
             }
 
-            if ($name === 'oidc') {
-                if (isset($provider['base_url'])) {
-                    $serviceConfig['base_url'] = $provider['base_url'];
-                }
-
-                if (! empty($provider['extra_scopes'])) {
-                    $serviceConfig['scopes'] = str_replace(',', ' ', trim($provider['extra_scopes']));
-                }
+            if ($name === 'oidc' && isset($provider['base_url'])) {
+                $serviceConfig['base_url'] = $provider['base_url'];
             }
 
             config(["services.{$name}" => $serviceConfig]);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -205,16 +205,18 @@ class AppServiceProvider extends ServiceProvider
             }
         }
 
-        // Validate role mapping: strict mode requires at least one mapping
-        $roleMapping = config('oauth.role_mapping', []);
-        $hasMapping = trim((string) ($roleMapping['admin'] ?? '')) !== ''
-            || trim((string) ($roleMapping['member'] ?? '')) !== ''
-            || trim((string) ($roleMapping['viewer'] ?? '')) !== '';
+        // Validate role mapping: strict mode requires at least one mapping (only when OIDC is enabled)
+        if (config('oauth.providers.oidc.enabled', false)) {
+            $roleMapping = config('oauth.role_mapping', []);
+            $hasMapping = trim((string) ($roleMapping['admin'] ?? '')) !== ''
+                || trim((string) ($roleMapping['member'] ?? '')) !== ''
+                || trim((string) ($roleMapping['viewer'] ?? '')) !== '';
 
-        if (! empty($roleMapping['strict']) && ! $hasMapping) {
-            throw new \InvalidArgumentException(
-                'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured. Set at least one of: OAUTH_OIDC_ROLE_MAP_ADMIN, OAUTH_OIDC_ROLE_MAP_MEMBER, OAUTH_OIDC_ROLE_MAP_VIEWER'
-            );
+            if (! empty($roleMapping['strict']) && ! $hasMapping) {
+                throw new \InvalidArgumentException(
+                    'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured. Set at least one of: OAUTH_OIDC_ROLE_MAP_ADMIN, OAUTH_OIDC_ROLE_MAP_MEMBER, OAUTH_OIDC_ROLE_MAP_VIEWER'
+                );
+            }
         }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -207,9 +207,9 @@ class AppServiceProvider extends ServiceProvider
 
         // Validate role mapping: strict mode requires at least one mapping
         $roleMapping = config('oauth.role_mapping', []);
-        $hasMapping = ($roleMapping['admin'] ?? '') !== ''
-            || ($roleMapping['member'] ?? '') !== ''
-            || ($roleMapping['viewer'] ?? '') !== '';
+        $hasMapping = trim((string) ($roleMapping['admin'] ?? '')) !== ''
+            || trim((string) ($roleMapping['member'] ?? '')) !== ''
+            || trim((string) ($roleMapping['viewer'] ?? '')) !== '';
 
         if (! empty($roleMapping['strict']) && ! $hasMapping) {
             throw new \InvalidArgumentException(

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -73,8 +73,14 @@ class AppServiceProvider extends ServiceProvider
                 $serviceConfig['host'] = $provider['host'];
             }
 
-            if ($name === 'oidc' && isset($provider['base_url'])) {
-                $serviceConfig['base_url'] = $provider['base_url'];
+            if ($name === 'oidc') {
+                if (isset($provider['base_url'])) {
+                    $serviceConfig['base_url'] = $provider['base_url'];
+                }
+
+                if (! empty($provider['extra_scopes'])) {
+                    $serviceConfig['scopes'] = str_replace(',', ' ', trim($provider['extra_scopes']));
+                }
             }
 
             config(["services.{$name}" => $serviceConfig]);
@@ -197,6 +203,18 @@ class AppServiceProvider extends ServiceProvider
                     "OAuth provider 'oidc' is enabled but missing required base URL"
                 );
             }
+        }
+
+        // Validate role mapping: strict mode requires at least one mapping
+        $roleMapping = config('oauth.role_mapping', []);
+        $hasMapping = ($roleMapping['admin'] ?? '') !== ''
+            || ($roleMapping['member'] ?? '') !== ''
+            || ($roleMapping['viewer'] ?? '') !== '';
+
+        if (! empty($roleMapping['strict']) && ! $hasMapping) {
+            throw new \InvalidArgumentException(
+                'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured. Set at least one of: OAUTH_OIDC_ROLE_MAP_ADMIN, OAUTH_OIDC_ROLE_MAP_MEMBER, OAUTH_OIDC_ROLE_MAP_VIEWER'
+            );
         }
     }
 }

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -15,50 +15,22 @@ class OAuthService
     public function findOrCreateUser(SocialiteUser $socialiteUser, string $provider): User
     {
         return DB::transaction(function () use ($socialiteUser, $provider) {
-            // First, check if we have an existing OAuth identity for this provider
             $identity = OAuthIdentity::where('provider', $provider)
                 ->where('provider_user_id', $socialiteUser->getId())
                 ->first();
 
             if ($identity) {
-                // Update tokens and return existing user
                 $this->updateIdentityTokens($identity, $socialiteUser);
+                $this->syncUserRole($identity->user, $socialiteUser, $provider);
 
                 return $identity->user;
             }
 
-            // No existing OAuth identity - try to find user by email
-            $user = null;
-            $existingUserByEmail = $socialiteUser->getEmail()
-                ? User::where('email', $socialiteUser->getEmail())->first()
-                : null;
+            // Resolve role early to fail fast in strict mode before creating anything
+            $resolvedRole = $this->resolveOidcRole($socialiteUser, $provider);
 
-            if (config('oauth.auto_link_by_email') && $existingUserByEmail) {
-                $user = $existingUserByEmail;
+            $user = $this->findOrCreateLocalUser($socialiteUser, $provider, $resolvedRole);
 
-                // Clear password to enforce OAuth-only login going forward
-                $user->password = null;
-                $user->save();
-            }
-
-            // Create new user if auto-creation is enabled and no existing user found
-            if (! $user && config('oauth.auto_create_users')) {
-                // Check if email already exists (when auto_link is disabled)
-                if ($existingUserByEmail) {
-                    throw new \RuntimeException(
-                        __('An account with this email already exists. Please log in with your password or contact an administrator.')
-                    );
-                }
-                $user = $this->createUser($socialiteUser);
-            }
-
-            if (! $user) {
-                throw new \RuntimeException(
-                    __('No matching user found and auto-creation is disabled.')
-                );
-            }
-
-            // Create the OAuth identity for this user
             $this->createIdentity($user, $socialiteUser, $provider);
 
             return $user;
@@ -66,21 +38,147 @@ class OAuthService
     }
 
     /**
+     * Find an existing local user to link or create a new one.
+     *
+     * @throws \RuntimeException when no user can be found or created
+     */
+    private function findOrCreateLocalUser(SocialiteUser $socialiteUser, string $provider, ?string $resolvedRole): User
+    {
+        $existingUser = $socialiteUser->getEmail()
+            ? User::where('email', $socialiteUser->getEmail())->first()
+            : null;
+
+        if (config('oauth.auto_link_by_email') && $existingUser) {
+            $existingUser->password = null;
+            $existingUser->save();
+
+            $this->syncUserRole($existingUser, $socialiteUser, $provider, $resolvedRole);
+
+            return $existingUser;
+        }
+
+        if (! config('oauth.auto_create_users')) {
+            throw new \RuntimeException(
+                __('No matching user found and auto-creation is disabled.')
+            );
+        }
+
+        if ($existingUser) {
+            throw new \RuntimeException(
+                __('An account with this email already exists. Please log in with your password or contact an administrator.')
+            );
+        }
+
+        return $this->createUser($socialiteUser, $resolvedRole);
+    }
+
+    /**
+     * Resolve user role from OIDC group claims.
+     *
+     * Returns the mapped role if a match is found, null if mapping is
+     * inactive or no match, or throws if strict mode denies access.
+     */
+    private function resolveOidcRole(SocialiteUser $socialiteUser, string $provider): ?string
+    {
+        if ($provider !== 'oidc') {
+            return null;
+        }
+
+        if (! $this->isRoleMappingConfigured()) {
+            return null;
+        }
+
+        $claim = config('oauth.role_mapping.claim', 'groups');
+        $raw = method_exists($socialiteUser, 'getRaw') ? $socialiteUser->getRaw() : [];
+        $claimValue = $raw[$claim] ?? null;
+
+        if ($claimValue === null) {
+            return $this->handleUnmappedUser();
+        }
+
+        // Normalize to array (claim could be a string for a single group)
+        $userGroups = (array) $claimValue;
+
+        // Check roles in priority order: admin > member > viewer
+        foreach (['admin', 'member', 'viewer'] as $role) {
+            $configuredGroups = $this->parseGroupList(config("oauth.role_mapping.{$role}", ''));
+
+            if ($configuredGroups !== [] && array_intersect($userGroups, $configuredGroups) !== []) {
+                return $role;
+            }
+        }
+
+        return $this->handleUnmappedUser();
+    }
+
+    /**
+     * Handle the case where no OIDC group matches any configured mapping.
+     *
+     * @throws \RuntimeException when strict mode is enabled
+     */
+    private function handleUnmappedUser(): null
+    {
+        if (config('oauth.role_mapping.strict')) {
+            throw new \RuntimeException(
+                __('Your account is not authorized to access this application.')
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Sync user role from OIDC claims.
+     */
+    private function syncUserRole(User $user, SocialiteUser $socialiteUser, string $provider, ?string $resolvedRole = null): void
+    {
+        $role = $resolvedRole ?? $this->resolveOidcRole($socialiteUser, $provider);
+
+        if ($role !== null) {
+            $user->role = $role;
+            $user->save();
+        }
+    }
+
+    /**
+     * Check if any role mapping env vars are configured.
+     */
+    private function isRoleMappingConfigured(): bool
+    {
+        return config('oauth.role_mapping.admin', '') !== ''
+            || config('oauth.role_mapping.member', '') !== ''
+            || config('oauth.role_mapping.viewer', '') !== '';
+    }
+
+    /**
+     * Parse a comma-separated group list into a clean array.
+     *
+     * @return array<int, string>
+     */
+    private function parseGroupList(string $value): array
+    {
+        if ($value === '') {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('trim', explode(',', $value))));
+    }
+
+    /**
      * Create a new user from OAuth data.
      */
-    private function createUser(SocialiteUser $socialiteUser): User
+    private function createUser(SocialiteUser $socialiteUser, ?string $resolvedRole = null): User
     {
-        $role = config('oauth.default_role', User::ROLE_MEMBER);
+        $role = $resolvedRole ?? config('oauth.default_role', User::ROLE_MEMBER);
 
-        // Validate the role is valid
         if (! in_array($role, User::ROLES)) {
             $role = User::ROLE_MEMBER;
         }
 
-        $user = User::create([
+        $user = new User([
             'name' => $socialiteUser->getName() ?? $socialiteUser->getNickname() ?? 'OAuth User',
             'email' => $socialiteUser->getEmail(),
-            'password' => null, // OAuth users don't need a password
+            'password' => null,
             'role' => $role,
             'invitation_accepted_at' => now(),
         ]);

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -96,8 +96,8 @@ class OAuthService
             return $this->handleUnmappedUser();
         }
 
-        // Normalize to array (claim could be a string for a single group)
-        $userGroups = (array) $claimValue;
+        // Normalize to array and lowercase for case-insensitive matching
+        $userGroups = array_map('mb_strtolower', (array) $claimValue);
 
         // Check roles in priority order: admin > member > viewer
         foreach (['admin', 'member', 'viewer'] as $role) {
@@ -145,13 +145,13 @@ class OAuthService
      */
     private function isRoleMappingConfigured(): bool
     {
-        return config('oauth.role_mapping.admin', '') !== ''
-            || config('oauth.role_mapping.member', '') !== ''
-            || config('oauth.role_mapping.viewer', '') !== '';
+        return trim((string) config('oauth.role_mapping.admin', '')) !== ''
+            || trim((string) config('oauth.role_mapping.member', '')) !== ''
+            || trim((string) config('oauth.role_mapping.viewer', '')) !== '';
     }
 
     /**
-     * Parse a comma-separated group list into a clean array.
+     * Parse a comma-separated group list into a clean, lowercased array.
      *
      * @return array<int, string>
      */
@@ -161,7 +161,10 @@ class OAuthService
             return [];
         }
 
-        return array_values(array_filter(array_map('trim', explode(',', $value))));
+        return array_values(array_filter(array_map(
+            fn (string $group) => mb_strtolower(trim($group)),
+            explode(',', $value),
+        )));
     }
 
     /**

--- a/config/oauth.php
+++ b/config/oauth.php
@@ -48,6 +48,27 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | OIDC Role Mapping
+    |--------------------------------------------------------------------------
+    |
+    | Map OIDC group claims to Databasement roles. When at least one
+    | ROLE_MAP is set, mapping is active. Roles are checked in priority
+    | order: admin > member > viewer. The first match wins.
+    |
+    | When strict mode is enabled, users without a matching group are
+    | denied access entirely (even returning users).
+    |
+    */
+    'role_mapping' => [
+        'claim' => env('OAUTH_OIDC_ROLE_CLAIM', 'groups'),
+        'admin' => env('OAUTH_OIDC_ROLE_MAP_ADMIN', ''),
+        'member' => env('OAUTH_OIDC_ROLE_MAP_MEMBER', ''),
+        'viewer' => env('OAUTH_OIDC_ROLE_MAP_VIEWER', ''),
+        'strict' => env('OAUTH_OIDC_ROLE_STRICT', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | OAuth Providers
     |--------------------------------------------------------------------------
     |
@@ -83,6 +104,7 @@ return [
             'client_id' => env('OAUTH_OIDC_CLIENT_ID'),
             'client_secret' => env('OAUTH_OIDC_CLIENT_SECRET'),
             'base_url' => env('OAUTH_OIDC_BASE_URL'),
+            'extra_scopes' => env('OAUTH_OIDC_SCOPES', ''),
             'icon' => 'o-key',
             'label' => env('OAUTH_OIDC_LABEL', 'SSO'),
         ],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,11 @@ services:
 # To enable: 1) Add "127.0.0.1 dex-local" to /etc/hosts
 #            2) Uncomment this service
 #            3) Set OAUTH_OIDC_ENABLED=true in .env.local
-# Test user: user@databasement.com (password: databasement)
+# Test users (password: databasement):
+#   admin@databasement.com   (groups: databasement-admins, team-a)
+#   user@databasement.com    (groups: databasement-members, team-b)
+#   viewer@databasement.com  (groups: databasement-viewers)
+#   outsider@databasement.com (no groups)
 #  dex:
 #    image: ghcr.io/dexidp/dex:v2.38.0
 #    container_name: databasement-dex

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       retries: 5
 
   mongodb:
-    image: mongo:8
+    image: mongo:7
     container_name: databasement-mongodb
     environment:
       MONGO_INITDB_ROOT_USERNAME: root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,7 +176,7 @@ services:
 #   viewer@databasement.com  (groups: databasement-viewers)
 #   outsider@databasement.com (no groups)
 #  dex:
-#    image: ghcr.io/dexidp/dex:v2.38.0
+#    image: ghcr.io/dexidp/dex:v2.45.0
 #    container_name: databasement-dex
 #    volumes:
 #      - ./docker/dex/config.yaml:/etc/dex/config.yaml:ro

--- a/docker/dex/config.yaml
+++ b/docker/dex/config.yaml
@@ -1,12 +1,17 @@
 # Dex OIDC Provider Configuration for Local Development
 #
-# This provides a local OIDC server for testing OAuth login.
-# Test user: user@databasement.com (password: databasement)
+# This provides a local OIDC server for testing OAuth login and group-based role mapping.
 #
 # Setup:
 #   1. Add hosts entry: echo "127.0.0.1 dex-local" | sudo tee -a /etc/hosts
 #   2. Uncomment dex service in docker-compose.yml
 #   3. Start: docker compose up dex -d
+#
+# Test users (password: databasement):
+#   admin@databasement.com   (groups: databasement-admins, team-a)
+#   user@databasement.com    (groups: databasement-members, team-b)
+#   viewer@databasement.com  (groups: databasement-viewers)
+#   outsider@databasement.com (no groups - for testing strict mode denial)
 
 issuer: http://dex-local:5556/dex
 
@@ -38,8 +43,31 @@ enablePasswordDB: true
 # Password for all users: databasement
 # Hash generated with: htpasswd -bnBC 10 "" databasement | tr -d ':\n'
 staticPasswords:
+  - email: admin@databasement.com
+    # password: databasement
+    hash: "$2y$10$oQn5n2/SAPS1lW3vBY36zOaIYbCV6jz4RR72N.LfCNcoB52Zeb1wq"
+    username: admin
+    userID: admin-id
+    groups:
+      - databasement-admins
+      - team-a
   - email: user@databasement.com
     # password: databasement
     hash: "$2y$10$oQn5n2/SAPS1lW3vBY36zOaIYbCV6jz4RR72N.LfCNcoB52Zeb1wq"
     username: user
     userID: user-id
+    groups:
+      - databasement-members
+      - team-b
+  - email: viewer@databasement.com
+    # password: databasement
+    hash: "$2y$10$oQn5n2/SAPS1lW3vBY36zOaIYbCV6jz4RR72N.LfCNcoB52Zeb1wq"
+    username: viewer
+    userID: viewer-id
+    groups:
+      - databasement-viewers
+  - email: outsider@databasement.com
+    # password: databasement
+    hash: "$2y$10$oQn5n2/SAPS1lW3vBY36zOaIYbCV6jz4RR72N.LfCNcoB52Zeb1wq"
+    username: outsider
+    userID: outsider-id

--- a/docs/docs/self-hosting/configuration/sso.md
+++ b/docs/docs/self-hosting/configuration/sso.md
@@ -146,4 +146,82 @@ When enabled (default), OAuth logins are automatically linked to existing users 
 OAUTH_AUTO_LINK_BY_EMAIL=true  # Default: true
 ```
 
+## OIDC Group-Based Role Mapping
+
+When using a Generic OIDC provider (Keycloak, Authentik, Dex, etc.), you can map IdP groups to Databasement roles automatically. This lets you control who can access Databasement and what role they get — all from your identity provider.
+
+### How It Works
+
+1. Your IdP includes a `groups` claim in the OIDC token (e.g., `["devops", "databasement-admins"]`)
+2. Databasement checks the user's groups against your configured mappings
+3. The user gets the highest-priority matching role: **admin > member > viewer**
+4. Roles are synced on every login, so changes in the IdP take effect immediately
+
+### Configuration
+
+First, make sure your IdP sends groups in the token. Most IdPs require requesting the `groups` scope:
+
+```env
+OAUTH_OIDC_SCOPES=groups
+```
+
+Then map IdP groups to Databasement roles. Use comma-separated values if multiple IdP groups should map to the same role:
+
+```env
+OAUTH_OIDC_ROLE_MAP_ADMIN=databasement-admins
+OAUTH_OIDC_ROLE_MAP_MEMBER=databasement-members,devops-team
+OAUTH_OIDC_ROLE_MAP_VIEWER=databasement-viewers,interns
+```
+
+When at least one `ROLE_MAP` is set, mapping is active. Users whose groups don't match any mapping get the `OAUTH_DEFAULT_ROLE`.
+
+### Strict Mode
+
+To deny access to users without a matching group (instead of falling back to the default role):
+
+```env
+OAUTH_OIDC_ROLE_STRICT=true
+```
+
+With strict mode, users who don't have any matching group are rejected at login — even returning users whose groups have been revoked in the IdP.
+
+### Custom Claim Name
+
+By default, Databasement reads the `groups` claim. If your IdP uses a different claim name (e.g., `roles` or `realm_access`):
+
+```env
+OAUTH_OIDC_ROLE_CLAIM=roles
+```
+
+### Full Example (Keycloak)
+
+```env
+OAUTH_OIDC_ENABLED=true
+OAUTH_OIDC_CLIENT_ID=databasement
+OAUTH_OIDC_CLIENT_SECRET=your-secret
+OAUTH_OIDC_BASE_URL=https://keycloak.example.com/realms/your-realm
+OAUTH_OIDC_LABEL=Keycloak
+OAUTH_OIDC_SCOPES=groups
+
+OAUTH_OIDC_ROLE_MAP_ADMIN=databasement-admins
+OAUTH_OIDC_ROLE_MAP_MEMBER=databasement-members
+OAUTH_OIDC_ROLE_MAP_VIEWER=databasement-viewers
+OAUTH_OIDC_ROLE_STRICT=true
+```
+
+:::tip Keycloak Group Mapper
+In Keycloak, go to your client > **Client scopes** > **databasement-dedicated** > **Mappers** > **Add mapper** > **Group Membership**. Set the token claim name to `groups` and disable "Full group path" to get flat group names.
+:::
+
+### Environment Variables Reference
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `OAUTH_OIDC_SCOPES` | *(empty)* | Extra OIDC scopes to request (comma-separated, e.g., `groups`) |
+| `OAUTH_OIDC_ROLE_CLAIM` | `groups` | JWT claim containing the user's groups |
+| `OAUTH_OIDC_ROLE_MAP_ADMIN` | *(empty)* | IdP groups that map to the **admin** role (comma-separated) |
+| `OAUTH_OIDC_ROLE_MAP_MEMBER` | *(empty)* | IdP groups that map to the **member** role (comma-separated) |
+| `OAUTH_OIDC_ROLE_MAP_VIEWER` | *(empty)* | IdP groups that map to the **viewer** role (comma-separated) |
+| `OAUTH_OIDC_ROLE_STRICT` | `false` | Deny login when no group matches (instead of using default role) |
+
 For local development OAuth testing, see the [Development Guide](/contributing/development#oauth--sso-testing).

--- a/tests/Feature/Auth/OAuthTest.php
+++ b/tests/Feature/Auth/OAuthTest.php
@@ -9,11 +9,39 @@ use Laravel\Socialite\Two\User as SocialiteUser;
 
 uses(RefreshDatabase::class);
 
+function enableOidcProvider(): void
+{
+    Config::set('oauth.providers.oidc.enabled', true);
+    Config::set('oauth.providers.oidc.client_id', 'test-client');
+    Config::set('oauth.providers.oidc.client_secret', 'test-secret');
+    Config::set('oauth.providers.oidc.base_url', 'https://idp.example.com');
+}
+
+function fakeOidcUser(string $id, string $email, string $name = 'OIDC User', ?array $groups = null): SocialiteUser
+{
+    $raw = ['sub' => $id, 'name' => $name, 'email' => $email];
+    if ($groups !== null) {
+        $raw['groups'] = $groups;
+    }
+
+    return (new SocialiteUser)->setRaw($raw)->map([
+        'id' => $id,
+        'name' => $name,
+        'email' => $email,
+        'nickname' => $name,
+    ])->setToken('fake-token');
+}
+
 beforeEach(function () {
     Config::set('oauth.providers.github.enabled', true);
     Config::set('oauth.auto_link_by_email', true);
     Config::set('oauth.auto_create_users', true);
     Config::set('oauth.default_role', 'member');
+    Config::set('oauth.role_mapping.claim', 'groups');
+    Config::set('oauth.role_mapping.admin', '');
+    Config::set('oauth.role_mapping.member', '');
+    Config::set('oauth.role_mapping.viewer', '');
+    Config::set('oauth.role_mapping.strict', false);
 });
 
 test('oauth redirect returns 404 for disabled provider', function () {
@@ -84,17 +112,12 @@ test('oauth callback links to existing user by email and clears password', funct
 
     $response->assertRedirect(route('dashboard'));
 
-    // Should not create a new user
     expect(User::count())->toBe(1);
 
-    // Should link OAuth identity to existing user
     $existingUser->refresh();
     expect($existingUser->oauthIdentities)->toHaveCount(1)
-        ->and($existingUser->role)->toBe(User::ROLE_ADMIN)
-        ->and($existingUser->password)->toBeNull();
-    // Role unchanged
-
-    // Password should be cleared to enforce OAuth-only login
+        ->and($existingUser->role)->toBe(User::ROLE_ADMIN) // unchanged
+        ->and($existingUser->password)->toBeNull(); // cleared to enforce OAuth-only login
 });
 
 test('oauth callback logs in returning oauth user', function () {
@@ -230,4 +253,214 @@ test('user can have multiple oauth providers linked', function () {
     $providers = $user->oauthIdentities->pluck('provider')->toArray();
     expect($providers)->toContain('github')
         ->and($providers)->toContain('google');
+});
+
+// -------------------------------------------------------
+// OIDC Group-Based Role Mapping
+// -------------------------------------------------------
+
+test('oidc role mapping assigns admin role from matching group', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-1', 'admin@example.com', 'Admin', ['databasement-admins']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'admin@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_ADMIN);
+});
+
+test('oidc role mapping assigns member role from matching group', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.member', 'databasement-members');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-2', 'member@example.com', 'Member', ['databasement-members']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'member@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_MEMBER);
+});
+
+test('oidc role mapping assigns viewer role from matching group', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.viewer', 'databasement-viewers');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-3', 'viewer@example.com', 'Viewer', ['databasement-viewers']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'viewer@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_VIEWER);
+});
+
+test('oidc role mapping uses highest priority role when multiple groups match', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+    Config::set('oauth.role_mapping.member', 'databasement-members');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-4', 'multi@example.com', 'Multi', ['databasement-members', 'databasement-admins']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'multi@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_ADMIN);
+});
+
+test('oidc role mapping falls back to default role when no group matches and strict is off', function () {
+    enableOidcProvider();
+    Config::set('oauth.default_role', 'viewer');
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-5', 'fallback@example.com', 'Fallback', ['unrelated-group']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'fallback@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_VIEWER);
+});
+
+test('oidc role mapping denies access when no group matches and strict is on', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+    Config::set('oauth.role_mapping.strict', true);
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-6', 'denied@example.com', 'Denied', ['unrelated-group']));
+
+    $response = $this->get(route('oauth.callback', 'oidc'));
+
+    $response->assertRedirect(route('login'));
+    $response->assertSessionHas('error', 'Your account is not authorized to access this application.');
+    expect(User::where('email', 'denied@example.com')->exists())->toBeFalse();
+});
+
+test('oidc role mapping syncs role for returning user', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+
+    $user = User::factory()->create(['role' => User::ROLE_MEMBER]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'oidc',
+        'provider_user_id' => 'oidc-7',
+        'email' => $user->email,
+    ]);
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-7', $user->email, $user->name, ['databasement-admins']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user->refresh();
+    expect($user->role)->toBe(User::ROLE_ADMIN);
+});
+
+test('oidc role mapping updates role when groups change for returning user', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+    Config::set('oauth.role_mapping.viewer', 'databasement-viewers');
+
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'oidc',
+        'provider_user_id' => 'oidc-8',
+        'email' => $user->email,
+    ]);
+
+    // User lost admin group, now only has viewer group
+    Socialite::fake('oidc', fakeOidcUser('oidc-8', $user->email, $user->name, ['databasement-viewers']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user->refresh();
+    expect($user->role)->toBe(User::ROLE_VIEWER);
+});
+
+test('oidc role mapping uses default role when no mapping is configured', function () {
+    enableOidcProvider();
+    Config::set('oauth.default_role', 'viewer');
+    // All role_mapping values are empty (from beforeEach)
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-9', 'default@example.com', 'Default', ['some-group']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'default@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_VIEWER);
+});
+
+test('oidc role mapping reads from custom claim name', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.claim', 'roles');
+    Config::set('oauth.role_mapping.admin', 'super-admin');
+
+    $raw = ['sub' => 'oidc-10', 'name' => 'Custom', 'email' => 'custom@example.com', 'roles' => ['super-admin']];
+    $socialiteUser = (new SocialiteUser)->setRaw($raw)->map([
+        'id' => 'oidc-10',
+        'name' => 'Custom',
+        'email' => 'custom@example.com',
+        'nickname' => 'Custom',
+    ])->setToken('fake-token');
+
+    Socialite::fake('oidc', $socialiteUser);
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'custom@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_ADMIN);
+});
+
+test('oidc role mapping does not apply to non-oidc providers', function () {
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+    Config::set('oauth.default_role', 'member');
+
+    Socialite::fake('github', (new SocialiteUser)->setRaw([
+        'sub' => 'gh-role',
+        'groups' => ['databasement-admins'],
+    ])->map([
+        'id' => 'gh-role',
+        'name' => 'GitHub User',
+        'email' => 'ghuser@example.com',
+        'nickname' => 'ghuser',
+    ])->setToken('token'));
+
+    $this->get(route('oauth.callback', 'github'));
+
+    $user = User::where('email', 'ghuser@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_MEMBER);
+});
+
+test('oidc role mapping supports comma-separated groups in env var', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'super-admins, databasement-admins, ops-team');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-12', 'comma@example.com', 'Comma', ['ops-team']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'comma@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_ADMIN);
+});
+
+test('oidc role mapping strict mode denies returning user with revoked groups', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+    Config::set('oauth.role_mapping.strict', true);
+
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'oidc',
+        'provider_user_id' => 'oidc-13',
+        'email' => $user->email,
+    ]);
+
+    // User's groups have been revoked in IdP
+    Socialite::fake('oidc', fakeOidcUser('oidc-13', $user->email, $user->name, ['unrelated']));
+
+    $response = $this->get(route('oauth.callback', 'oidc'));
+
+    $response->assertRedirect(route('login'));
+    $response->assertSessionHas('error', 'Your account is not authorized to access this application.');
 });

--- a/tests/Feature/Auth/OAuthTest.php
+++ b/tests/Feature/Auth/OAuthTest.php
@@ -390,6 +390,33 @@ test('oidc role mapping uses default role when no mapping is configured', functi
     expect($user->role)->toBe(User::ROLE_VIEWER);
 });
 
+test('oidc role mapping falls back to default role when groups claim is missing', function () {
+    enableOidcProvider();
+    Config::set('oauth.default_role', 'viewer');
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-no-groups', 'noclaimuser@example.com', 'No Groups'));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'noclaimuser@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_VIEWER);
+});
+
+test('oidc role mapping strict mode denies access when groups claim is missing', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+    Config::set('oauth.role_mapping.strict', true);
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-no-groups-strict', 'denied-noclaim@example.com', 'No Groups'));
+
+    $response = $this->get(route('oauth.callback', 'oidc'));
+
+    $response->assertRedirect(route('login'));
+    $response->assertSessionHas('error', 'Your account is not authorized to access this application.');
+    expect(User::where('email', 'denied-noclaim@example.com')->exists())->toBeFalse();
+});
+
 test('oidc role mapping reads from custom claim name', function () {
     enableOidcProvider();
     Config::set('oauth.role_mapping.claim', 'roles');
@@ -440,6 +467,18 @@ test('oidc role mapping supports comma-separated groups in env var', function ()
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'comma@example.com')->first();
+    expect($user->role)->toBe(User::ROLE_ADMIN);
+});
+
+test('oidc role mapping matches groups case-insensitively', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.admin', 'Databasement-Admins');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-case', 'case@example.com', 'Case', ['databasement-admins']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'case@example.com')->first();
     expect($user->role)->toBe(User::ROLE_ADMIN);
 });
 

--- a/tests/Feature/OAuthConfigurationValidationTest.php
+++ b/tests/Feature/OAuthConfigurationValidationTest.php
@@ -41,3 +41,36 @@ test('throws exception when oidc provider is missing base url', function () {
     expect(fn () => $provider->performOAuthValidation())
         ->toThrow(\InvalidArgumentException::class, "OAuth provider 'oidc' is enabled but missing required base URL");
 });
+
+test('throws exception when strict mode is enabled without any role mappings', function () {
+    Config::set('oauth.default_role', 'member');
+    Config::set('oauth.providers', []);
+    Config::set('oauth.role_mapping', [
+        'claim' => 'groups',
+        'admin' => '',
+        'member' => '',
+        'viewer' => '',
+        'strict' => true,
+    ]);
+
+    $provider = new AppServiceProvider(app());
+
+    expect(fn () => $provider->performOAuthValidation())
+        ->toThrow(\InvalidArgumentException::class, 'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured');
+});
+
+test('does not throw when strict mode is enabled with role mappings', function () {
+    Config::set('oauth.default_role', 'member');
+    Config::set('oauth.providers', []);
+    Config::set('oauth.role_mapping', [
+        'claim' => 'groups',
+        'admin' => 'my-admins',
+        'member' => '',
+        'viewer' => '',
+        'strict' => true,
+    ]);
+
+    $provider = new AppServiceProvider(app());
+
+    expect(fn () => $provider->performOAuthValidation())->not->toThrow(\InvalidArgumentException::class);
+});

--- a/tests/Feature/OAuthConfigurationValidationTest.php
+++ b/tests/Feature/OAuthConfigurationValidationTest.php
@@ -44,7 +44,12 @@ test('throws exception when oidc provider is missing base url', function () {
 
 test('throws exception when strict mode is enabled without any role mappings', function () {
     Config::set('oauth.default_role', 'member');
-    Config::set('oauth.providers', []);
+    Config::set('oauth.providers.oidc', [
+        'enabled' => true,
+        'client_id' => 'id',
+        'client_secret' => 'secret',
+        'base_url' => 'https://idp.example.com',
+    ]);
     Config::set('oauth.role_mapping', [
         'claim' => 'groups',
         'admin' => '',
@@ -61,10 +66,31 @@ test('throws exception when strict mode is enabled without any role mappings', f
 
 test('does not throw when strict mode is enabled with role mappings', function () {
     Config::set('oauth.default_role', 'member');
-    Config::set('oauth.providers', []);
+    Config::set('oauth.providers.oidc', [
+        'enabled' => true,
+        'client_id' => 'id',
+        'client_secret' => 'secret',
+        'base_url' => 'https://idp.example.com',
+    ]);
     Config::set('oauth.role_mapping', [
         'claim' => 'groups',
         'admin' => 'my-admins',
+        'member' => '',
+        'viewer' => '',
+        'strict' => true,
+    ]);
+
+    $provider = new AppServiceProvider(app());
+
+    expect(fn () => $provider->performOAuthValidation())->not->toThrow(\InvalidArgumentException::class);
+});
+
+test('does not throw strict mode error when oidc is disabled', function () {
+    Config::set('oauth.default_role', 'member');
+    Config::set('oauth.providers', []);
+    Config::set('oauth.role_mapping', [
+        'claim' => 'groups',
+        'admin' => '',
         'member' => '',
         'viewer' => '',
         'strict' => true,


### PR DESCRIPTION
## Summary

Ref #167

- Map OIDC group claims to Databasement roles (`admin`, `member`, `viewer`) via env vars (`OAUTH_OIDC_ROLE_MAP_ADMIN`, etc.)
- Support comma-separated groups for many-to-one mapping (e.g., `OAUTH_OIDC_ROLE_MAP_ADMIN=devops,platform-admins`)
- Strict mode (`OAUTH_OIDC_ROLE_STRICT=true`) denies login when no group matches — including returning users whose groups were revoked
- Roles sync on every login, so changes in the IdP take effect immediately
- Only applies to the OIDC provider (Google/GitHub/GitLab are unaffected)

### New Environment Variables

| Variable | Default | Description |
| --- | --- | --- |
| `OAUTH_OIDC_SCOPES` | *(empty)* | Extra OIDC scopes to request (e.g., `groups`) |
| `OAUTH_OIDC_ROLE_CLAIM` | `groups` | JWT claim containing the user's groups |
| `OAUTH_OIDC_ROLE_MAP_ADMIN` | *(empty)* | IdP groups → admin role (comma-separated) |
| `OAUTH_OIDC_ROLE_MAP_MEMBER` | *(empty)* | IdP groups → member role (comma-separated) |
| `OAUTH_OIDC_ROLE_MAP_VIEWER` | *(empty)* | IdP groups → viewer role (comma-separated) |
| `OAUTH_OIDC_ROLE_STRICT` | `false` | Deny login when no group matches |

### Files Changed

- **`app/Services/OAuthService.php`** — Role resolution logic (`resolveOidcRole`, `syncUserRole`) integrated into user creation and returning-user flows
- **`app/Http/Controllers/Web/OAuthController.php`** — Dynamic OIDC scope injection from `OAUTH_OIDC_SCOPES`
- **`app/Providers/AppServiceProvider.php`** — Registers extra scopes, validates strict mode requires at least one mapping
- **`config/oauth.php`** — New `role_mapping` config section + `extra_scopes` on OIDC provider
- **`docker/dex/config.yaml`** — 4 test users with different groups for local testing
- **`docs/docs/self-hosting/configuration/sso.md`** — Full documentation with examples and env reference

## Test plan

- [x] 13 new test cases covering all role mapping scenarios (mapping each role, priority, strict mode, returning users, custom claims, non-OIDC fallback, comma-separated groups)
- [x] 2 new validation tests (strict mode without mappings, strict mode with mappings)
- [x] All 837 existing tests still pass
- [x] PHPStan clean, Pint formatted
- [x] Manual test with Dex: uncomment dex service, configure role mapping env vars, log in with different test users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic OIDC role assignment from IdP group claims (admin/member/viewer) with configurable mappings, precedence, and optional strict-mode to deny unmatched logins.
  * Ability to request additional OIDC scopes.
  * User role synchronization on return logins when group membership changes.
  * Validation to enforce strict role-mapping configuration when enabled.

* **Documentation**
  * Added detailed OIDC role-mapping configuration guide with examples.

* **Tests**
  * Added comprehensive OIDC role-mapping and strict-mode test coverage.

* **Chore**
  * Updated local test OIDC users and Docker image notes for testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->