### PR TITLE
feat: introduce x-radio-card component for selection inputs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,7 +415,7 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.18
+- php - 8.4.19
 - laravel/fortify (FORTIFY) - v1
 - laravel/framework (LARAVEL) - v12
 - laravel/mcp (MCP) - v0

--- a/app/Livewire/Forms/UserForm.php
+++ b/app/Livewire/Forms/UserForm.php
@@ -73,14 +73,14 @@ class UserForm extends Form
     }
 
     /**
-     * @return array<int, array<string, string>>
+     * @return array<int, array{id: string, name: string, description: string, icon: string}>
      */
     public function roleOptions(): array
     {
         return [
-            ['id' => User::ROLE_VIEWER, 'name' => __('Viewer'), 'description' => __('Read-only access to all resources')],
-            ['id' => User::ROLE_MEMBER, 'name' => __('Member'), 'description' => __('Full access except user management')],
-            ['id' => User::ROLE_ADMIN, 'name' => __('Admin'), 'description' => __('Full access including user management')],
+            ['id' => User::ROLE_VIEWER, 'name' => __('Viewer'), 'description' => __('Read-only access to all resources'), 'icon' => User::roleIcon(User::ROLE_VIEWER)],
+            ['id' => User::ROLE_MEMBER, 'name' => __('Member'), 'description' => __('Full access except user management'), 'icon' => User::roleIcon(User::ROLE_MEMBER)],
+            ['id' => User::ROLE_ADMIN, 'name' => __('Admin'), 'description' => __('Full access including user management'), 'icon' => User::roleIcon(User::ROLE_ADMIN)],
         ];
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -85,6 +85,17 @@ class User extends Authenticatable
         self::ROLE_ADMIN,
     ];
 
