### PR TITLE
fix: set SQLite busy_timeout and WAL journal mode to prevent database locking

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -43,8 +43,8 @@ return [
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-            'busy_timeout' => null,
-            'journal_mode' => null,
+            'busy_timeout' => env('DB_BUSY_TIMEOUT', 5000),
+            'journal_mode' => env('DB_JOURNAL_MODE', 'wal'),
             'synchronous' => null,
         ],
 


### PR DESCRIPTION
## Related issue

Related to #230 — does not auto-close, waiting for user feedback.

## Problem

Users running Databasement with SQLite (the default) experience intermittent `SQLSTATE[HY000]: General error: 5 database is locked` errors when scheduled backups run.

### Root cause

The SQLite connection in `config/database.php` has `busy_timeout: null` and `journal_mode: null`, which means:

- **`busy_timeout = 0`** — any write that encounters a lock fails **instantly** instead of retrying
- **`journal_mode = DELETE`** (SQLite default) — uses exclusive locks that block all concurrent access during writes

This becomes a problem because **three processes share the same SQLite file** concurrently:

1. **The queue worker** (long-running daemon) — pops jobs, marks them reserved/completed, deletes finished jobs
2. **FrankenPHP/Octane** (web server) — handles HTTP requests (dashboard polling, status updates)
3. **The scheduler** (`schedule:run` via cron) — dispatches new backup jobs (inserts into the `jobs` table)

Even with a **single queue worker**, jobs are processed sequentially but the lock contention isn't just between backup jobs — it's between the worker, web server, and scheduler all writing to the same SQLite file. The error in the stacktrace occurs at `DatabaseQueue::pop()` → `markJobAsReserved()` (between jobs, when the worker tries to pick up the next one), meaning something else holds the lock at that moment.

With **multiple workers**, the problem would be significantly worse due to additional worker-vs-worker contention.

### Why manual backups work

Manual backups dispatch a single job with no concurrent queue activity, so there's no write contention.

### Why scheduled backups fail

When 20+ databases are scheduled at the same time (e.g., 02:00), the scheduler dispatches all jobs at once. As the worker processes them sequentially, the constant writes (job completion → pop next → job completion → pop next) overlap with web server requests and potential scheduler activity, triggering the instant-fail behavior.

## Fix

Set sensible defaults for SQLite concurrency:

- **`busy_timeout: 5000`** — wait up to 5 seconds for a lock to be released before failing
- **`journal_mode: wal`** — Write-Ahead Logging allows concurrent reads while a write is in progress, dramatically reducing contention

Both values are configurable via `DB_BUSY_TIMEOUT` and `DB_JOURNAL_MODE` environment variables.

## Test plan

- [ ] Verify existing tests pass (config-only change, no behavioral changes)
- [ ] Request feedback from issue reporters (@vsc55, @thorin8k) to confirm scheduled backups no longer fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database configuration to support environment-driven settings for connection timeout and journal mode, with sensible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->