### PR TITLE
fix: use version_compare for robust version status detection

### DIFF
--- a/app/Livewire/VersionStatus.php
+++ b/app/Livewire/VersionStatus.php
@@ -27,29 +27,26 @@ class VersionStatus extends Component
     public ?string $releaseUrl = null;
 
     #[Locked]
-    public ?string $currentVersion = null;
+    public ?string $appVersion = null;
 
     #[Locked]
-    public bool $isAppVersion = false;
+    public ?string $appCommitHash = null;
 
     public function mount(): void
     {
         $this->getCurrentVersion();
-
-        if ($this->currentVersion) {
-            $this->loadLatestRelease();
-        }
+        $this->loadLatestRelease();
     }
 
     private function getCurrentVersion(): void
     {
         if ($version = config('app.version')) {
-            $this->currentVersion = str_starts_with($version, 'v') ? $version : 'v'.$version;
-            $this->isAppVersion = true;
-        } elseif (config('app.commit_hash')) {
-            $this->currentVersion = substr(config('app.commit_hash'), 0, 7);
+            $this->appVersion = str_starts_with($version, 'v') ? $version : 'v'.$version;
+        }
+        if (config('app.commit_hash')) {
+            $this->appCommitHash = substr(config('app.commit_hash'), 0, 7);
         } elseif ($gitHash = $this->getGitShortHash()) {
-            $this->currentVersion = $gitHash;
+            $this->appCommitHash = $gitHash;
         }
     }
 
@@ -109,6 +106,19 @@ class VersionStatus extends Component
         $path = trim(str_replace('https://github.com/', '', $repo), '/');
 
         return "https://api.github.com/repos/{$path}/releases/latest";
+    }
+
+    public function isUpToDate(): bool
+    {
+        if (! $this->appVersion || ! $this->latestVersion) {
+            return false;
+        }
+
+        return version_compare(
+            ltrim($this->appVersion, 'v'),
+            ltrim($this->latestVersion, 'v'),
+            '>='
+        );
     }
 
     protected function getGitShortHash(): ?string

--- a/resources/views/livewire/version-status-placeholder.blade.php
+++ b/resources/views/livewire/version-status-placeholder.blade.php
@@ -1,10 +1,12 @@
 <div class="inline-flex">
-    @if($currentVersion)
+    @if($appVersion || $appCommitHash)
     {{-- Up to date or no latest info — subtle version with green dot --}}
     <button
         class="inline-flex items-center gap-1.5 text-sm text-base-content/60 hover:text-base-content transition-colors cursor-pointer"
     >
-        <span class="font-mono">{{ $currentVersion }}</span>
+        <span class="font-mono">
+            {{ $appVersion ?: $appCommitHash }}
+        </span>
     </button>
     @else
         <button

--- a/resources/views/livewire/version-status.blade.php
+++ b/resources/views/livewire/version-status.blade.php
@@ -1,6 +1,6 @@
 <div class="inline-flex">
     {{-- Footer trigger --}}
-    @if($latestVersion && $currentVersion && $latestVersion !== $currentVersion && $isAppVersion)
+    @if($latestVersion && $appVersion && ! $this->isUpToDate())
         {{-- Update available — eye-catching pill --}}
         <button
             wire:click="open"
@@ -13,18 +13,20 @@
             </span>
             {{ $latestVersion }} {{ __('available') }}
         </button>
-    @elseif($currentVersion)
+    @elseif($appVersion || $appCommitHash)
         {{-- Up to date or no latest info — subtle version with green dot --}}
         <button
             wire:click="open"
             class="inline-flex items-center gap-1.5 text-sm text-base-content/60 hover:text-base-content transition-colors cursor-pointer"
         >
-            @if($latestVersion === $currentVersion)
+            @if($this->isUpToDate())
                 <span class="flex h-1.5 w-1.5 shrink-0">
                     <span class="block h-full w-full rounded-full bg-success opacity-70"></span>
                 </span>
             @endif
-            <span class="font-mono">{{ $currentVersion }}</span>
+            <span class="font-mono">
+                {{ $appVersion ?: $appCommitHash }}
+            </span>
         </button>
     @else
         {{-- No version info — plain link --}}
@@ -38,42 +40,52 @@
 
     {{-- Modal --}}
     <x-modal wire:model="showModal" :title="__('How to update?')" class="backdrop-blur" box-class="max-w-2xl">
-
         {{-- Version status --}}
-        @if($latestVersion && $currentVersion && $latestVersion === $currentVersion)
+        @if($latestVersion && $appVersion && $this->isUpToDate())
             <x-alert icon="o-check-circle" class="alert-success mb-4">
                 {{ __('You are running the latest version') }}
                 <a href="{{ $releaseUrl }}" target="_blank" rel="noopener" class="font-mono font-semibold link">{{ $latestVersion }}</a>
             </x-alert>
