### PR TITLE
fix: make db:wait --check-migrations retry on pending migrations

### DIFF
--- a/app/Console/Commands/WaitForDatabase.php
+++ b/app/Console/Commands/WaitForDatabase.php
@@ -44,10 +44,17 @@ class WaitForDatabase extends Command
 
             try {
                 DB::connection()->getPdo();
-                $this->info('Database connection established!');
-                $connected = true;
 
-                break;
+                if (! $connected) {
+                    $this->info('Database connection established!');
+                    $connected = true;
+                }
+
+                if ($this->option('check-migrations')) {
+                    $this->checkMigrations();
+                }
+
+                return 0;
             } catch (\Exception $e) {
                 if ($this->option('allow-missing-db') && $this->isMissingDatabaseError($e, $isSqlite)) {
                     $this->info('Database connection works. (Database not created yet).');
@@ -67,17 +74,9 @@ class WaitForDatabase extends Command
             }
         }
 
-        if (! $connected) {
-            $this->error('Database not ready after multiple attempts.');
+        $this->error('Database not ready after multiple attempts.');
 
-            return 1;
-        }
-
-        if ($this->option('check-migrations')) {
-            $this->checkMigrations();
-        }
-
-        return 0;
+        return 1;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Move `checkMigrations()` inside the connection retry loop's try-catch block so `db:wait --check-migrations` keeps polling when migrations are pending, instead of crashing with an unhandled `RuntimeException`
- Deduplicate the "Database connection established!" message across retries
- Simplify post-loop logic: `return 0` on success inside the loop, unconditional error + `return 1` after exhausting retries

## Test plan

- [x] `db:wait` with DB up exits 0 immediately
- [x] `db:wait --check-migrations` with all migrations applied exits 0
- [x] `db:wait --check-migrations` with pending migration retries cleanly (no stack trace)
- [x] `db:wait --check-migrations` in background + `migrate` from another process exits 0
- [x] `db:wait --allow-missing-db` with DB up exits 0
- [x] All 897 existing tests pass