### PR TITLE
fix: don't require notification channels when trigger is disabled

### DIFF
--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -666,7 +666,10 @@ class DatabaseServerForm extends Form
             'dump_flags' => ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'],
             'notification_trigger' => ['required', 'string', Rule::in(array_column(NotificationTrigger::cases(), 'value'))],
             'notification_channel_selection' => ['required', 'string', Rule::in(array_column(NotificationChannelSelection::cases(), 'value'))],
-            'notification_channel_ids' => ['array', Rule::requiredIf($this->notification_channel_selection === NotificationChannelSelection::Selected->value)],
+            'notification_channel_ids' => ['array', Rule::requiredIf(
+                $this->notification_trigger !== NotificationTrigger::None->value
+                && $this->notification_channel_selection === NotificationChannelSelection::Selected->value
+            )],
             'notification_channel_ids.*' => ['string', 'exists:notification_channels,id'],
         ];
     }

--- a/tests/Feature/DatabaseServer/EditTest.php
+++ b/tests/Feature/DatabaseServer/EditTest.php
@@ -281,8 +281,26 @@ test('selected notification channel selection requires at least one channel', fu
 
     Livewire::actingAs($admin)
         ->test(Edit::class, ['server' => $server])
+        ->set('form.notification_trigger', 'failure')
         ->set('form.notification_channel_selection', 'selected')
         ->set('form.notification_channel_ids', [])
         ->call('save')
         ->assertHasErrors('form.notification_channel_ids');
+});
+
+test('notification channel selection is not required when trigger is disabled', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    NotificationChannel::factory()->email()->create();
+    $server = DatabaseServer::factory()->create();
+
+    // Previously: switching to "selected" then to "none" (disabled) left an
+    // invisible `notification_channel_ids` required error that blocked saving.
+    Livewire::actingAs($admin)
+        ->test(Edit::class, ['server' => $server])
+        ->set('form.notification_channel_selection', 'selected')
+        ->set('form.notification_channel_ids', [])
+        ->set('form.notification_trigger', 'none')
+        ->call('save')
+        ->assertHasNoErrors('form.notification_channel_ids')
+        ->assertRedirect(route('database-servers.index'));
 });

--- a/tests/Feature/DatabaseServer/EditTest.php
+++ b/tests/Feature/DatabaseServer/EditTest.php
@@ -274,24 +274,28 @@ test('admin can select notification channels for a database server', function ()
     expect($synced)->toBe(collect([$email->id, $slack->id])->sort()->values()->toArray());
 });
 
-test('selected notification channel selection requires at least one channel', function () {
+test('selected notification channel selection requires at least one channel', function (string $trigger) {
     $admin = User::factory()->create(['role' => 'admin']);
     NotificationChannel::factory()->email()->create();
-    $server = DatabaseServer::factory()->create();
+    $server = DatabaseServer::factory()->create(['database_names' => ['myapp']]);
 
     Livewire::actingAs($admin)
         ->test(Edit::class, ['server' => $server])
-        ->set('form.notification_trigger', 'failure')
+        ->set('form.notification_trigger', $trigger)
         ->set('form.notification_channel_selection', 'selected')
         ->set('form.notification_channel_ids', [])
         ->call('save')
         ->assertHasErrors('form.notification_channel_ids');
-});
+})->with([
+    'all events' => 'all',
+    'success only' => 'success',
+    'failure only' => 'failure',
+]);
 
 test('notification channel selection is not required when trigger is disabled', function () {
     $admin = User::factory()->create(['role' => 'admin']);
     NotificationChannel::factory()->email()->create();
-    $server = DatabaseServer::factory()->create();
+    $server = DatabaseServer::factory()->create(['database_names' => ['myapp']]);
 
     // Previously: switching to "selected" then to "none" (disabled) left an
     // invisible `notification_channel_ids` required error that blocked saving.


### PR DESCRIPTION
## Summary

- When a user picked **Specific channels** then switched the notification trigger to **Disabled**, the channel-selection UI was hidden but the `notification_channel_ids` required validation rule stayed active — producing an invisible error that silently blocked saving the form.
- Fix: only require `notification_channel_ids` when notifications are actually enabled (trigger ≠ `none`) AND the user chose the `selected` mode.

## Test plan

- [x] New regression test: `notification channel selection is not required when trigger is disabled` — reproduces the bug on `main` and passes with the fix
- [x] Existing regression test: `selected notification channel selection requires at least one channel` — still passes (now explicitly sets trigger to `failure` to assert the guard still fires when notifications are enabled)
- [x] `make test` — 842 tests passing
- [x] `make phpstan` — no errors
- [x] `make lint-fix` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed validation behavior for notification channels. Channels are now only required when notifications are enabled. Previously, channels remained required even when the notification trigger was disabled, creating unnecessary validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->