-        @elseif($latestVersion && $currentVersion)
+        @elseif($latestVersion && $appVersion)
             <x-alert icon="o-arrow-path" class="alert-warning mb-4">
                 <span class="inline-flex items-center gap-1.5 flex-wrap">
                     {{ __('Update available:') }}
-                    <span class="font-mono">{{ $currentVersion }}</span>
+                    <span class="font-mono">
+                        {{ $appVersion }}
+                    </span>
                     <x-icon name="o-arrow-right" class="w-3.5 h-3.5" />
                     <a href="{{ $releaseUrl }}" target="_blank" rel="noopener" class="font-mono font-bold link">{{ $latestVersion }}</a>
                 </span>
             </x-alert>
-            @unless($isAppVersion)
-                <x-alert icon="o-information-circle" class="alert-info mb-4">
-                    {{ __('You are not using a version tag. Consider using docker tag "1" instead of "latest" for reliable update detection.') }}
-                </x-alert>
-            @endunless
-        @elseif($latestVersion && !$currentVersion)
+        @elseif($latestVersion && !$appVersion)
             <x-alert icon="o-exclamation-triangle" class="alert-warning mb-4">
                 {{ __('Could not determine current version.') }}
                 {{ __('Latest available:') }}
                 <a href="{{ $releaseUrl }}" target="_blank" rel="noopener" class="font-mono font-semibold link">{{ $latestVersion }}</a>
             </x-alert>
-        @elseif($currentVersion && !$latestVersion)
+            <x-alert icon="o-information-circle" class="alert-info mb-4">
+                {{ __('You are not using a version tag. Consider using docker tag "1" instead of "latest" for reliable update detection.') }}
+            </x-alert>
+        @elseif($appVersion && !$latestVersion)
             <x-alert icon="o-exclamation-triangle" class="alert-warning mb-4">
-                {{ __('Could not determine latest version.') }}
+                {{ __('Could not determine latest version, check your self on GitHub.') }}
                 {{ __('Current version:') }}
-                <span class="font-mono font-semibold">{{ $currentVersion }}</span>
+                <span class="font-mono font-semibold">{{ $appVersion }}</span>
             </x-alert>
         @else
             <x-alert icon="o-exclamation-triangle" class="alert-warning mb-4">
                 {{ __('Could not determine version information.') }}
+            </x-alert>
+        @endif
+
+        @if($appCommitHash)
+            <x-alert class="alert-info mb-4">
+                {{ __('Current commit hash:') }}
+                <span class="font-mono font-semibold">
+                    <a href="https://github.com/David-Crty/databasement/commit/{{ $appCommitHash }}" target="_blank" rel="noopener" class="link">
+                        {{ $appCommitHash }}
+                    </a>
+                </span>
             </x-alert>
         @endif
 

--- a/resources/views/livewire/version-status.blade.php
+++ b/resources/views/livewire/version-status.blade.php
@@ -68,7 +68,7 @@
             </x-alert>
         @elseif($appVersion && !$latestVersion)
             <x-alert icon="o-exclamation-triangle" class="alert-warning mb-4">
-                {{ __('Could not determine latest version, check your self on GitHub.') }}
+                {{ __('Could not determine latest version, check yourself on GitHub.') }}
                 {{ __('Current version:') }}
                 <span class="font-mono font-semibold">{{ $appVersion }}</span>
             </x-alert>
@@ -82,7 +82,7 @@
             <x-alert class="alert-info mb-4">
                 {{ __('Current commit hash:') }}
                 <span class="font-mono font-semibold">
-                    <a href="https://github.com/David-Crty/databasement/commit/{{ $appCommitHash }}" target="_blank" rel="noopener" class="link">
+                    <a href="{{ config('app.github_repo') }}/commit/{{ $appCommitHash }}" target="_blank" rel="noopener" class="link">
                         {{ $appCommitHash }}
                     </a>
                 </span>

--- a/tests/Feature/Livewire/VersionStatusTest.php
+++ b/tests/Feature/Livewire/VersionStatusTest.php
@@ -26,13 +26,26 @@ test('component is rendered in the layout', function () {
         ->assertSeeLivewire(VersionStatus::class);
 });
 
