### PR TITLE
fix: improve database server index table for mobile

### DIFF
--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -72,8 +72,8 @@ class Index extends Component
     {
         return [
             ['key' => 'name', 'label' => __('Name'), 'class' => 'w-48'],
-            ['key' => 'backup', 'label' => __('Backup'), 'sortable' => false, 'class' => 'overflow-hidden'],
-            ['key' => 'jobs', 'label' => __('Jobs'), 'sortable' => false, 'class' => 'w-16'],
+            ['key' => 'backup', 'label' => __('Backup'), 'sortable' => false, 'class' => 'overflow-hidden hidden sm:table-cell'],
+            ['key' => 'jobs', 'label' => __('Jobs'), 'sortable' => false, 'class' => 'w-16 hidden sm:table-cell'],
             ['key' => 'actions', 'label' => null, 'sortable' => false, 'class' => 'w-32'],
         ];
     }

--- a/resources/views/components/databaserver-backup-index.blade.php
+++ b/resources/views/components/databaserver-backup-index.blade.php
@@ -21,18 +21,20 @@
         </span>
     @endif
     @if($label['retention'])
-    <span class="max-md:hidden inline-flex items-center gap-1 rounded px-1.5 py-0.5 te5xt-[0.625rem] font-medium leading-none bg-info/10 text-info shrink-0">
+    <span class="max-md:hidden inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[0.625rem] font-medium leading-none bg-info/10 text-info shrink-0">
             <x-icon name="o-archive-box" class="w-2.5 h-2.5" />
             {{ \Illuminate\Support\Str::limit($label['retention'], 15) }}
         </span>
     @endif
-    @can('backup', $server)
-        <x-button
-            icon="o-arrow-down-tray"
-            wire:click="runBackup('{{ $backup->id }}')"
-            spinner
-            tooltip="{{ __('Backup now') }}"
-            class="btn-ghost btn-xs text-info ml-auto shrink-0 -mr-1"
-        />
-    @endcan
+    @if($server->backups->count() > 1)
+        @can('backup', $server)
+            <x-button
+                icon="o-arrow-down-tray"
+                wire:click="runBackup('{{ $backup->id }}')"
+                spinner
+                tooltip="{{ __('Backup now') }}"
+                class="btn-ghost btn-xs text-info ml-auto shrink-0 -mr-1"
+            />
+        @endcan
+    @endif
 </div>


### PR DESCRIPTION
## Summary

- **Hide Backup and Jobs columns on mobile** — these columns take too much horizontal space on small screens. The action column buttons still provide full functionality.
- **Hide per-backup "Backup Now" button when server has a single backup** — redundant with the action column's "Backup now" button which triggers `runBackupAll`. Only shown when there are multiple backup configs so users can trigger them individually.

## Test plan

- [x] Verify table renders correctly on desktop (Backup and Jobs columns visible)
- [x] Verify table hides Backup and Jobs columns on mobile (`< 640px`)
- [x] Verify "Backup Now" button is hidden in backup row when server has one backup
- [x] Verify "Backup Now" button is shown per-row when server has multiple backups