### PR TITLE
fix: allow backup card label to wrap on mobile

### DIFF
--- a/resources/views/livewire/database-server/_backup-form.blade.php
+++ b/resources/views/livewire/database-server/_backup-form.blade.php
@@ -40,8 +40,8 @@
             <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
                 <x-icon name="o-archive-box-arrow-down" class="w-4 h-4" />
             </span>
-            <div class="min-w-0">
-                <p class="text-sm font-semibold truncate">{{ $cardLabel }}</p>
+            <div>
+                <p class="text-sm font-semibold">{{ $cardLabel }}</p>
                 <p class="text-xs text-base-content/60">
                     {{ __('Backup #:num', ['num' => $position]) }}
                 </p>


### PR DESCRIPTION
## Summary
- Remove `truncate` and `min-w-0` from the backup card header label so it wraps naturally on small screens instead of causing layout overflow

## Test plan
- [ ] Verify on mobile viewport that a long backup summary label wraps correctly without breaking the page layout