-test('up to date: shows version and success alert in modal', function () {
+test('up to date: shows version with green dot and success alert', function () {
     Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.0.0'])]);
     config(['app.version' => 'v1.0.0']);
 
     Livewire::actingAs(User::factory()->create())
         ->test(VersionStatus::class)
+        ->assertSet('appVersion', 'v1.0.0')
         ->assertSee('v1.0.0')
+        ->assertDontSee(__('available'))
+        ->call('open')
+        ->assertSee(__('You are running the latest version'));
+});
+
+test('current version ahead of latest: treated as up to date', function () {
+    Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.0.0'])]);
+    config(['app.version' => 'v1.2.0']);
+
+    Livewire::actingAs(User::factory()->create())
+        ->test(VersionStatus::class)
+        ->assertSee('v1.2.0')
         ->assertDontSee(__('available'))
         ->call('open')
         ->assertSee(__('You are running the latest version'));
@@ -52,29 +65,40 @@ test('update available: shows pill and warning alert in modal', function () {
         ->assertSee('v1.2.0');
 });
 
-test('no version set: shows plain link and does not fetch github api', function () {
+test('no version or commit hash: shows plain link', function () {
     Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.2.0'])]);
 
     Livewire::actingAs(User::factory()->create())
         ->test(VersionStatusWithoutGit::class)
-        ->assertSee(__('How to update?'))
-        ->assertSet('latestVersion', null);
-
-    Http::assertNothingSent();
+        ->assertSet('appVersion', null)
+        ->assertSet('appCommitHash', null)
+        ->assertSee(__('How to update?'));
 });
 
-test('falls back to commit hash when version is not set', function () {
-    config(['app.commit_hash' => 'abc1234']);
+test('commit hash shown when version is not set', function () {
+    Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.2.0'])]);
+    config(['app.commit_hash' => 'abc1234def']);
 
     Livewire::actingAs(User::factory()->create())
         ->test(VersionStatus::class)
-        ->assertSet('currentVersion', 'abc1234')
+        ->assertSet('appVersion', null)
+        ->assertSet('appCommitHash', 'abc1234')
         ->assertSee('abc1234');
 });
 
+test('both version and commit hash are set independently', function () {
+    Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.0.0'])]);
+    config(['app.version' => 'v1.0.0', 'app.commit_hash' => 'abc1234def']);
+
+    Livewire::actingAs(User::factory()->create())
+        ->test(VersionStatus::class)
+        ->assertSet('appVersion', 'v1.0.0')
+        ->assertSet('appCommitHash', 'abc1234');
+});
+
 test('modal contains update instructions for all deployment methods', function () {
-    config(['app.version' => 'v1.0.0']);
     Http::fake(['api.github.com/*' => Http::response([], 404)]);
+    config(['app.version' => 'v1.0.0']);
 
     Livewire::actingAs(User::factory()->create())
         ->test(VersionStatus::class)
@@ -85,8 +109,8 @@ test('modal contains update instructions for all deployment methods', function (
 });
 
 test('github response is cached and reused on subsequent mounts', function () {
-    config(['app.version' => 'v1.0.0']);
     Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.2.3'])]);
+    config(['app.version' => 'v1.0.0']);
 
     $user = User::factory()->create();
     Livewire::actingAs($user)->test(VersionStatus::class);
@@ -103,8 +127,8 @@ test('github response is cached and reused on subsequent mounts', function () {
 });
 
 test('github api failure is cached to avoid retries', function () {
-    config(['app.version' => 'v1.0.0']);
     Http::fake(['api.github.com/*' => Http::response([], 500)]);
+    config(['app.version' => 'v1.0.0']);
 
     Livewire::actingAs(User::factory()->create())
         ->test(VersionStatus::class)

--- a/tests/Feature/Livewire/VersionStatusTest.php
+++ b/tests/Feature/Livewire/VersionStatusTest.php
@@ -96,6 +96,16 @@ test('both version and commit hash are set independently', function () {
         ->assertSet('appCommitHash', 'abc1234');
 });
 
+test('malformed version: renders without error', function () {
+    Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.0.0'])]);
+    config(['app.version' => 'not-a-version']);
+
+    Livewire::actingAs(User::factory()->create())
+        ->test(VersionStatus::class)
+        ->assertSet('appVersion', 'vnot-a-version')
+        ->assertOk();
+});
+
 test('modal contains update instructions for all deployment methods', function () {
     Http::fake(['api.github.com/*' => Http::response([], 404)]);
     config(['app.version' => 'v1.0.0']);


### PR DESCRIPTION
## Summary
- Replace string equality (`===`) with PHP's native `version_compare()` so running a version ahead of the latest release (e.g. dev builds) is treated as up-to-date instead of showing "update available"
- Split `$currentVersion`/`$isAppVersion` into separate `$appVersion` and `$appCommitHash` properties for clarity
- Show commit hash link separately in the modal when available

## Test plan
- [x] All 896 tests pass (10 VersionStatus tests, including new `version ahead` and `both properties set` cases)
- [x] PHPStan passes
- [x] Pint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced version status detection and display logic for more accurate update availability indicators.
  * Improved UI presentation showing app version and commit hash information with clearer visual feedback on current update status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->