### PR TITLE
fix: replace Font Awesome icons with Bootstrap Icons for OAuth providers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,6 @@
         "livewire/livewire": "^4.0",
         "lorisleiva/cron-translator": "^0.5.0",
         "mongodb/mongodb": "^2.2",
-        "owenvoke/blade-fontawesome": "^2.7",
         "robsontenorio/mary": "^2.4",
         "spatie/laravel-query-builder": "^6.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a71d1158c3c2a6a197bd13af03f954e4",
+    "content-hash": "ce0db25f07a344522125bb77c747a253",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -4803,66 +4803,6 @@
                 }
             ],
             "time": "2026-02-16T23:10:27+00:00"
-        },
-        {
-            "name": "owenvoke/blade-fontawesome",
-            "version": "v2.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/owenvoke/blade-fontawesome.git",
-                "reference": "94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/owenvoke/blade-fontawesome/zipball/94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1",
-                "reference": "94dcd0c78f43f8234b0d9c76c903ecd288b8b0d1",
-                "shasum": ""
-            },
-            "require": {
-                "blade-ui-kit/blade-icons": "^1.5",
-                "illuminate/support": "^10.34|^11.0|^12.0",
-                "php": "^8.1"
-            },
-            "require-dev": {
-                "laravel/pint": "^1.13",
-                "orchestra/testbench": "^8.12|^9.0|^10.0",
-                "pestphp/pest": "^2.26|^3.7",
-                "phpstan/phpstan": "^1.10|^2.1",
-                "symfony/var-dumper": "^6.3|^7.2"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "OwenVoke\\BladeFontAwesome\\BladeFontAwesomeServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "OwenVoke\\BladeFontAwesome\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "A package to easily make use of Font Awesome in your Laravel Blade views",
-            "support": {
-                "issues": "https://github.com/owenvoke/blade-fontawesome/issues",
-                "source": "https://github.com/owenvoke/blade-fontawesome/tree/v2.9.1"
-            },
-            "funding": [
-                {
-                    "url": "https://ecologi.com/owenvoke?gift-trees",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/owenvoke",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-28T16:03:42+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",

--- a/config/oauth.php
+++ b/config/oauth.php
@@ -81,14 +81,14 @@ return [
             'enabled' => env('OAUTH_GOOGLE_ENABLED', false),
             'client_id' => env('OAUTH_GOOGLE_CLIENT_ID'),
             'client_secret' => env('OAUTH_GOOGLE_CLIENT_SECRET'),
-            'icon' => 'fab-google',
+            'icon' => 'bi.google',
             'label' => 'Google',
         ],
         'github' => [
             'enabled' => env('OAUTH_GITHUB_ENABLED', false),
             'client_id' => env('OAUTH_GITHUB_CLIENT_ID'),
             'client_secret' => env('OAUTH_GITHUB_CLIENT_SECRET'),
-            'icon' => 'fab-github',
+            'icon' => 'bi.github',
             'label' => 'GitHub',
         ],
         'gitlab' => [
@@ -96,7 +96,7 @@ return [
             'client_id' => env('OAUTH_GITLAB_CLIENT_ID'),
             'client_secret' => env('OAUTH_GITLAB_CLIENT_SECRET'),
             'host' => env('OAUTH_GITLAB_HOST', 'https://gitlab.com'),
-            'icon' => 'fab-gitlab',
+            'icon' => 'bi.gitlab',
             'label' => 'GitLab',
         ],
         'oidc' => [

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -107,7 +107,7 @@
                         <a href="https://crty.dev" target="_blank" rel="noopener" class="link link-hover">David-Crty</a>
                     </span>
                     <a href="{{ $githubRepo }}" target="_blank" rel="noopener" class="link link-hover flex items-center gap-1">
-                        <x-fab-github class="w-4 h-4" />
+                        <x-bi-github class="w-4 h-4" />
                         {{ $githubRepoShort }}
                     </a>
                 </div>

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -92,6 +92,28 @@ test('users with two factor enabled are redirected to two factor challenge', fun
     $this->assertGuest();
 });
 
+test('login screen renders oauth provider button when enabled', function (string $provider, string $label) {
+    User::factory()->create();
+
+    config()->set("oauth.providers.{$provider}.enabled", true);
+    config()->set("oauth.providers.{$provider}.client_id", 'test');
+    config()->set("oauth.providers.{$provider}.client_secret", 'test');
+
+    if ($provider === 'oidc') {
+        config()->set('oauth.providers.oidc.base_url', 'https://idp.example.com');
+    }
+
+    $response = $this->get(route('login'));
+
+    $response->assertStatus(200);
+    $response->assertSeeText("Continue with {$label}");
+})->with([
+    'google' => ['google', 'Google'],
+    'github' => ['github', 'GitHub'],
+    'gitlab' => ['gitlab', 'GitLab'],
+    'oidc' => ['oidc', 'SSO'],
+]);
+
 test('users can logout', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
## Summary

Closes #218

- Mary UI's `<x-icon>` prepends `heroicon-` to icon names without a dot, causing `fab-*` Font Awesome icons to be looked up in the heroicons set and throw `SvgNotFound`
- Switch OAuth provider icons from `fab-google`/`fab-github`/`fab-gitlab` to `bi.google`/`bi.github`/`bi.gitlab` (Bootstrap Icons, already installed)
- Replace `<x-fab-github>` with `<x-bi-github>` in the footer layout
- Remove `owenvoke/blade-fontawesome` dependency (no longer used anywhere)

## Test plan

- [x] Added dataset-driven test covering all 4 OAuth providers (google, github, gitlab, oidc) render correctly on the login page
- [x] All 860 tests pass
- [x] PHPStan clean