### PR TITLE
feat: add per-backup trigger button on server index

### DIFF
--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\DatabaseServer;
 
 use App\Enums\DatabaseType;
+use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\NotificationChannel;
 use App\Queries\DatabaseServerQuery;
@@ -70,7 +71,7 @@ class Index extends Component
     public function headers(): array
     {
         return [
-            ['key' => 'name', 'label' => __('Name'), 'class' => 'w-80'],
+            ['key' => 'name', 'label' => __('Name'), 'class' => 'w-64'],
             ['key' => 'backup', 'label' => __('Backup'), 'sortable' => false],
             ['key' => 'jobs', 'label' => __('Jobs'), 'sortable' => false, 'class' => 'w-32'],
         ];
@@ -127,6 +128,24 @@ class Index extends Component
         }
 
         $this->dispatch('open-restore-modal', targetServerId: $id);
+    }
+
+    public function runBackup(string $backupId, TriggerBackupAction $action): void
+    {
+        $backup = Backup::with(['databaseServer', 'volume', 'backupSchedule'])->findOrFail($backupId);
+
+        $this->authorize('backup', $backup->databaseServer);
+
+        try {
+            $userId = auth()->id();
+            $action->execute($backup, is_int($userId) ? $userId : null);
+            $this->success(
+                title: __('Backup started successfully!'),
+                description: $backup->getDisplayLabel(),
+            );
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage(), timeout: 0);
+        }
     }
 
     public function runBackupAll(string $serverId, TriggerBackupAction $action): void

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -104,31 +104,38 @@
                 @elseif($server->backups->isEmpty())
                     <span class="text-base-content/50">—</span>
                 @else
-                    <div class="flex flex-col gap-1 min-w-[200px] max-w-[400px]">
+                    <div class="flex flex-col gap-1">
                         @foreach($server->backups as $backup)
                             @php $label = $backup->getDisplayLabel(false); @endphp
-                            <div class="rounded-md bg-base-200/60 border border-base-300 px-2 py-1.5" title="{{ $backup->getDisplayLabel() }}">
-                                <div class="flex items-center gap-1.5 min-w-0 flex-wrap">
-                                    {{-- Primary: schedule → volume --}}
-                                    <x-icon name="o-clock" class="w-3 h-3 shrink-0 text-primary/80" />
-                                    <span class="text-xs font-semibold text-base-content truncate">{{ $label['schedule'] }}</span>
-                                    <span class="text-base-content/30 text-[0.625rem] shrink-0">→</span>
-                                    <x-volume-type-icon :type="$backup->volume->type" class="w-3 h-3 shrink-0 text-primary/80" />
-                                    <span class="text-xs font-semibold text-base-content truncate">{{ $label['volume'] }}</span>
-                                    {{-- Secondary: databases + retention badges (wrap to next line if needed) --}}
-                                    @if($label['databases'])
-                                        <span class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] font-medium leading-none bg-base-300/60 text-base-content/60">
-                                            <x-icon name="o-circle-stack" class="w-2.5 h-2.5 shrink-0" />
-                                            <span class="max-w-[120px] truncate">{{ $label['databases'] }}</span>
-                                        </span>
-                                    @endif
-                                    @if($label['retention'])
-                                        <span class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] font-medium leading-none bg-info/10 text-info">
-                                            <x-icon name="o-archive-box" class="w-2.5 h-2.5 shrink-0" />
-                                            <span>{{ $label['retention'] }}</span>
-                                        </span>
-                                    @endif
-                                </div>
+                            <div class="flex items-center gap-1.5 whitespace-nowrap rounded-md bg-base-200/60 border border-base-300 px-2 py-1.5" title="{{ $backup->getDisplayLabel() }}">
+                                <x-icon name="o-clock" class="w-3 h-3 shrink-0 text-primary/80" />
+                                <span class="text-xs font-semibold text-base-content">{{ $label['schedule'] }}</span>
+                                <span class="text-base-content/30 text-[0.625rem]">→</span>
+                                <x-volume-type-icon :type="$backup->volume->type" class="w-3 h-3 shrink-0 text-primary/80" />
+                                <span class="text-xs font-semibold text-base-content">{{ $label['volume'] }}</span>
+                                @if($label['databases'])
+                                    <span class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] font-medium leading-none bg-base-300/60 text-base-content/60">
+                                        <x-icon name="o-circle-stack" class="w-2.5 h-2.5" />
+                                        {{ $label['databases'] }}
+                                    </span>
+                                @endif
+                                @if($label['retention'])
+                                    <span class="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] font-medium leading-none bg-info/10 text-info">
+                                        <x-icon name="o-archive-box" class="w-2.5 h-2.5" />
+                                        {{ $label['retention'] }}
+                                    </span>
+                                @endif
+                                @if($server->backups->count() > 1)
+                                    @can('backup', $server)
+                                        <x-button
+                                            icon="o-arrow-down-tray"
+                                            wire:click="runBackup('{{ $backup->id }}')"
+                                            spinner
+                                            tooltip="{{ __('Backup now') }}"
+                                            class="btn-ghost btn-xs text-info ml-auto -mr-1"
+                                        />
+                                    @endcan
+                                @endif
                             </div>
                         @endforeach
                     </div>

--- a/tests/Feature/Livewire/DatabaseServer/IndexTest.php
+++ b/tests/Feature/Livewire/DatabaseServer/IndexTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Jobs\ProcessBackupJob;
+use App\Livewire\DatabaseServer\Index;
+use App\Models\Backup;
+use App\Models\DatabaseServer;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Queue::fake();
+});
+
+test('runBackup triggers backup for a specific backup configuration', function () {
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $server = DatabaseServer::factory()->withoutBackups()->create();
+    $backup = Backup::factory()->for($server)->selected(['test_db'])->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->call('runBackup', $backup->id);
+
+    Queue::assertPushed(ProcessBackupJob::class, 1);
+});
+
+test('runBackup includes backup display label in success toast', function () {
+    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $server = DatabaseServer::factory()->withoutBackups()->create();
+    $backup = Backup::factory()->for($server)->selected(['test_db'])->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->call('runBackup', $backup->id);
+
+    // Verify a backup job was created
+    Queue::assertPushed(ProcessBackupJob::class, 1);
+});
+
+test('runBackup fails with authorization error if user is viewer', function () {
+    $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+    $server = DatabaseServer::factory()->withoutBackups()->create();
+    $backup = Backup::factory()->for($server)->selected(['test_db'])->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->call('runBackup', $backup->id)
+        ->assertForbidden();
+});


### PR DESCRIPTION
## Summary
- When a server has multiple backup configurations, each backup card now shows its own trigger button (download icon) so users can start a specific backup instead of running all at once
- The `runBackup()` action includes the backup display label in the success toast for clarity
- Simplified backup card layout to always render as a single line (`whitespace-nowrap`) with the button floated right via `ml-auto`
- Narrowed the Name column (`w-80` → `w-64`) to give the Backup column more room

Closes #138

## Test plan
- [ ] Verify per-backup trigger button appears only when a server has 2+ backup configs
- [ ] Verify clicking the button triggers the correct backup and shows a toast with the backup label
- [ ] Verify viewers cannot trigger backups (authorization check)
- [ ] Verify the "Backup now" button in the Actions column still triggers all backups
- [ ] Check layout at various screen widths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to trigger individual backups directly from the backups table with a "Backup now" action button (available for servers with multiple backups).

* **Improvements**
  * Optimized backup display layout for improved readability with single-line, non-wrapping backup rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->