### PR TITLE
fix: resolve SQLite database locking under concurrent load

### DIFF
--- a/app/Console/Commands/WaitForDatabase.php
+++ b/app/Console/Commands/WaitForDatabase.php
@@ -35,6 +35,8 @@ class WaitForDatabase extends Command
         $driverName = config('database.default');
         $isSqlite = config("database.connections.{$driverName}.driver") === 'sqlite';
 
+        $connected = false;
+
         for ($i = 0; $i < $maxRetries; $i++) {
             if ($i > 0) {
                 sleep($retryDelay);
@@ -43,12 +45,9 @@ class WaitForDatabase extends Command
             try {
                 DB::connection()->getPdo();
                 $this->info('Database connection established!');
+                $connected = true;
 
-                if ($this->option('check-migrations')) {
-                    $this->checkMigrations();
-                }
-
-                return 0;
+                break;
             } catch (\Exception $e) {
                 if ($this->option('allow-missing-db') && $this->isMissingDatabaseError($e, $isSqlite)) {
                     $this->info('Database connection works. (Database not created yet).');
@@ -68,9 +67,17 @@ class WaitForDatabase extends Command
             }
         }
 
-        $this->error('Database not ready after multiple attempts.');
+        if (! $connected) {
+            $this->error('Database not ready after multiple attempts.');
 
-        return 1;
+            return 1;
+        }
+
+        if ($this->option('check-migrations')) {
+            $this->checkMigrations();
+        }
+
+        return 0;
     }
 
     /**

--- a/app/Console/Commands/WaitForDatabase.php
+++ b/app/Console/Commands/WaitForDatabase.php
@@ -55,15 +55,15 @@ class WaitForDatabase extends Command
                     return 0;
                 }
 
-                $this->warn("Not ready yet. Retrying in {$retryDelay} seconds... ({$i}/{$maxRetries})");
-                $this->warn($e->getMessage());
-            } finally {
-                // Always release the connection to avoid holding SQLite file locks between retries
+                // Release the connection to avoid holding SQLite file locks between retries
                 try {
                     DB::purge();
                 } catch (\Exception) {
                     // Ignore purge errors
                 }
+
+                $this->warn("Not ready yet. Retrying in {$retryDelay} seconds... ({$i}/{$maxRetries})");
+                $this->warn($e->getMessage());
             }
         }
 

--- a/app/Console/Commands/WaitForDatabase.php
+++ b/app/Console/Commands/WaitForDatabase.php
@@ -3,9 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Database\Migrations\Migrator;
 use Illuminate\Support\Facades\DB;
-use RuntimeException;
 
 class WaitForDatabase extends Command
 {
@@ -28,49 +26,45 @@ class WaitForDatabase extends Command
     /**
      * Execute the console command.
      */
-    public function handle(Migrator $migrator): int
+    public function handle(): int
     {
         $this->info('Waiting for database connection...');
 
         $maxRetries = 60;
         $retryDelay = 1; // seconds
+        $driverName = config('database.default');
+        $isSqlite = config("database.connections.{$driverName}.driver") === 'sqlite';
 
         for ($i = 0; $i < $maxRetries; $i++) {
+            if ($i > 0) {
+                sleep($retryDelay);
+            }
+
             try {
                 DB::connection()->getPdo();
                 $this->info('Database connection established!');
 
                 if ($this->option('check-migrations')) {
-                    $this->checkMigrations($migrator);
+                    $this->checkMigrations();
                 }
 
                 return 0;
             } catch (\Exception $e) {
-                if ($this->option('allow-missing-db')) {
-                    // if driver is sqlite, then the database does not exist yet
-                    if (DB::connection()->getDriverName() === 'sqlite' && str_contains($e->getMessage(), 'Database file at path')) {
-                        $this->info('Sqlite database file not found. (Database not created yet).');
+                if ($this->option('allow-missing-db') && $this->isMissingDatabaseError($e, $isSqlite)) {
+                    $this->info('Database connection works. (Database not created yet).');
 
-                        return 0;
-                    }
-                    if (str_contains($e->getMessage(), 'Unknown database') || preg_match('/database\s+"[^"]+"\s+does not exist/i', $e->getMessage())) {
-                        $this->info('Database connection established! (Database not created yet).');
-
-                        return 0;
-                    }
+                    return 0;
                 }
 
                 $this->warn("Not ready yet. Retrying in {$retryDelay} seconds... ({$i}/{$maxRetries})");
                 $this->warn($e->getMessage());
-
-                // Force a fresh connection attempt on the next iteration
+            } finally {
+                // Always release the connection to avoid holding SQLite file locks between retries
                 try {
                     DB::purge();
-                } catch (\Exception $purgeException) {
+                } catch (\Exception) {
                     // Ignore purge errors
                 }
-
-                sleep($retryDelay);
             }
         }
 
@@ -80,27 +74,50 @@ class WaitForDatabase extends Command
     }
 
     /**
-     * @throws RuntimeException
+     * Check if all migrations have been run.
      */
-    private function checkMigrations(Migrator $migrator): void
+    private function checkMigrations(): void
     {
         $this->info('Checking migrations...');
 
-        $migrator->setConnection(DB::getDefaultConnection());
-        $migrationPath = database_path('migrations');
-
-        if (! $migrator->repositoryExists()) {
-            throw new RuntimeException('Migrations table does not exist.');
+        if (! DB::connection()->getSchemaBuilder()->hasTable('migrations')) {
+            throw new \RuntimeException('Migrations table does not exist.');
         }
 
-        $ranMigrations = $migrator->getRepository()->getRan();
-        $allMigrations = array_keys($migrator->getMigrationFiles($migrationPath));
+        $ranMigrations = DB::table('migrations')->orderBy('batch')->pluck('migration')->all();
+
+        $migrationPath = database_path('migrations');
+        $allMigrations = [];
+        if (is_dir($migrationPath)) {
+            foreach (scandir($migrationPath) as $file) {
+                if (str_ends_with($file, '.php')) {
+                    $allMigrations[] = str_replace('.php', '', $file);
+                }
+            }
+            sort($allMigrations);
+        }
+
         $pendingMigrations = array_diff($allMigrations, $ranMigrations);
 
         if (count($pendingMigrations) > 0) {
-            throw new RuntimeException('Pending migrations: '.implode(', ', $pendingMigrations));
+            throw new \RuntimeException('Pending migrations: '.implode(', ', $pendingMigrations));
         }
 
         $this->info('All migrations have been run!');
+    }
+
+    /**
+     * Determine if the exception indicates a missing database (not a connection failure).
+     */
+    private function isMissingDatabaseError(\Exception $e, bool $isSqlite): bool
+    {
+        $message = $e->getMessage();
+
+        if ($isSqlite && str_contains($message, 'Database file at path')) {
+            return true;
+        }
+
+        return str_contains($message, 'Unknown database')
+            || (bool) preg_match('/database\s+"[^"]+"\s+does not exist/i', $message);
     }
 }

--- a/config/database.php
+++ b/config/database.php
@@ -44,7 +44,8 @@ return [
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
             'busy_timeout' => env('DB_BUSY_TIMEOUT', 5000),
-            'journal_mode' => env('DB_JOURNAL_MODE', 'wal'),
+            'journal_mode' => null,
+            'transaction_mode' => env('DB_TRANSACTION_MODE', 'IMMEDIATE'),
             'synchronous' => null,
         ],
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -35,6 +35,7 @@
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="DB_TRANSACTION_MODE" value=""/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -35,7 +35,7 @@
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
-        <env name="DB_TRANSACTION_MODE" value=""/>
+        <env name="DB_TRANSACTION_MODE" value="" force="true"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
## Summary

Resolves the root cause of `SQLSTATE[HY000]: General error: 5 database is locked` errors reported by SQLite users running scheduled backups (#230). PR #233 was a first attempt that set `busy_timeout` and WAL journal mode, but users continued to report issues. This PR supersedes that fix with a more thorough approach based on deep investigation and local reproduction.

## Root Cause Analysis

The "database is locked" error occurs when multiple processes compete for SQLite write access — the web server (FrankenPHP/Octane), queue worker, scheduler (`schedule:work`), and `db:wait` all hold connections to the same SQLite file. Three independent factors contributed:

### 1. Missing `busy_timeout` (already fixed in #233)

SQLite's default behavior is to fail **instantly** when it encounters a lock — no waiting, no retry. Setting `busy_timeout: 5000` tells SQLite to wait up to 5 seconds for a lock to clear before throwing an error. This alone significantly reduces lock errors.

### 2. `DEFERRED` transaction mode (the key missing piece)

Laravel's default SQLite transaction mode is `DEFERRED`, which delays lock acquisition until the first write statement inside a transaction. This creates a dangerous pattern:

```
BEGIN DEFERRED          -- no lock acquired
SELECT ...              -- shared lock acquired
INSERT/UPDATE ...       -- tries to escalate to EXCLUSIVE lock → can fail!
```

When the escalation from shared → exclusive fails, SQLite throws "database is locked" **and `busy_timeout` does NOT reliably help here** because the lock escalation path is different from the initial lock acquisition path.

With `IMMEDIATE` mode:

```
BEGIN IMMEDIATE         -- exclusive lock acquired here (busy_timeout works!)
SELECT ...              -- already have the lock
INSERT/UPDATE ...       -- already have the lock
COMMIT
```

The lock is acquired at `BEGIN` where `busy_timeout` works reliably. Laravel 12 on PHP 8.4+ supports `transaction_mode` in the SQLite config via `SQLiteConnection::executeBeginTransactionStatement()`.

Additionally, Laravel's `DatabaseQueue::pop()` calls `transaction()` with the default `$attempts = 1` (no retry). While `ConcurrencyErrorDetector` correctly identifies "database is locked" as a concurrency error, the retry only fires when `$attempts > 1`. This means the queue system will fail immediately on any lock conflict — making `IMMEDIATE` mode essential for reliability.

### 3. WAL journal mode creating stale locks

PR #233 enabled WAL (Write-Ahead Logging) mode, which creates `-shm` and `-wal` sidecar files alongside the database. This caused additional problems:

- **Stale file locks**: With Octane/FrankenPHP's persistent connections, the `-shm` file can hold locks that survive across requests
- **NFS incompatibility**: WAL mode doesn't work on NFS volumes (relevant for Docker setups with NFS-mounted volumes, as reported by @vsc55)
- **Migration conflicts**: `migrate:fresh` with WAL active caused cascading lock errors because the sidecar files couldn't be cleaned up while other processes held references

Removing WAL (setting `journal_mode: null` to keep SQLite's default DELETE mode) eliminated these issues. The DELETE journal mode uses a single rollback journal file that's deleted after each transaction — no persistent sidecar files to cause stale locks.

**Important**: `busy_timeout` and `transaction_mode: IMMEDIATE` work independently of the journal mode. They don't require WAL.

### 4. `db:wait` command holding file locks

The `db:wait` command (used by the Docker queue worker entrypoint) held a database connection open during its `sleep()` retry loop. With SQLite, this means holding a file descriptor open to the database file — preventing other processes from writing. Key issues:

- Injected `Migrator` which internally creates its own DB connections
- Called `DB::connection()->getDriverName()` inside the retry loop (opens a new connection per attempt)
- `sleep()` called while connections were still open
- `DB::purge()` was called but lingering references (from Migrator) prevented actual garbage collection

## Reproduction

We reproduced the exact scenario from #230 locally:
- Created 40 MySQL databases with 500 rows each
- Configured 41 backup jobs on a single server
- Dispatched all jobs simultaneously while sending 100 concurrent web requests

**Results:**
| Configuration | Lock errors (out of ~180 jobs) |
|---|---|
| `busy_timeout: null`, `transaction_mode: null` (original) | Frequent failures |
| `busy_timeout: 5000`, `transaction_mode: null` | 3 failures |
| `busy_timeout: 5000`, `transaction_mode: IMMEDIATE` | **0 failures** |

This confirms that `transaction_mode: IMMEDIATE` is essential — `busy_timeout` alone is not sufficient.

## Changes

### `config/database.php`
- `busy_timeout: 5000` — wait up to 5s for locks (was already in #233, retained)
- `journal_mode: null` — removed WAL, use SQLite's default DELETE mode (reverts part of #233)
- `transaction_mode: IMMEDIATE` — acquire write locks at BEGIN where busy_timeout works reliably (**new**)
- Both `busy_timeout` and `transaction_mode` are configurable via `DB_BUSY_TIMEOUT` and `DB_TRANSACTION_MODE` env vars

### `app/Console/Commands/WaitForDatabase.php`
- Removed `Migrator` dependency — no longer holds internal DB connections
- Cached driver name (`$driverName`, `$isSqlite`) upfront to avoid DB calls in the retry loop
- Moved `sleep()` before retry (not after exception), so the first attempt runs immediately
- `DB::purge()` only runs on failure (in `catch` block) — prevents destroying `:memory:` test databases on success
- Migration check (`checkMigrations()`) moved outside the retry loop — fails fast on non-transient errors instead of retrying 60 times
- Extracted `isMissingDatabaseError()` and `checkMigrations()` as clean private methods
- `checkMigrations()` now uses direct DB queries instead of Migrator internals

### `phpunit.xml`
- Set `DB_TRANSACTION_MODE=""` to disable IMMEDIATE mode in tests — avoids `VACUUM` failures inside `RefreshDatabase`'s `migrate:fresh` (VACUUM cannot run within a transaction). IMMEDIATE mode is a production concern, not needed in single-process test databases.

## Test plan

- [x] All 897 tests pass
- [x] PHPStan clean
- [x] Pint formatted
- [x] Reproduced with 41 concurrent backup jobs + web traffic: 0 lock errors
- [x] Verified lock errors return (3/180) without `transaction_mode: IMMEDIATE`
- [x] `make migrate-fresh-seed` works with all Docker services running
- [ ] User confirmation from #230 reporters (@vsc55, @kfrfrfkh)

Relates to #230

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved database startup verification and migration validation logic.
  * Updated SQLite configuration with enhanced transaction mode settings.

* **Tests**
  * Added transaction mode configuration to test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->