### PR TITLE
docs: update SQLite backup method from "File copy" to sqlite3 .backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For production deployments, see our [configuration guide](https://david-crty.git
 | MariaDB    | 10.x, 11.x, 12.x             | `mariadb-dump`               | Yes     |
 | PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v18                | Yes     |
 | MongoDB    | 4.2, 4.4, 5.0, 6.0, 7.0, 8.0 | `mongodump` / `mongorestore` | Yes     |
-| SQLite     | 3.x                          | File copy                    | Yes     |
+| SQLite     | 3.x                          | `sqlite3 .backup`            | Yes     |
 | Redis      | 2.8+                         | `redis-cli --rdb`            | No      |
 | Valkey     | 7.2+                         | `redis-cli --rdb`            | No      |
 


### PR DESCRIPTION
The README table currently lists "File copy" as the backup method for SQLite, but the implementation in `SqliteDatabase.php` already uses `sqlite3 .backup` (SQLite's Online Backup API), which produces a consistent, point-in-time snapshot even when the database is actively being written to.

I verified this in the current source and also confirmed with @David-Crty that this was intentionally implemented. This PR updates the documentation to reflect the actual behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Supported Database Versions table to specify SQLite database restoration using the `sqlite3 .backup` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->