### PR TITLE
fix: set default podSecurityContext so worker runs as UID 1000

### DIFF
--- a/helm/databasement/tests/__snapshot__/deployment_test.yaml.snap
+++ b/helm/databasement/tests/__snapshot__/deployment_test.yaml.snap
@@ -183,7 +183,11 @@ should render deployment with default values:
               volumeMounts:
                 - mountPath: /data
                   name: data
-          securityContext: {}
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsUser: 1000
           serviceAccountName: default
           volumes:
             - name: data
@@ -407,7 +411,11 @@ should render deployment with mysql database:
               volumeMounts:
                 - mountPath: /data
                   name: data
-          securityContext: {}
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsUser: 1000
           serviceAccountName: default
           volumes:
             - name: data

--- a/helm/databasement/values.yaml
+++ b/helm/databasement/values.yaml
@@ -146,7 +146,11 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  fsGroupChangePolicy: OnRootMismatch
 
 securityContext: {}
 


### PR DESCRIPTION
## Summary

Fixes #213 — Helm worker sidecar creates local backups as root, making them inaccessible to the web UI.

### Root cause

The Dockerfile has no `USER` directive, so all containers start as **root** by default. The app container handles this gracefully via `start.sh`, which launches supervisord with FrankenPHP running as the `application` user (UID 1000). However, the worker sidecar overrides the command directly (`command: ["sh", "-c", "php artisan queue:work ..."]`), bypassing `start.sh` entirely — so it stays running as root.

This means local backup files and directories are created as `root:root`, making them unreadable by the web UI process (UID 1000). The download route then returns a 404 because `file_exists()` fails due to permissions.

### Fix

Set sensible `podSecurityContext` defaults in `values.yaml` so all containers (app, worker sidecar, init container) run as UID/GID 1000, matching the `application` user from the Dockerfile:

```yaml
podSecurityContext:
  runAsUser: 1000
  runAsGroup: 1000
  fsGroup: 1000
  fsGroupChangePolicy: OnRootMismatch
```

- `runAsUser`/`runAsGroup`: All containers run as UID/GID 1000 instead of root
- `fsGroup`: Mounted volumes are owned by GID 1000
- `fsGroupChangePolicy: OnRootMismatch`: Kubernetes recursively chowns existing root-owned files on the volume on the first restart (fixing already-broken deployments), then skips it on subsequent restarts for performance

The `start.sh` script already handles the non-root case (skips permission fix, strips `user=` from supervisord config), so this change is safe for the app container.

## Test plan

- [ ] Deploy with default values — verify worker, app, and init containers all run as UID 1000
- [ ] Run a backup to a local volume — verify files are created as `1000:1000`
- [ ] Download the backup from the web UI — verify it succeeds (no 404)
- [ ] Upgrade an existing deployment with root-owned files — verify `fsGroupChangePolicy: OnRootMismatch` fixes ownership on first restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default security configuration for application containers to use specific user and group permissions (UID/GID 1000) with automatic filesystem permission adjustments when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->