+    public static function roleIcon(string $role): string
+    {
+        return match ($role) {
+            self::ROLE_ADMIN => 'o-shield-check',
+            self::ROLE_MEMBER => 'o-pencil-square',
+            self::ROLE_VIEWER => 'o-eye',
+            self::ROLE_DEMO => 'o-beaker',
+            default => 'o-user',
+        };
+    }
+
     /**
      * The attributes that are mass assignable.
      *

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "ext-pdo": "*",
         "blade-ui-kit/blade-icons": "^1.8",
         "codeat3/blade-devicons": "^1.8",
+        "davidhsianturi/blade-bootstrap-icons": "^2.2",
         "dedoc/scramble": "^0.13.8",
         "kovah/laravel-socialite-oidc": "^0.6.0",
         "laravel-notification-channels/discord": "^1.7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cdbb4604e0e9047e2c62eb50511f994a",
+    "content-hash": "a71d1158c3c2a6a197bd13af03f954e4",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -612,6 +612,67 @@
                 "source": "https://github.com/DASPRiD/Enum/tree/1.0.7"
             },
             "time": "2025-09-16T12:23:56+00:00"
+        },
+        {
+            "name": "davidhsianturi/blade-bootstrap-icons",
+            "version": "v2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/davidhsianturi/blade-bootstrap-icons.git",
+                "reference": "6b6729e90e36c38e2c2f6bc557bba99c93a03db7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/davidhsianturi/blade-bootstrap-icons/zipball/6b6729e90e36c38e2c2f6bc557bba99c93a03db7",
+                "reference": "6b6729e90e36c38e2c2f6bc557bba99c93a03db7",
+                "shasum": ""
+            },
+            "require": {
+                "blade-ui-kit/blade-icons": "^1.6",
+                "illuminate/support": "^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^7.0|^8.0|^9.0|^10.1|^11.0",
+                "phpunit/phpunit": "^9.0|^10.5|^11.5|^12.5.12"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Davidhsianturi\\BladeBootstrapIcons\\BladeBootstrapIconsServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Davidhsianturi\\BladeBootstrapIcons\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "David H. Sianturi",
+                    "email": "davidhsianturi@gmail.com",
+                    "homepage": "https://davidhsianturi.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A package to easily make use of Bootstrap Icons in your Laravel Blade views.",
+            "homepage": "https://github.com/davidhsianturi/blade-bootstrap-icons",
+            "keywords": [
+                "Bootstrap Icons",
+                "blade",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/davidhsianturi/blade-bootstrap-icons/issues",
+                "source": "https://github.com/davidhsianturi/blade-bootstrap-icons/tree/v2.2.0"
+            },
+            "time": "2026-04-02T08:34:05+00:00"
         },
         {
             "name": "dedoc/scramble",
@@ -5897,27 +5958,27 @@
         },
         {
             "name": "robsontenorio/mary",
-            "version": "2.8.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robsontenorio/mary.git",
-                "reference": "726ad37fd0e4461b0a146be158fd3dd985a255e8"
+                "reference": "dc5394d91397e69b1008ee371c11d22d8370cbac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/726ad37fd0e4461b0a146be158fd3dd985a255e8",
-                "reference": "726ad37fd0e4461b0a146be158fd3dd985a255e8",
+                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/dc5394d91397e69b1008ee371c11d22d8370cbac",
+                "reference": "dc5394d91397e69b1008ee371c11d22d8370cbac",
                 "shasum": ""
             },
             "require": {
                 "blade-ui-kit/blade-heroicons": "^2.6",
-                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "jfcherng/php-diff": "^6.15",
                 "laravel/prompts": "^0|^1"
             },
             "require-dev": {
-                "orchestra/testbench": "^8|^9|^10",
-                "phpunit/phpunit": "^10|^11"
+                "orchestra/testbench": "^8|^9|^10|^11.0",
+                "phpunit/phpunit": "^10|^11|^12.5.12"
             },
             "type": "library",
             "extra": {
@@ -5971,7 +6032,7 @@
             ],
             "support": {
                 "issues": "https://github.com/robsontenorio/mary/issues",
-                "source": "https://github.com/robsontenorio/mary/tree/2.8.0"
+                "source": "https://github.com/robsontenorio/mary/tree/2.8.1"
             },
             "funding": [
                 {
@@ -5979,7 +6040,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-26T22:17:12+00:00"
+            "time": "2026-03-23T19:55:17+00:00"
         },
         {
             "name": "socialiteproviders/manager",

--- a/resources/views/components/database-type-icon.blade.php
+++ b/resources/views/components/database-type-icon.blade.php
@@ -1,8 +1,0 @@
-@props(['type', 'class' => 'w-5 h-5'])
-
-@php
-    $dbType = $type instanceof \App\Enums\DatabaseType ? $type : \App\Enums\DatabaseType::from($type);
-    $iconName = $dbType->icon();
-@endphp
-
-<x-icon :name="$iconName" {{ $attributes->merge(['class' => $class]) }} />

--- a/resources/views/components/icon-regex.blade.php
+++ b/resources/views/components/icon-regex.blade.php
@@ -1,3 +1,0 @@
-<svg {{ $attributes->merge(['xmlns' => 'http://www.w3.org/2000/svg', 'viewBox' => '0 0 24 24', 'fill' => 'none', 'stroke' => 'currentColor', 'stroke-width' => '2', 'stroke-linecap' => 'round', 'stroke-linejoin' => 'round']) }}>
-    <path d="M17 3v10" /><path d="m12.67 5.5 8.66 5" /><path d="m12.67 10.5 8.66-5" /><path d="M9 17a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v2a2 2 0 0 0 2 2h2a2 2 0 0 0 2-2v-2z" />
-</svg>

--- a/resources/views/components/radio-card-group.blade.php
+++ b/resources/views/components/radio-card-group.blade.php
@@ -1,0 +1,9 @@
+@props(['label' => null])
+
+<div
+    role="radiogroup"
+    @if($label) aria-label="{{ $label }}" @endif
+    {{ $attributes->merge(['class' => 'grid gap-2 rounded-xl bg-base-200 p-2']) }}
+>
+    {{ $slot }}
+</div>

--- a/resources/views/components/radio-card.blade.php
+++ b/resources/views/components/radio-card.blade.php
@@ -7,76 +7,37 @@
     'horizontal' => false,
     'disabled' => false,
     'value' => null,
+    'name' => null,
 ])
 
 @php
-    $colorMap = [
-        'primary' => [
-            'ring' => 'ring-primary/40',
-            'iconBg' => 'bg-primary/10',
-            'iconText' => 'text-primary',
-            'check' => 'text-primary',
-        ],
-        'info' => [
-            'ring' => 'ring-info/40',
-            'iconBg' => 'bg-info/10',
-            'iconText' => 'text-info',
-            'check' => 'text-info',
-        ],
-        'success' => [
-            'ring' => 'ring-success/40',
-            'iconBg' => 'bg-success/10',
-            'iconText' => 'text-success',
-            'check' => 'text-success',
-        ],
-        'warning' => [
-            'ring' => 'ring-warning/40',
-            'iconBg' => 'bg-warning/10',
-            'iconText' => 'text-warning',
-            'check' => 'text-warning',
-        ],
-        'error' => [
-            'ring' => 'ring-error/40',
-            'iconBg' => 'bg-error/10',
-            'iconText' => 'text-error',
-            'check' => 'text-error',
-        ],
-        'default' => [
-            'ring' => 'ring-base-300',
-            'iconBg' => 'bg-base-300',
-            'iconText' => 'text-base-content/70',
-            'check' => 'text-base-content',
-        ],
+    // Per-color Tailwind classes. Listed as literals so Tailwind's JIT scanner picks them up.
+    [$activeRing, $activeIconBg, $activeText] = match ($color) {
+        'info'    => ['ring-info/40',    'bg-info/10',    'text-info'],
+        'success' => ['ring-success/40', 'bg-success/10', 'text-success'],
+        'warning' => ['ring-warning/40', 'bg-warning/10', 'text-warning'],
+        'error'   => ['ring-error/40',   'bg-error/10',   'text-error'],
+        'default' => ['ring-base-300',   'bg-base-300',   'text-base-content/70'],
+        default   => ['ring-primary/40', 'bg-primary/10', 'text-primary'],
+    };
+
+    // Native radio group name; falls back to the wire:model target so callers don't repeat it.
+    $wireModelAttrs = $attributes->whereStartsWith('wire:model')->getAttributes();
+    $resolvedName = $name ?? (empty($wireModelAttrs) ? null : reset($wireModelAttrs));
+
+    $labelClasses = [
+        'relative rounded-lg transition-all px-3 py-3',
+        $horizontal ? 'flex items-center gap-3 text-left' : 'flex flex-col items-center gap-1.5 text-center',
+        $active ? "bg-base-100 shadow-sm ring-1 {$activeRing}" : 'hover:bg-base-100/50',
+        $disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
+        'has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-primary has-[:focus-visible]:ring-offset-2 has-[:focus-visible]:ring-offset-base-200',
     ];
-    $c = $colorMap[$color] ?? $colorMap['primary'];
-
-    $cardClasses = $active
-        ? 'bg-base-100 shadow-sm ring-1 '.$c['ring']
-        : ($disabled ? '' : 'hover:bg-base-100/50');
-
-    if ($disabled) {
-        $cardClasses .= ' opacity-50 cursor-not-allowed';
-    } else {
-        $cardClasses .= ' cursor-pointer';
-    }
-
-    $iconChipClasses = $active
-        ? $c['iconBg'].' '.$c['iconText']
-        : 'bg-base-100 text-base-content/60';
-
-    $labelColor = $active ? 'text-base-content' : 'text-base-content/70';
-    $hintColor = $active ? 'text-base-content/60' : 'text-base-content/40';
-
-    $layoutClasses = $horizontal
-        ? 'flex items-center gap-3 text-left px-3 py-3'
-        : 'flex flex-col items-center gap-1.5 text-center px-3 py-3';
 @endphp
 
-<label
-    {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => 'relative rounded-lg transition-all '.$layoutClasses.' '.$cardClasses]) }}
->
+<label {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => implode(' ', $labelClasses)]) }}>
     <input
         type="radio"
+        @if($resolvedName) name="{{ $resolvedName }}" @endif
         value="{{ $value }}"
         @checked($active)
         @disabled($disabled)
@@ -85,22 +46,19 @@
     />
 
     @if($icon)
-        <span class="shrink-0 rounded-md p-1.5 {{ $iconChipClasses }}">
+        <span class="shrink-0 rounded-md p-1.5 {{ $active ? "{$activeIconBg} {$activeText}" : 'bg-base-100 text-base-content/60' }}">
             <x-icon :name="$icon" class="w-5 h-5" />
         </span>
     @endif
 
     <span class="{{ $horizontal ? 'flex-1 min-w-0' : 'block' }}">
-        <span class="block text-sm font-semibold leading-tight {{ $labelColor }}">{{ $label }}</span>
+        <span class="block text-sm font-semibold leading-tight {{ $active ? 'text-base-content' : 'text-base-content/70' }}">{{ $label }}</span>
         @if($hint)
-            <span class="block text-xs mt-0.5 leading-snug {{ $hintColor }}">{{ $hint }}</span>
+            <span class="block text-xs mt-0.5 leading-snug {{ $active ? 'text-base-content/60' : 'text-base-content/40' }}">{{ $hint }}</span>
         @endif
     </span>
 
     @if($active)
-        <x-icon
-            name="s-check-circle"
-            class="w-4 h-4 {{ $c['check'] }} {{ $horizontal ? 'shrink-0' : 'absolute top-2 right-2' }}"
-        />
+        <x-icon name="s-check-circle" class="w-4 h-4 {{ $activeText }} {{ $horizontal ? 'shrink-0' : 'absolute top-2 right-2' }}" />
     @endif
 </label>

--- a/resources/views/components/radio-card.blade.php
+++ b/resources/views/components/radio-card.blade.php
@@ -1,0 +1,106 @@
+@props([
+    'active' => false,
+    'color' => 'primary',
+    'icon' => null,
+    'label',
+    'hint' => null,
+    'horizontal' => false,
+    'disabled' => false,
+    'value' => null,
+])
+
+@php
+    $colorMap = [
+        'primary' => [
+            'ring' => 'ring-primary/40',
+            'iconBg' => 'bg-primary/10',
+            'iconText' => 'text-primary',
+            'check' => 'text-primary',
+        ],
+        'info' => [
+            'ring' => 'ring-info/40',
+            'iconBg' => 'bg-info/10',
+            'iconText' => 'text-info',
+            'check' => 'text-info',
+        ],
+        'success' => [
+            'ring' => 'ring-success/40',
+            'iconBg' => 'bg-success/10',
+            'iconText' => 'text-success',
+            'check' => 'text-success',
+        ],
+        'warning' => [
+            'ring' => 'ring-warning/40',
+            'iconBg' => 'bg-warning/10',
+            'iconText' => 'text-warning',
+            'check' => 'text-warning',
+        ],
+        'error' => [
+            'ring' => 'ring-error/40',
+            'iconBg' => 'bg-error/10',
+            'iconText' => 'text-error',
+            'check' => 'text-error',
+        ],
+        'default' => [
+            'ring' => 'ring-base-300',
+            'iconBg' => 'bg-base-300',
+            'iconText' => 'text-base-content/70',
+            'check' => 'text-base-content',
+        ],
+    ];
+    $c = $colorMap[$color] ?? $colorMap['primary'];
+
+    $cardClasses = $active
+        ? 'bg-base-100 shadow-sm ring-1 '.$c['ring']
+        : ($disabled ? '' : 'hover:bg-base-100/50');
+
+    if ($disabled) {
+        $cardClasses .= ' opacity-50 cursor-not-allowed';
+    } else {
+        $cardClasses .= ' cursor-pointer';
+    }
+
+    $iconChipClasses = $active
+        ? $c['iconBg'].' '.$c['iconText']
+        : 'bg-base-100 text-base-content/60';
+
+    $labelColor = $active ? 'text-base-content' : 'text-base-content/70';
+    $hintColor = $active ? 'text-base-content/60' : 'text-base-content/40';
+
+    $layoutClasses = $horizontal
+        ? 'flex items-center gap-3 text-left px-3 py-3'
+        : 'flex flex-col items-center gap-1.5 text-center px-3 py-3';
+@endphp
+
+<label
+    {{ $attributes->whereDoesntStartWith('wire:model')->merge(['class' => 'relative rounded-lg transition-all '.$layoutClasses.' '.$cardClasses]) }}
+>
+    <input
+        type="radio"
+        value="{{ $value }}"
+        @checked($active)
+        @disabled($disabled)
+        class="sr-only"
+        {{ $attributes->whereStartsWith('wire:model') }}
+    />
+
+    @if($icon)
+        <span class="shrink-0 rounded-md p-1.5 {{ $iconChipClasses }}">
+            <x-icon :name="$icon" class="w-5 h-5" />
+        </span>
+    @endif
+
+    <span class="{{ $horizontal ? 'flex-1 min-w-0' : 'block' }}">
+        <span class="block text-sm font-semibold leading-tight {{ $labelColor }}">{{ $label }}</span>
+        @if($hint)
+            <span class="block text-xs mt-0.5 leading-snug {{ $hintColor }}">{{ $hint }}</span>
+        @endif
+    </span>
+
+    @if($active)
+        <x-icon
+            name="s-check-circle"
+            class="w-4 h-4 {{ $c['check'] }} {{ $horizontal ? 'shrink-0' : 'absolute top-2 right-2' }}"
+        />
+    @endif
+</label>

--- a/resources/views/livewire/backup-job/_logs-modal.blade.php
+++ b/resources/views/livewire/backup-job/_logs-modal.blade.php
@@ -12,9 +12,9 @@
                     {{-- Left: Icon + Job info --}}
                     <div class="flex items-center gap-3">
                         @if($this->selectedJob->snapshot)
-                            <x-database-type-icon :type="$this->selectedJob->snapshot->database_type" class="w-6 h-6 shrink-0" />
+                            <x-icon :name="$this->selectedJob->snapshot->database_type->icon()" class="w-6 h-6 shrink-0" />
                         @elseif($this->selectedJob->restore?->snapshot)
-                            <x-database-type-icon :type="$this->selectedJob->restore->snapshot->database_type" class="w-6 h-6 shrink-0" />
+                            <x-icon :name="$this->selectedJob->restore->snapshot->database_type->icon()" class="w-6 h-6 shrink-0" />
                         @endif
                         <div class="min-w-0">
                             <div class="text-sm text-base-content/70">

--- a/resources/views/livewire/backup-job/index.blade.php
+++ b/resources/views/livewire/backup-job/index.blade.php
@@ -52,7 +52,7 @@
             @scope('cell_server', $job)
                 @if($job->snapshot && $job->snapshot->databaseServer)
                     <div class="flex items-center gap-2">
-                        <x-database-type-icon :type="$job->snapshot->database_type" />
+                        <x-icon :name="$job->snapshot->database_type->icon()" class="w-5 h-5" />
                         <div>
                             <div class="table-cell-primary">{{ $job->snapshot->databaseServer->name }}</div>
                             <div class="text-sm text-base-content/70">{{ $job->snapshot->database_name }}</div>
@@ -61,7 +61,7 @@
                 @elseif($job->restore && $job->restore->targetServer)
                     <div class="flex items-center gap-2">
                         @if($job->restore->snapshot)
-                            <x-database-type-icon :type="$job->restore->snapshot->database_type" />
+                            <x-icon :name="$job->restore->snapshot->database_type->icon()" class="w-5 h-5" />
                         @endif
                         <div>
                             <div class="table-cell-primary">{{ $job->restore->targetServer->name }} (Target)</div>

--- a/resources/views/livewire/dashboard/latest-jobs.blade.php
+++ b/resources/views/livewire/dashboard/latest-jobs.blade.php
@@ -37,12 +37,12 @@
                                 {{-- Server Name (icon visible on desktop only in line 1) --}}
                                 <div class="flex items-center gap-2 flex-1 min-w-0">
                                     @if($job->snapshot && $job->snapshot->databaseServer)
-                                        <x-database-type-icon :type="$job->snapshot->database_type" class="w-4 h-4 shrink-0 hidden sm:block" />
+                                        <x-icon :name="$job->snapshot->database_type->icon()" class="w-4 h-4 shrink-0 hidden sm:block" />
                                         <span class="truncate text-sm font-medium">{{ $job->snapshot->databaseServer->name }}</span>
                                         <span class="text-xs text-base-content/50 truncate hidden sm:inline">{{ $job->snapshot->database_name }}</span>
                                     @elseif($job->restore && $job->restore->targetServer)
                                         @if($job->restore->snapshot)
-                                            <x-database-type-icon :type="$job->restore->snapshot->database_type" class="w-4 h-4 shrink-0 hidden sm:block" />
+                                            <x-icon :name="$job->restore->snapshot->database_type->icon()" class="w-4 h-4 shrink-0 hidden sm:block" />
                                         @endif
                                         <span class="truncate text-sm font-medium">{{ $job->restore->targetServer->name }}</span>
                                         <span class="text-xs text-base-content/50 truncate hidden sm:inline">{{ $job->restore->schema_name }}</span>
@@ -69,11 +69,11 @@
                             {{-- Line 2 on mobile: DB icon + name + time + logs --}}
                             <div class="flex items-center gap-2 sm:hidden text-base-content/70">
                                 @if($job->snapshot && $job->snapshot->databaseServer)
-                                    <x-database-type-icon :type="$job->snapshot->database_type" class="w-4 h-4 shrink-0" />
+                                    <x-icon :name="$job->snapshot->database_type->icon()" class="w-4 h-4 shrink-0" />
                                     <span class="text-xs truncate flex-1">{{ $job->snapshot->database_name }}</span>
                                 @elseif($job->restore && $job->restore->targetServer)
                                     @if($job->restore->snapshot)
-                                        <x-database-type-icon :type="$job->restore->snapshot->database_type" class="w-4 h-4 shrink-0" />
+                                        <x-icon :name="$job->restore->snapshot->database_type->icon()" class="w-4 h-4 shrink-0" />
                                     @endif
                                     <span class="text-xs truncate flex-1">{{ $job->restore->schema_name }}</span>
                                 @endif

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -335,7 +335,7 @@ use App\Enums\DatabaseType;
 
                 <div class="space-y-4">
                     <!-- Segmented Control -->
-                    <x-radio-card-group class="grid-cols-3" :label="__('Database selection mode')">
+                    <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Database selection mode')">
                         <x-radio-card
                             :active="$form->database_selection_mode === DatabaseSelectionMode::All->value"
                             icon="o-circle-stack"

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -105,22 +105,17 @@ use App\Enums\DatabaseType;
                 <!-- Database Type Selection -->
                 <div>
                     <label class="label label-text font-semibold mb-2">{{ __('Database Type') }}</label>
-                    <div class="grid grid-cols-2 sm:grid-cols-5 gap-2">
+                    <x-radio-card-group class="grid-cols-2 sm:grid-cols-5" :label="__('Database Type')">
                         @foreach(DatabaseType::cases() as $dbType)
-                            @php
-                                $isSelected = $form->database_type === $dbType->value;
-                                $buttonClass = $isSelected ? 'btn-primary' : 'btn-outline';
-                            @endphp
-                            <button
-                                type="button"
-                                wire:click="$set('form.database_type', '{{ $dbType->value }}')"
-                                class="btn justify-start gap-2 h-auto py-3 {{ $buttonClass }}"
-                            >
-                                <x-database-type-icon :type="$dbType" class="w-5 h-5" />
-                                <span>{{ $dbType->label() }}</span>
-                            </button>
+                            <x-radio-card
+                                :active="$form->database_type === $dbType->value"
+                                :icon="$dbType->icon()"
+                                :label="$dbType->label()"
+                                :value="$dbType->value"
+                                wire:model.live="form.database_type"
+                            />
                         @endforeach
-                    </div>
+                    </x-radio-card-group>
                 </div>
 
                 @if($form->database_type)
@@ -340,31 +335,32 @@ use App\Enums\DatabaseType;
 
                 <div class="space-y-4">
                     <!-- Segmented Control -->
-                    @php
-                        $modes = [
-                            DatabaseSelectionMode::All->value => ['icon' => 'o-circle-stack', 'label' => __('All Databases'), 'hint' => __('Backup everything')],
-                            DatabaseSelectionMode::Selected->value => ['icon' => 'o-check-badge', 'label' => __('Selected'), 'hint' => __('Pick specific ones')],
-                            DatabaseSelectionMode::Pattern->value => ['icon' => null, 'label' => __('Pattern'), 'hint' => __('Match by regex')],
-                        ];
-                    @endphp
-                    <div class="grid grid-cols-3 gap-2 rounded-xl bg-base-200 p-2">
-                        @foreach($modes as $mode => $opt)
-                            @php $isActive = $form->database_selection_mode === $mode; @endphp
-                            <button
-                                type="button"
-                                wire:click="$set('form.database_selection_mode', '{{ $mode }}')"
-                                class="flex flex-col items-center gap-1 rounded-lg px-3 py-3 text-center transition-all cursor-pointer {{ $isActive ? 'bg-base-100 shadow-sm ring-1 ring-base-300' : 'hover:bg-base-100/50' }}"
-                            >
-                                @if($opt['icon'])
-                                    <x-icon :name="$opt['icon']" class="w-5 h-5 {{ $isActive ? 'text-base-content' : 'text-base-content/50' }}" />
-                                @else
-                                    <x-icon-regex class="w-5 h-5 {{ $isActive ? 'text-base-content' : 'text-base-content/50' }}" />
-                                @endif
-                                <span class="text-sm font-semibold {{ $isActive ? 'text-base-content' : 'text-base-content/70' }}">{{ $opt['label'] }}</span>
-                                <span class="text-xs {{ $isActive ? 'text-base-content/60' : 'text-base-content/40' }}">{{ $opt['hint'] }}</span>
-                            </button>
-                        @endforeach
-                    </div>
+                    <x-radio-card-group class="grid-cols-3" :label="__('Database selection mode')">
+                        <x-radio-card
+                            :active="$form->database_selection_mode === DatabaseSelectionMode::All->value"
+                            icon="o-circle-stack"
+                            :label="__('All Databases')"
+                            :hint="__('Backup everything')"
+                            :value="DatabaseSelectionMode::All->value"
+                            wire:model.live="form.database_selection_mode"
+                        />
+                        <x-radio-card
+                            :active="$form->database_selection_mode === DatabaseSelectionMode::Selected->value"
+                            icon="o-check-badge"
+                            :label="__('Selected')"
+                            :hint="__('Pick specific ones')"
+                            :value="DatabaseSelectionMode::Selected->value"
+                            wire:model.live="form.database_selection_mode"
+                        />
+                        <x-radio-card
+                            :active="$form->database_selection_mode === DatabaseSelectionMode::Pattern->value"
+                            icon="bi.regex"
+                            :label="__('Pattern')"
+                            :hint="__('Match by regex')"
+                            :value="DatabaseSelectionMode::Pattern->value"
+                            wire:model.live="form.database_selection_mode"
+                        />
+                    </x-radio-card-group>
 
                     <!-- All Databases Panel -->
                     @if($form->database_selection_mode === DatabaseSelectionMode::All->value)
@@ -659,7 +655,7 @@ use App\Enums\DatabaseType;
                         'all' => ['icon' => 'o-bell-alert', 'label' => __('All events'), 'hint' => __('Success & failure'), 'color' => 'info'],
                         'success' => ['icon' => 'o-check-circle', 'label' => __('Success only'), 'hint' => __('Completed backups'), 'color' => 'success'],
                         'failure' => ['icon' => 'o-exclamation-triangle', 'label' => __('Failure only'), 'hint' => __('Errors & timeouts'), 'color' => 'error'],
-                        'none' => ['icon' => 'o-bell-slash', 'label' => __('Disabled'), 'hint' => __('No notifications'), 'color' => 'muted'],
+                        'none' => ['icon' => 'o-bell-slash', 'label' => __('Disabled'), 'hint' => __('No notifications'), 'color' => 'default'],
                     ];
                 @endphp
 
@@ -670,49 +666,19 @@ use App\Enums\DatabaseType;
                             <p class="text-sm font-semibold">{{ __('Notify me on') }}</p>
                             <p class="text-xs text-base-content/60">{{ __('When should this server send a notification?') }}</p>
                         </div>
-                        <div class="grid grid-cols-2 sm:grid-cols-4 gap-3" role="radiogroup" aria-label="{{ __('Notification trigger') }}">
+                        <x-radio-card-group class="grid-cols-2 sm:grid-cols-4" :label="__('Notification trigger')">
                             @foreach($triggerOptions as $value => $opt)
-                                @php
-                                    $isActive = $form->notification_trigger === $value;
-                                    $activeClasses = match ($opt['color']) {
-                                        'info' => 'border-info bg-info/5',
-                                        'success' => 'border-success bg-success/5',
-                                        'error' => 'border-error bg-error/5',
-                                        default => 'border-base-content/30 bg-base-200',
-                                    };
-                                    $iconClasses = $isActive ? match ($opt['color']) {
-                                        'info' => 'bg-info/10 text-info',
-                                        'success' => 'bg-success/10 text-success',
-                                        'error' => 'bg-error/10 text-error',
-                                        default => 'bg-base-300 text-base-content/60',
-                                    } : 'bg-base-200 text-base-content/60';
-                                    $checkClasses = match ($opt['color']) {
-                                        'info' => 'text-info',
-                                        'success' => 'text-success',
-                                        'error' => 'text-error',
-                                        default => 'text-base-content/60',
-                                    };
-                                @endphp
-                                <button
-                                    type="button"
-                                    role="radio"
-                                    aria-checked="{{ $isActive ? 'true' : 'false' }}"
-                                    wire:click="$set('form.notification_trigger', '{{ $value }}')"
-                                    class="relative flex flex-col items-start gap-2.5 rounded-lg border-2 p-4 text-left transition-all cursor-pointer {{ $isActive ? $activeClasses.' shadow-sm' : 'border-base-300 bg-base-100 hover:bg-base-200' }}"
-                                >
-                                    @if($isActive)
-                                        <x-icon name="s-check-circle" class="absolute top-2.5 right-2.5 w-4 h-4 {{ $checkClasses }}" />
-                                    @endif
-                                    <span class="rounded-md p-1.5 {{ $iconClasses }}">
-                                        <x-icon :name="$opt['icon']" class="w-5 h-5" />
-                                    </span>
-                                    <span class="block">
-                                        <span class="block text-sm font-semibold leading-tight">{{ $opt['label'] }}</span>
-                                        <span class="block text-xs text-base-content/60 leading-snug mt-0.5">{{ $opt['hint'] }}</span>
-                                    </span>
-                                </button>
+                                <x-radio-card
+                                    :active="$form->notification_trigger === $value"
+                                    :color="$opt['color']"
+                                    :icon="$opt['icon']"
+                                    :label="$opt['label']"
+                                    :hint="$opt['hint']"
+                                    :value="$value"
+                                    wire:model.live="form.notification_trigger"
+                                />
                             @endforeach
-                        </div>
+                        </x-radio-card-group>
                     </div>
 
                     <!-- Channel selection (hidden when disabled) -->
@@ -744,39 +710,33 @@ use App\Enums\DatabaseType;
                                     <p class="text-sm font-semibold">{{ __('Send to') }}</p>
                                     <p class="text-xs text-base-content/60">{{ __('Target one or all of your notification channels.') }}</p>
                                 </div>
-                                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                                    @php
-                                        $modeOptions = [
-                                            'all' => [
-                                                'icon' => 'o-user-group',
-                                                'label' => __('All channels'),
-                                                'hint' => __(':count configured', ['count' => $notificationChannels->count()]),
-                                            ],
-                                            'selected' => [
-                                                'icon' => 'o-adjustments-horizontal',
-                                                'label' => __('Specific channels'),
-                                                'hint' => __('Pick individual channels'),
-                                            ],
-                                        ];
-                                    @endphp
+                                @php
+                                    $modeOptions = [
+                                        'all' => [
+                                            'icon' => 'o-user-group',
+                                            'label' => __('All channels'),
+                                            'hint' => __(':count configured', ['count' => $notificationChannels->count()]),
+                                        ],
+                                        'selected' => [
+                                            'icon' => 'o-adjustments-horizontal',
+                                            'label' => __('Specific channels'),
+                                            'hint' => __('Pick individual channels'),
+                                        ],
+                                    ];
+                                @endphp
+                                <x-radio-card-group class="grid-cols-1 sm:grid-cols-2" :label="__('Send to')">
                                     @foreach($modeOptions as $value => $opt)
-                                        @php $isActive = $form->notification_channel_selection === $value; @endphp
-                                        <button
-                                            type="button"
-                                            wire:click="$set('form.notification_channel_selection', '{{ $value }}')"
-                                            class="flex items-center gap-3 rounded-lg border-2 px-4 py-3 text-left transition-all cursor-pointer {{ $isActive ? 'border-primary bg-primary/5 shadow-sm' : 'border-base-300 bg-base-100 hover:bg-base-200' }}"
-                                        >
-                                            <x-icon :name="$opt['icon']" class="w-5 h-5 shrink-0 {{ $isActive ? 'text-primary' : 'text-base-content/60' }}" />
-                                            <span class="flex-1 min-w-0">
-                                                <span class="block text-sm font-semibold">{{ $opt['label'] }}</span>
-                                                <span class="block text-xs text-base-content/60 mt-0.5">{{ $opt['hint'] }}</span>
-                                            </span>
-                                            @if($isActive)
-                                                <x-icon name="s-check-circle" class="w-5 h-5 text-primary shrink-0" />
-                                            @endif
-                                        </button>
+                                        <x-radio-card
+                                            :active="$form->notification_channel_selection === $value"
+                                            :icon="$opt['icon']"
+                                            :label="$opt['label']"
+                                            :hint="$opt['hint']"
+                                            :value="$value"
+                                            horizontal
+                                            wire:model.live="form.notification_channel_selection"
+                                        />
                                     @endforeach
-                                </div>
+                                </x-radio-card-group>
                             </div>
 
                             <!-- Channel picker (when 'selected') -->

--- a/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
+++ b/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
@@ -113,24 +113,26 @@
                     <label class="label">
                         <span class="label-text font-medium">{{ __('Authentication Method') }}</span>
                     </label>
-                    <div class="flex flex-wrap gap-2">
-                        <label class="cursor-pointer">
-                            <input type="radio" name="ssh_auth_type" value="password"
-                                   wire:model.live="form.ssh_auth_type" class="peer hidden">
-                            <div class="btn btn-sm peer-checked:btn-primary peer-checked:btn-active btn-outline gap-2">
-                                <x-icon name="o-key" class="w-4 h-4" />
-                                {{ __('Password') }}
-                            </div>
-                        </label>
-                        <label class="cursor-pointer">
-                            <input type="radio" name="ssh_auth_type" value="key"
-                                   wire:model.live="form.ssh_auth_type" class="peer hidden">
-                            <div class="btn btn-sm peer-checked:btn-primary peer-checked:btn-active btn-outline gap-2">
-                                <x-icon name="o-finger-print" class="w-4 h-4" />
-                                {{ __('Private Key') }}
-                            </div>
-                        </label>
-                    </div>
+                    <x-radio-card-group class="grid-cols-1 sm:grid-cols-2" :label="__('Authentication Method')">
+                        <x-radio-card
+                            :active="$form->ssh_auth_type === 'password'"
+                            icon="o-key"
+                            :label="__('Password')"
+                            :hint="__('Authenticate with a password')"
+                            value="password"
+                            horizontal
+                            wire:model.live="form.ssh_auth_type"
+                        />
+                        <x-radio-card
+                            :active="$form->ssh_auth_type === 'key'"
+                            icon="o-finger-print"
+                            :label="__('Private Key')"
+                            :hint="__('Authenticate with an SSH key')"
+                            value="key"
+                            horizontal
+                            wire:model.live="form.ssh_auth_type"
+                        />
+                    </x-radio-card-group>
                 </div>
 
                 @if($form->ssh_auth_type === 'password')

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -55,7 +55,7 @@
             @scope('cell_name', $server)
                 <div class="flex items-center gap-2">
                     <div class="relative inline-flex">
-                        <x-database-type-icon :type="$server->database_type" class="w-6 h-6" />
+                        <x-icon :name="$server->database_type->icon()" class="w-6 h-6" />
                         <div class="absolute -top-1 -right-1">
                             <livewire:database-server.connection-status :server="$server" lazy :key="'conn-'.$server->id" />
                         </div>

--- a/resources/views/livewire/user/create.blade.php
+++ b/resources/views/livewire/user/create.blade.php
@@ -24,21 +24,21 @@
                 required
             />
 
-            <x-select
-                wire:model="form.role"
-                label="{{ __('Role') }}"
-                :options="$roleOptions"
-                icon="o-shield-check"
-                required
-            />
-
-            <div class="bg-base-200 p-4 rounded-lg">
-                <h4 class="font-medium mb-2">{{ __('Role Permissions') }}</h4>
-                <ul class="text-sm space-y-1 text-base-content/70">
-                    <li><strong>{{ __('Viewer') }}:</strong> {{ __('Read-only access to all index pages and details. Cannot perform any actions.') }}</li>
-                    <li><strong>{{ __('Member') }}:</strong> {{ __('Full access to create, edit, and delete resources. Cannot manage users.') }}</li>
-                    <li><strong>{{ __('Admin') }}:</strong> {{ __('Full access to everything, including user management.') }}</li>
-                </ul>
+            <div>
+                <label class="label label-text font-semibold mb-2">{{ __('Role') }}</label>
+                <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Role')">
+                    @foreach($roleOptions as $option)
+                        <x-radio-card
+                            :active="$form->role === $option['id']"
+                            :icon="$option['icon']"
+                            :label="$option['name']"
+                            :hint="$option['description']"
+                            :value="$option['id']"
+                            horizontal
+                            wire:model.live="form.role"
+                        />
+                    @endforeach
+                </x-radio-card-group>
             </div>
 
             <div class="flex justify-end gap-3">

--- a/resources/views/livewire/user/edit.blade.php
+++ b/resources/views/livewire/user/edit.blade.php
@@ -30,15 +30,29 @@
                 required
             />
 
-            <x-select
-                wire:model="form.role"
-                label="{{ __('Role') }}"
-                :options="$roleOptions"
-                icon="o-shield-check"
-                required
-            />
+            @php
+                $isOnlyAdmin = $form->user->isAdmin() && \App\Models\User::where('role', 'admin')->count() === 1;
+            @endphp
 
-            @if($form->user->isAdmin() && \App\Models\User::where('role', 'admin')->count() === 1)
+            <div>
+                <label class="label label-text font-semibold mb-2">{{ __('Role') }}</label>
+                <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Role')">
+                    @foreach($roleOptions as $option)
+                        <x-radio-card
+                            :active="$form->role === $option['id']"
+                            :icon="$option['icon']"
+                            :label="$option['name']"
+                            :hint="$option['description']"
+                            :value="$option['id']"
+                            :disabled="$isOnlyAdmin && $option['id'] !== \App\Models\User::ROLE_ADMIN"
+                            horizontal
+                            wire:model.live="form.role"
+                        />
+                    @endforeach
+                </x-radio-card-group>
+            </div>
+
+            @if($isOnlyAdmin)
                 <x-alert class="alert-warning" icon="o-exclamation-triangle">
                     {{ __('This is the only administrator. The role cannot be changed.') }}
                 </x-alert>

--- a/resources/views/livewire/user/index.blade.php
+++ b/resources/views/livewire/user/index.blade.php
@@ -54,7 +54,7 @@
                         default => 'badge-ghost',
                     };
                 @endphp
-                <x-badge :value="ucfirst($user->role)" class="{{ $roleClass }}" />
+                <x-badge :value="ucfirst($user->role)" :icon="\App\Models\User::roleIcon($user->role)" class="{{ $roleClass }}" />
             @endscope
 
             @scope('cell_status', $user)

--- a/resources/views/livewire/volume/_form.blade.php
+++ b/resources/views/livewire/volume/_form.blade.php
@@ -21,28 +21,18 @@ use App\Enums\VolumeType;
         @php $typeDisabled = $readonly || $form->volume !== null; @endphp
         <div>
             <label class="label label-text font-semibold mb-2">{{ __('Storage Type') }}</label>
-            <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            <x-radio-card-group class="grid-cols-2 sm:grid-cols-4" :label="__('Storage Type')">
                 @foreach(VolumeType::cases() as $volumeType)
-                    @php
-                        $isSelected = $form->type === $volumeType->value;
-                        $buttonClass = match(true) {
-                            $isSelected && $typeDisabled => 'btn-primary opacity-70 cursor-not-allowed border-2 border-primary',
-                            $isSelected => 'btn-primary',
-                            $typeDisabled => 'btn-outline opacity-40 cursor-not-allowed',
-                            default => 'btn-outline',
-                        };
-                    @endphp
-                    <button
-                        type="button"
-                        wire:click="$set('form.type', '{{ $volumeType->value }}')"
-                        @if($typeDisabled) disabled @endif
-                        class="btn justify-start gap-2 h-auto py-3 {{ $buttonClass }}"
-                    >
-                        <x-volume-type-icon :type="$volumeType" class="w-5 h-5" />
-                        <span>{{ $volumeType->label() }}</span>
-                    </button>
+                    <x-radio-card
+                        :active="$form->type === $volumeType->value"
+                        :icon="$volumeType->icon()"
+                        :label="$volumeType->label()"
+                        :value="$volumeType->value"
+                        :disabled="$typeDisabled"
+                        wire:model.live="form.type"
+                    />
                 @endforeach
-            </div>
+            </x-radio-card-group>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

- New reusable `<x-radio-card>` / `<x-radio-card-group>` component built on top of a native `<input type="radio">` so callers use `wire:model.live` directly. Supports daisyUI color variants, optional icon (heroicon or any blade-icons prefix like `bi.regex`), hint text, horizontal layout, and a disabled state.
- Replaces ad-hoc radio-style button groups across the app with a single consistent component.
- Drops two thin icon wrappers (`x-icon-regex`, `x-database-type-icon`) in favor of inline `<x-icon :name="enum->icon()">`.

## Refactored callsites

- **DatabaseServer form** — database type, selection mode, notification trigger (per-trigger color), channel selection mode (horizontal)
- **DatabaseServer SSH tunnel** — authentication method (Password / Private Key)
- **Volume form** — storage type (preserves immutable-after-creation via `disabled` prop)
- **User create / edit** — role picker; edit page now disables non-admin cards when editing the only admin
- **User index** — role badge now shows the role icon via Mary 2.8.1's new `<x-badge :icon="...">` prop

## Other touches

- Added `User::roleIcon(string $role): string` helper, used by both `UserForm::roleOptions()` and the user index, so the icon mapping has a single source of truth.
- Bumped `robsontenorio/mary` to `2.8.1` to pick up the badge `:icon` prop.

## Test plan

- [x] `make lint-fix`
- [x] `make phpstan`
- [x] `make test` — 841 passed (2535 assertions)
- [x] `npm run build`
- [ ] Manual: open create / edit DatabaseServer flow, click through each radio group (db type, selection mode, notify on, send to, ssh auth) and confirm visual + state behavior
- [ ] Manual: open Volume create form (cards interactive) and edit form (cards disabled but selected card highlighted)
- [ ] Manual: open Users create / edit, switch role, confirm warning + disabled cards on the only-admin edge case
- [ ] Manual: confirm role icon shows next to the badge in the user index

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Bootstrap icons and added role icons across the UI.
  * Introduced radio-card group and radio-card components for richer selection controls.

* **Bug Fixes & Improvements**
  * Replaced multiple inline pickers with unified radio-card controls (database, storage, SSH auth, notifications, user roles).
  * Standardized icon rendering across servers, backups, dashboards, and lists for consistent visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->