### PR TITLE
feat: add database_server_id filter to snapshots API

### DIFF
--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -26,6 +26,7 @@ class SnapshotQuery
         return QueryBuilder::for(Snapshot::class)
             ->with(self::RELATIONSHIPS)
             ->allowedFilters([
+                AllowedFilter::exact('database_server_id'),
                 AllowedFilter::partial('database_name'),
                 AllowedFilter::exact('database_type'),
                 AllowedFilter::exact('method'),

--- a/tests/Feature/Api/SnapshotApiTest.php
+++ b/tests/Feature/Api/SnapshotApiTest.php
@@ -54,6 +54,24 @@ test('authenticated users can filter snapshots by database name', function () {
         ->assertJsonPath('data.0.database_name', 'production_db');
 });
 
+test('authenticated users can filter snapshots by database server id', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $server1 = DatabaseServer::factory()->create(['database_names' => ['db_one']]);
+    $factory->createSnapshots($server1, 'manual');
+
+    $server2 = DatabaseServer::factory()->create(['database_names' => ['db_two']]);
+    $factory->createSnapshots($server2, 'manual');
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->getJson("/api/v1/snapshots?filter[database_server_id]={$server1->id}");
+
+    $response->assertOk()
+        ->assertJsonCount(1, 'data')
+        ->assertJsonPath('data.0.server.id', $server1->id);
+});
+
 test('authenticated users can filter snapshots by database type', function () {
     $user = User::factory()->create();
     $factory = app(BackupJobFactory::class);


### PR DESCRIPTION
## Summary

- Add `database_server_id` as an exact filter on the snapshots API (`?filter[database_server_id]=...`), making it easy to retrieve snapshots from a specific server without client-side filtering
- Add test coverage for the new filter
- Include a draft reply for #214 with curl/crontab examples showing how to script scheduled cross-server restores

Ref #214

## Test plan

- [x] New test: filter snapshots by `database_server_id` returns only matching snapshots
- [x] Existing snapshot API tests still pass (851 tests, 0 failures)
- [x] PHPStan passes
- [x] Pint passes