### PR TITLE
chore: exclude docs/ from security scanners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  # PHP/Composer - root only
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # npm - root only (excludes docs/)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,5 @@
+version: v1.5.0
+
+exclude:
+  global:
+    - docs/**


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` scoped to root-only ecosystems (composer, npm, github-actions), so Dependabot skips `docs/package.json`
- Add `.snyk` policy file excluding `docs/**` from Snyk scans

## Why

The `docs/` folder is a self-contained Docusaurus static site used solely to generate documentation pages. Its npm dependencies:

- Are **never deployed** to production
- **Never handle user data** or run server-side
- Only execute at **build time** to produce static HTML/CSS/JS

Security alerts on these build-only dependencies are false positives that create noise and waste triage time. Vulnerabilities in Docusaurus's React/MDX stack have zero impact on the application's security posture.

## Test plan

- [x] Pre-commit hooks pass (lint, PHPStan, 897 tests)
- [ ] Verify Dependabot no longer opens PRs for `docs/` dependencies
- [ ] Verify Snyk no longer flags `docs/` dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated weekly dependency scanning across multiple package ecosystems
  * Set up security scanning with exclusions for documentation files
  * Adjusted documentation framework dependency versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->