### PR TITLE
feat: resource-scoped server access permissions for Viewer/Demo users

### DIFF
--- a/app/Http/Controllers/Api/V1/DatabaseServerController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Enums\DatabaseType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\RestoreRequest;
 use App\Http\Requests\Api\V1\SaveDatabaseServerRequest;
@@ -194,6 +195,14 @@ class DatabaseServerController extends Controller
         BackupJobFactory $backupJobFactory
     ): JsonResponse {
         $this->authorize('restore', $databaseServer);
+
+        if ($databaseServer->agent_id !== null) {
+            return response()->json(['message' => 'Restore is not supported for agent-backed servers.'], 422);
+        }
+
+        if ($databaseServer->database_type === DatabaseType::REDIS) {
+            return response()->json(['message' => 'Automated restore is not supported for Redis/Valkey servers.'], 422);
+        }
 
         /** @var Snapshot $snapshot */
         $snapshot = Snapshot::findOrFail($request->validated('snapshot_id'));

--- a/app/Http/Controllers/Api/V1/DatabaseServerController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Enums\DatabaseType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\RestoreRequest;
 use App\Http\Requests\Api\V1\SaveDatabaseServerRequest;
@@ -195,14 +194,6 @@ class DatabaseServerController extends Controller
         BackupJobFactory $backupJobFactory
     ): JsonResponse {
         $this->authorize('restore', $databaseServer);
-
-        if ($databaseServer->agent_id !== null) {
-            return response()->json(['message' => 'Restore is not supported for agent-backed servers.'], 422);
-        }
-
-        if ($databaseServer->database_type === DatabaseType::REDIS) {
-            return response()->json(['message' => 'Automated restore is not supported for Redis/Valkey servers.'], 422);
-        }
 
         /** @var Snapshot $snapshot */
         $snapshot = Snapshot::findOrFail($request->validated('snapshot_id'));

--- a/app/Livewire/BackupJob/Index.php
+++ b/app/Livewire/BackupJob/Index.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\BackupJob;
 
+use App\Enums\DatabaseType;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\Snapshot;
@@ -182,7 +183,13 @@ class Index extends Component
      */
     public function serverOptions(): array
     {
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
         return DatabaseServer::query()
+            ->when($user->isScopedUser(), function ($query) use ($user) {
+                $query->whereIn('id', $user->getAccessibleServerIds());
+            })
             ->orderBy('name')
             ->get()
             ->map(fn (DatabaseServer $server) => [
@@ -190,6 +197,27 @@ class Index extends Component
                 'name' => $server->name,
             ])
             ->toArray();
+    }
+
+    public function confirmRestoreFromJob(string $serverId, string $snapshotId): void
+    {
+        $server = DatabaseServer::findOrFail($serverId);
+
+        $this->authorize('restore', $server);
+
+        if ($server->agent_id) {
+            $this->error(__('Restore is not yet supported for agent-backed servers.'));
+
+            return;
+        }
+
+        if ($server->database_type === DatabaseType::REDIS) {
+            $this->error(__('Automated restore is not supported for Redis/Valkey.'));
+
+            return;
+        }
+
+        $this->dispatch('open-restore-from-snapshot', targetServerId: $serverId, snapshotId: $snapshotId);
     }
 
     public function confirmDeleteSnapshot(string $snapshotId): void
@@ -259,6 +287,9 @@ class Index extends Component
 
     public function render(): View
     {
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
         $jobs = BackupJobQuery::buildFromParams(
             search: $this->search,
             statusFilter: $this->statusFilter !== '' ? [$this->statusFilter] : [],
@@ -266,7 +297,8 @@ class Index extends Component
             serverFilter: $this->serverFilter,
             fileMissing: $this->fileMissing !== '',
             sortColumn: $this->sortBy['column'],
-            sortDirection: $this->sortBy['direction']
+            sortDirection: $this->sortBy['direction'],
+            scopedUser: $user->isScopedUser() ? $user : null,
         )->paginate(15);
 
         return view('livewire.backup-job.index', [

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -112,21 +112,18 @@ class Index extends Component
     {
         $server = DatabaseServer::findOrFail($id);
 
-        $this->authorize('restore', $server);
-
-        $this->restoreId = $id;
-
-        if ($server->agent_id) {
-            $this->error(__('Restore is not yet supported for agent-backed servers.'));
-
-            return;
-        }
-
+        // Redis/Valkey: show manual instructions without a policy check since
+        // no automated restore job is dispatched — just documentation.
         if ($server->database_type === DatabaseType::REDIS) {
             $this->showRedisRestoreModal = true;
 
             return;
         }
+
+        // Policy blocks agent-backed servers and unathorized users (403).
+        $this->authorize('restore', $server);
+
+        $this->restoreId = $id;
 
         $this->dispatch('open-restore-modal', targetServerId: $id);
     }

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -203,10 +203,14 @@ class Index extends Component
 
     public function render(): View
     {
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
         $servers = DatabaseServerQuery::buildFromParams(
             search: $this->search,
             sortColumn: $this->sortBy['column'],
-            sortDirection: $this->sortBy['direction']
+            sortDirection: $this->sortBy['direction'],
+            scopedUser: $user->isScopedUser() ? $user : null,
         )->paginate(10);
 
         // Share total count globally so it's available inside Mary UI scoped slots

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -112,18 +112,17 @@ class Index extends Component
     {
         $server = DatabaseServer::findOrFail($id);
 
-        // Redis/Valkey: show manual instructions without a policy check since
-        // no automated restore job is dispatched — just documentation.
+        $this->authorize('view', $server);
+        $this->restoreId = $id;
+
         if ($server->database_type === DatabaseType::REDIS) {
             $this->showRedisRestoreModal = true;
 
             return;
         }
 
-        // Policy blocks agent-backed servers and unathorized users (403).
+        // Policy blocks agent-backed servers and unauthorized users (403).
         $this->authorize('restore', $server);
-
-        $this->restoreId = $id;
 
         $this->dispatch('open-restore-modal', targetServerId: $id);
     }

--- a/app/Livewire/DatabaseServer/RestoreModal.php
+++ b/app/Livewire/DatabaseServer/RestoreModal.php
@@ -101,12 +101,23 @@ class RestoreModal extends Component
     {
         $this->reset(['selectedSnapshotId', 'schemaName', 'forceDatabase', 'ownerUser', 'currentStep', 'existingDatabases', 'snapshotSearch', 'serverFilter']);
         $this->resetPage('snapshots');
-        $this->targetServer = DatabaseServer::find($targetServerId);
+        $this->targetServer = DatabaseServer::findOrFail($targetServerId);
 
         $this->authorize('restore', $this->targetServer);
 
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
+        $snapshot = SnapshotQuery::buildFromParams(
+            statusFilter: 'completed',
+            scopedUser: $user->isScopedUser() ? $user : null,
+        )
+            ->whereKey($snapshotId)
+            ->whereHas('databaseServer', fn (Builder $q) => $q->whereRaw('database_type = ?', [$this->targetServer->database_type->value]))
+            ->firstOrFail();
+
         $this->showModal = true;
-        $this->selectSnapshot($snapshotId);
+        $this->selectSnapshot($snapshot->id);
     }
 
     public function selectSnapshot(string $snapshotId): void

--- a/app/Livewire/DatabaseServer/RestoreModal.php
+++ b/app/Livewire/DatabaseServer/RestoreModal.php
@@ -96,6 +96,19 @@ class RestoreModal extends Component
         $this->showModal = true;
     }
 
+    #[On('open-restore-from-snapshot')]
+    public function openFromSnapshot(string $targetServerId, string $snapshotId): void
+    {
+        $this->reset(['selectedSnapshotId', 'schemaName', 'forceDatabase', 'ownerUser', 'currentStep', 'existingDatabases', 'snapshotSearch', 'serverFilter']);
+        $this->resetPage('snapshots');
+        $this->targetServer = DatabaseServer::find($targetServerId);
+
+        $this->authorize('restore', $this->targetServer);
+
+        $this->showModal = true;
+        $this->selectSnapshot($snapshotId);
+    }
+
     public function selectSnapshot(string $snapshotId): void
     {
         $this->selectedSnapshotId = $snapshotId;
@@ -210,10 +223,16 @@ class RestoreModal extends Component
             return collect();
         }
 
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
         return DatabaseServer::query()
             ->where('database_type', $this->targetServer->database_type)
             ->whereHas('snapshots', function ($query) {
                 $query->whereHas('job', fn ($q) => $q->whereRaw("status = 'completed'"));
+            })
+            ->when($user->isScopedUser(), function ($query) use ($user) {
+                $query->whereIn('id', $user->getAccessibleServerIds());
             })
             ->orderBy('name')
             ->get(['id', 'name']);
@@ -239,11 +258,15 @@ class RestoreModal extends Component
             return null;
         }
 
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
         return SnapshotQuery::buildFromParams(
             search: $this->snapshotSearch ?: null,
             statusFilter: 'completed',
             sortColumn: 'created_at',
-            sortDirection: 'desc'
+            sortDirection: 'desc',
+            scopedUser: $user->isScopedUser() ? $user : null,
         )
             ->whereHas('databaseServer', fn (Builder $q) => $q->whereRaw('database_type = ?', [$this->targetServer->database_type]))
             ->when($this->serverFilter, fn ($q) => $q->where('database_server_id', $this->serverFilter))

--- a/app/Livewire/User/ServerAccess.php
+++ b/app/Livewire/User/ServerAccess.php
@@ -40,12 +40,25 @@ class ServerAccess extends Component
         $this->user = $user;
     }
 
-    public function openGrantModal(): void
+    public function openGrantModal(?string $accessId = null): void
     {
         $this->authorize('update', $this->user);
 
         $this->reset(['selectedServerId', 'allowedDatabases', 'databaseSearch', 'canDownload', 'canBackup', 'canRestore']);
         $this->canDownload = true;
+
+        if ($accessId !== null) {
+            $access = UserServerAccess::where('id', $accessId)
+                ->where('user_id', $this->user->id)
+                ->firstOrFail();
+
+            $this->selectedServerId = $access->database_server_id;
+            $this->allowedDatabases = $access->allowed_databases ?? [];
+            $this->canDownload = $access->can_download;
+            $this->canBackup = $access->can_backup;
+            $this->canRestore = $access->can_restore;
+        }
+
         $this->showGrantModal = true;
     }
 
@@ -142,7 +155,8 @@ class ServerAccess extends Component
     }
 
     /**
-     * Servers that can still be granted (exclude already-granted ones).
+     * Servers available for selection: excludes already-granted servers
+     * except the one currently selected (so editing a grant keeps it visible).
      *
      * @return array<int, array<string, string>>
      */
@@ -150,8 +164,13 @@ class ServerAccess extends Component
     {
         $grantedIds = $this->user->serverAccesses()->pluck('database_server_id')->all();
 
+        // When editing an existing grant, keep its server selectable
+        if ($this->selectedServerId !== '') {
+            $grantedIds = array_filter($grantedIds, fn ($id) => $id !== $this->selectedServerId);
+        }
+
         return DatabaseServer::query()
-            ->whereNotIn('id', $grantedIds)
+            ->whereNotIn('id', array_values($grantedIds))
             ->orderBy('name')
             ->get()
             ->map(fn (DatabaseServer $server) => [

--- a/app/Livewire/User/ServerAccess.php
+++ b/app/Livewire/User/ServerAccess.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Livewire\User;
+
+use App\Models\DatabaseServer;
+use App\Models\Snapshot;
+use App\Models\User;
+use App\Models\UserServerAccess;
+use App\Traits\Toast;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class ServerAccess extends Component
+{
+    use AuthorizesRequests, Toast;
+
+    #[Locked]
+    public User $user;
+
+    public bool $showGrantModal = false;
+
+    public string $selectedServerId = '';
+
+    /** @var array<int, string> */
+    public array $allowedDatabases = [];
+
+    public string $databaseSearch = '';
+
+    public bool $canDownload = true;
+
+    public bool $canBackup = false;
+
+    public bool $canRestore = false;
+
+    public function mount(User $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function openGrantModal(): void
+    {
+        $this->authorize('update', $this->user);
+
+        $this->reset(['selectedServerId', 'allowedDatabases', 'databaseSearch', 'canDownload', 'canBackup', 'canRestore']);
+        $this->canDownload = true;
+        $this->showGrantModal = true;
+    }
+
+    public function updatedSelectedServerId(): void
+    {
+        $this->databaseSearch = '';
+    }
+
+    /**
+     * Known database names from past snapshots for the selected server.
+     *
+     * @return array<int, string>
+     */
+    #[Computed]
+    public function knownDatabases(): array
+    {
+        if ($this->selectedServerId === '') {
+            return [];
+        }
+
+        return Snapshot::where('database_server_id', $this->selectedServerId)
+            ->whereNotNull('database_name')
+            ->when($this->databaseSearch !== '', function ($q) {
+                $q->where('database_name', 'like', '%'.$this->databaseSearch.'%');
+            })
+            ->distinct()
+            ->orderBy('database_name')
+            ->pluck('database_name')
+            ->filter(fn ($db) => ! in_array($db, $this->allowedDatabases, strict: true))
+            ->values()
+            ->all();
+    }
+
+    public function addDatabase(string $database): void
+    {
+        $db = trim($database);
+
+        if ($db !== '' && ! in_array($db, $this->allowedDatabases, strict: true)) {
+            $this->allowedDatabases[] = $db;
+        }
+
+        $this->databaseSearch = '';
+    }
+
+    public function addSearchedDatabase(): void
+    {
+        $this->addDatabase($this->databaseSearch);
+    }
+
+    public function removeDatabase(string $database): void
+    {
+        $this->allowedDatabases = array_values(
+            array_filter($this->allowedDatabases, fn ($d) => $d !== $database)
+        );
+    }
+
+    public function grantAccess(): void
+    {
+        $this->authorize('update', $this->user);
+
+        $this->validate([
+            'selectedServerId' => 'required|exists:database_servers,id',
+            'canDownload' => 'boolean',
+            'canBackup' => 'boolean',
+            'canRestore' => 'boolean',
+        ]);
+
+        UserServerAccess::updateOrCreate(
+            [
+                'user_id' => $this->user->id,
+                'database_server_id' => $this->selectedServerId,
+            ],
+            [
+                'allowed_databases' => ! empty($this->allowedDatabases) ? array_values($this->allowedDatabases) : null,
+                'can_download' => $this->canDownload,
+                'can_backup' => $this->canBackup,
+                'can_restore' => $this->canRestore,
+            ]
+        );
+
+        $this->showGrantModal = false;
+        $this->success(__('Access granted successfully.'));
+    }
+
+    public function revokeAccess(int $accessId): void
+    {
+        $this->authorize('update', $this->user);
+
+        UserServerAccess::where('id', $accessId)
+            ->where('user_id', $this->user->id)
+            ->delete();
+
+        $this->success(__('Access revoked successfully.'));
+    }
+
+    /**
+     * Servers that can still be granted (exclude already-granted ones).
+     *
+     * @return array<int, array<string, string>>
+     */
+    public function availableServerOptions(): array
+    {
+        $grantedIds = $this->user->serverAccesses()->pluck('database_server_id')->all();
+
+        return DatabaseServer::query()
+            ->whereNotIn('id', $grantedIds)
+            ->orderBy('name')
+            ->get()
+            ->map(fn (DatabaseServer $server) => [
+                'id' => $server->id,
+                'name' => $server->name.' ('.$server->database_type->value.')',
+            ])
+            ->toArray();
+    }
+
+    public function render(): View
+    {
+        $accesses = $this->user->serverAccesses()
+            ->with('databaseServer')
+            ->get();
+
+        return view('livewire.user.server-access', [
+            'accesses' => $accesses,
+            'availableServers' => $this->availableServerOptions(),
+        ]);
+    }
+}

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -44,6 +44,8 @@ use Illuminate\Support\Carbon;
  * @property-read int|null $snapshots_count
  * @property-read Collection<int, NotificationChannel> $notificationChannels
  * @property-read int|null $notification_channels_count
+ * @property-read Collection<int, UserServerAccess> $userAccesses
+ * @property-read int|null $user_accesses_count
  *
  * @method static DatabaseServerFactory factory($count = null, $state = [])
  * @method static Builder<static>|DatabaseServer newModelQuery()
@@ -178,6 +180,14 @@ class DatabaseServer extends Model
     public function sshConfig(): BelongsTo
     {
         return $this->belongsTo(DatabaseServerSshConfig::class, 'ssh_config_id');
+    }
+
+    /**
+     * @return HasMany<UserServerAccess, DatabaseServer>
+     */
+    public function userAccesses(): HasMany
+    {
+        return $this->hasMany(UserServerAccess::class);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -38,6 +38,8 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read int|null $triggered_snapshots_count
  * @property-read Collection<int, OAuthIdentity> $oauthIdentities
  * @property-read int|null $oauth_identities_count
+ * @property-read Collection<int, UserServerAccess> $serverAccesses
+ * @property-read int|null $server_accesses_count
  *
  * @method static Builder<static>|User active()
  * @method static UserFactory factory($count = null, $state = [])
@@ -164,6 +166,14 @@ class User extends Authenticatable
         return $this->hasMany(OAuthIdentity::class);
     }
 
+    /**
+     * @return HasMany<UserServerAccess, User>
+     */
+    public function serverAccesses(): HasMany
+    {
+        return $this->hasMany(UserServerAccess::class);
+    }
+
     public function isDemo(): bool
     {
         return $this->role === self::ROLE_DEMO;
@@ -192,6 +202,59 @@ class User extends Authenticatable
     public function canPerformActions(): bool
     {
         return ! $this->isViewer() && ! $this->isDemo();
+    }
+
+    /**
+     * Returns true when this user's visibility is restricted by server access grants.
+     * Admins and members always see everything regardless of any grants.
+     */
+    public function isScopedUser(): bool
+    {
+        if ($this->isAdmin() || $this->isMember()) {
+            return false;
+        }
+
+        return $this->serverAccesses()->exists();
+    }
+
+    /**
+     * Returns the IDs of database servers this user is explicitly granted access to.
+     *
+     * @return array<int, string>
+     */
+    public function getAccessibleServerIds(): array
+    {
+        return $this->serverAccesses()->pluck('database_server_id')->all();
+    }
+
+    public function getServerAccess(DatabaseServer $server): ?UserServerAccess
+    {
+        return $this->serverAccesses()
+            ->where('database_server_id', $server->id)
+            ->first();
+    }
+
+    /**
+     * Applies per-server and per-database visibility constraints to a Snapshot query.
+     * Each grant contributes one OR branch: server match + optional database filter.
+     *
+     * @param  Builder<\App\Models\Snapshot>  $query
+     */
+    public function applyScopedSnapshotFilter(Builder $query): void
+    {
+        $accesses = $this->serverAccesses()->get();
+
+        $query->where(function (Builder $q) use ($accesses) {
+            foreach ($accesses as $access) {
+                $q->orWhere(function (Builder $sq) use ($access) {
+                    $sq->where('database_server_id', $access->database_server_id);
+
+                    if ($access->allowed_databases !== null) {
+                        $sq->whereIn('database_name', $access->allowed_databases);
+                    }
+                });
+            }
+        });
     }
 
     public function isPending(): bool

--- a/app/Models/UserServerAccess.php
+++ b/app/Models/UserServerAccess.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\UserServerAccessFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property string $database_server_id
+ * @property array<int, string>|null $allowed_databases
+ * @property bool $can_download
+ * @property bool $can_backup
+ * @property bool $can_restore
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read DatabaseServer $databaseServer
+ * @property-read User $user
+ *
+ * @method static UserServerAccessFactory factory($count = null, $state = [])
+ *
+ * @mixin \Eloquent
+ */
+class UserServerAccess extends Model
+{
+    /** @use HasFactory<UserServerAccessFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'database_server_id',
+        'allowed_databases',
+        'can_download',
+        'can_backup',
+        'can_restore',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'allowed_databases' => 'array',
+            'can_download' => 'boolean',
+            'can_backup' => 'boolean',
+            'can_restore' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, UserServerAccess>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<DatabaseServer, UserServerAccess>
+     */
+    public function databaseServer(): BelongsTo
+    {
+        return $this->belongsTo(DatabaseServer::class);
+    }
+
+    public function allowsDatabase(string $databaseName): bool
+    {
+        if ($this->allowed_databases === null) {
+            return true;
+        }
+
+        return in_array($databaseName, $this->allowed_databases, strict: true);
+    }
+}

--- a/app/Policies/DatabaseServerPolicy.php
+++ b/app/Policies/DatabaseServerPolicy.php
@@ -86,10 +86,15 @@ class DatabaseServerPolicy
 
     /**
      * Determine whether the user can restore to a server.
+     * Agent-backed servers do not support restore in any form.
      * Scoped users may restore only when their grant includes can_restore.
      */
     public function restore(User $user, DatabaseServer $databaseServer): bool
     {
+        if ($databaseServer->agent_id !== null) {
+            return false;
+        }
+
         if ($user->isScopedUser()) {
             $access = $user->getServerAccess($databaseServer);
 

--- a/app/Policies/DatabaseServerPolicy.php
+++ b/app/Policies/DatabaseServerPolicy.php
@@ -18,10 +18,14 @@ class DatabaseServerPolicy
 
     /**
      * Determine whether the user can view the model.
-     * All authenticated users can view details.
+     * Scoped users may only see servers they have been granted access to.
      */
     public function view(User $user, DatabaseServer $databaseServer): bool
     {
+        if ($user->isScopedUser()) {
+            return $user->getServerAccess($databaseServer) !== null;
+        }
+
         return true;
     }
 
@@ -63,7 +67,7 @@ class DatabaseServerPolicy
 
     /**
      * Determine whether the user can run a backup.
-     * Demo users can trigger backups.
+     * Scoped users may trigger backups when their grant includes can_backup.
      */
     public function backup(User $user, DatabaseServer $databaseServer): bool
     {
@@ -71,15 +75,27 @@ class DatabaseServerPolicy
             return false;
         }
 
+        if ($user->isScopedUser()) {
+            $access = $user->getServerAccess($databaseServer);
+
+            return $access !== null && $access->can_backup;
+        }
+
         return $user->isDemo() || $user->canPerformActions();
     }
 
     /**
      * Determine whether the user can restore to a server.
-     * Demo users can trigger restores.
+     * Scoped users may restore only when their grant includes can_restore.
      */
     public function restore(User $user, DatabaseServer $databaseServer): bool
     {
+        if ($user->isScopedUser()) {
+            $access = $user->getServerAccess($databaseServer);
+
+            return $access !== null && $access->can_restore;
+        }
+
         return $user->isDemo() || $user->canPerformActions();
     }
 }

--- a/app/Policies/DatabaseServerPolicy.php
+++ b/app/Policies/DatabaseServerPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\DatabaseType;
 use App\Models\DatabaseServer;
 use App\Models\User;
 
@@ -86,12 +87,12 @@ class DatabaseServerPolicy
 
     /**
      * Determine whether the user can restore to a server.
-     * Agent-backed servers do not support restore in any form.
+     * Agent-backed and Redis/Valkey servers do not support automated restore.
      * Scoped users may restore only when their grant includes can_restore.
      */
     public function restore(User $user, DatabaseServer $databaseServer): bool
     {
-        if ($databaseServer->agent_id !== null) {
+        if ($databaseServer->agent_id !== null || $databaseServer->database_type === DatabaseType::REDIS) {
             return false;
         }
 

--- a/app/Policies/SnapshotPolicy.php
+++ b/app/Policies/SnapshotPolicy.php
@@ -18,10 +18,14 @@ class SnapshotPolicy
 
     /**
      * Determine whether the user can view the model.
-     * All authenticated users can view details.
+     * Scoped users may only see snapshots from their granted servers and databases.
      */
     public function view(User $user, Snapshot $snapshot): bool
     {
+        if ($user->isScopedUser()) {
+            return $this->snapshotIsAccessible($user, $snapshot);
+        }
+
         return true;
     }
 
@@ -36,10 +40,31 @@ class SnapshotPolicy
 
     /**
      * Determine whether the user can download the snapshot.
-     * Demo users can download snapshots.
+     * Scoped users may download when their grant includes can_download for that server/database.
      */
     public function download(User $user, Snapshot $snapshot): bool
     {
+        if ($user->isScopedUser()) {
+            $access = $user->getServerAccess($snapshot->databaseServer);
+
+            if ($access === null || ! $access->allowsDatabase($snapshot->database_name)) {
+                return false;
+            }
+
+            return $access->can_download;
+        }
+
         return $user->isDemo() || $user->canPerformActions();
+    }
+
+    private function snapshotIsAccessible(User $user, Snapshot $snapshot): bool
+    {
+        $access = $user->getServerAccess($snapshot->databaseServer);
+
+        if ($access === null) {
+            return false;
+        }
+
+        return $access->allowsDatabase($snapshot->database_name);
     }
 }

--- a/app/Queries/BackupJobQuery.php
+++ b/app/Queries/BackupJobQuery.php
@@ -4,6 +4,7 @@ namespace App\Queries;
 
 use App\Models\BackupJob;
 use App\Models\Snapshot;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedSort;
@@ -61,7 +62,8 @@ class BackupJobQuery
         string $serverFilter = '',
         bool $fileMissing = false,
         string $sortColumn = 'created_at',
-        string $sortDirection = 'desc'
+        string $sortDirection = 'desc',
+        ?User $scopedUser = null,
     ): Builder {
         $query = BackupJob::query()
             ->with(self::RELATIONSHIPS)
@@ -91,6 +93,20 @@ class BackupJobQuery
             })
             ->when($fileMissing, function (Builder $query) {
                 $query->whereHas('snapshot', fn (Builder $q) => $q->whereRaw('file_exists = ?', [false]));
+            })
+            ->when($scopedUser, function (Builder $query) use ($scopedUser) {
+                $accesses = $scopedUser->serverAccesses()->get();
+                $query->where(function (Builder $q) use ($accesses) {
+                    foreach ($accesses as $access) {
+                        $q->orWhereHas('snapshot', function (Builder $sq) use ($access) {
+                            $sq->whereRaw('database_server_id = ?', [$access->database_server_id]);
+                            if ($access->allowed_databases !== null) {
+                                $sq->whereIn('database_name', $access->allowed_databases);
+                            }
+                        });
+                        $q->orWhereHas('restore', fn (Builder $rq) => $rq->whereRaw('target_server_id = ?', [$access->database_server_id]));
+                    }
+                });
             });
 
         // Handle sorting

--- a/app/Queries/BackupJobQuery.php
+++ b/app/Queries/BackupJobQuery.php
@@ -104,7 +104,12 @@ class BackupJobQuery
                                 $sq->whereIn('database_name', $access->allowed_databases);
                             }
                         });
-                        $q->orWhereHas('restore', fn (Builder $rq) => $rq->whereRaw('target_server_id = ?', [$access->database_server_id]));
+                        $q->orWhereHas('restore', function (Builder $rq) use ($access) {
+                            $rq->whereRaw('target_server_id = ?', [$access->database_server_id]);
+                            if ($access->allowed_databases !== null) {
+                                $rq->whereIn('schema_name', $access->allowed_databases);
+                            }
+                        });
                     }
                 });
             });

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -4,6 +4,7 @@ namespace App\Queries;
 
 use App\Models\DatabaseServer;
 use App\Models\Restore;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedSort;
@@ -42,7 +43,8 @@ class DatabaseServerQuery
     public static function buildFromParams(
         ?string $search = null,
         string $sortColumn = 'created_at',
-        string $sortDirection = 'desc'
+        string $sortDirection = 'desc',
+        ?User $scopedUser = null,
     ): Builder {
         return DatabaseServer::query()
             ->with(['backups.volume', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])
@@ -51,6 +53,9 @@ class DatabaseServerQuery
                 'restores_count' => Restore::selectRaw('count(*)')
                     ->whereColumn('target_server_id', 'database_servers.id'),
             ])
+            ->when($scopedUser, function (Builder $query) use ($scopedUser) {
+                $query->whereIn('id', $scopedUser->getAccessibleServerIds());
+            })
             ->when($search, function (Builder $query) use ($search) {
                 $query->where(function (Builder $q) use ($search) {
                     $q->where('name', 'like', "%{$search}%")

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -48,14 +48,43 @@ class DatabaseServerQuery
     ): Builder {
         return DatabaseServer::query()
             ->with(['backups.volume', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])
-            ->withCount('snapshots')
-            ->addSelect([
-                'restores_count' => Restore::selectRaw('count(*)')
-                    ->whereColumn('target_server_id', 'database_servers.id'),
-            ])
-            ->when($scopedUser, function (Builder $query) use ($scopedUser) {
-                $query->whereIn('id', $scopedUser->getAccessibleServerIds());
-            })
+            ->when(
+                $scopedUser !== null,
+                function (Builder $query) use ($scopedUser) {
+                    $query->whereIn('id', $scopedUser->getAccessibleServerIds());
+
+                    // Collect all allowed databases across grants; null means unrestricted on that server
+                    $allAllowedDbs = $scopedUser->serverAccesses()->get()
+                        ->filter(fn ($a) => $a->allowed_databases !== null)
+                        ->flatMap(fn ($a) => (array) $a->allowed_databases)
+                        ->unique()
+                        ->values()
+                        ->all();
+
+                    if (! empty($allAllowedDbs)) {
+                        $query
+                            ->withCount(['snapshots' => fn (Builder $q) => $q->whereIn('database_name', $allAllowedDbs)])
+                            ->addSelect([
+                                'restores_count' => Restore::selectRaw('count(*)')
+                                    ->whereColumn('target_server_id', 'database_servers.id')
+                                    ->whereIn('schema_name', $allAllowedDbs),
+                            ]);
+                    } else {
+                        $query
+                            ->withCount('snapshots')
+                            ->addSelect([
+                                'restores_count' => Restore::selectRaw('count(*)')
+                                    ->whereColumn('target_server_id', 'database_servers.id'),
+                            ]);
+                    }
+                },
+                fn (Builder $query) => $query
+                    ->withCount('snapshots')
+                    ->addSelect([
+                        'restores_count' => Restore::selectRaw('count(*)')
+                            ->whereColumn('target_server_id', 'database_servers.id'),
+                    ])
+            )
             ->when($search, function (Builder $query) use ($search) {
                 $query->where(function (Builder $q) use ($search) {
                     $q->where('name', 'like', "%{$search}%")

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -49,34 +49,41 @@ class DatabaseServerQuery
         return DatabaseServer::query()
             ->with(['backups.volume', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])
             ->when(
-                $scopedUser !== null,
+                $scopedUser !== null && $scopedUser->isScopedUser(),
                 function (Builder $query) use ($scopedUser) {
                     $query->whereIn('id', $scopedUser->getAccessibleServerIds());
 
-                    // Collect all allowed databases across grants; null means unrestricted on that server
-                    $allAllowedDbs = $scopedUser->serverAccesses()->get()
-                        ->filter(fn ($a) => $a->allowed_databases !== null)
-                        ->flatMap(fn ($a) => (array) $a->allowed_databases)
-                        ->unique()
-                        ->values()
-                        ->all();
+                    // Build per-server correlated filters so each database_server row
+                    // counts only snapshots/restores permitted by its specific grant.
+                    $accesses = $scopedUser->serverAccesses()->get();
 
-                    if (! empty($allAllowedDbs)) {
-                        $query
-                            ->withCount(['snapshots' => fn (Builder $q) => $q->whereIn('database_name', $allAllowedDbs)])
-                            ->addSelect([
-                                'restores_count' => Restore::selectRaw('count(*)')
-                                    ->whereColumn('target_server_id', 'database_servers.id')
-                                    ->whereIn('schema_name', $allAllowedDbs),
-                            ]);
-                    } else {
-                        $query
-                            ->withCount('snapshots')
-                            ->addSelect([
-                                'restores_count' => Restore::selectRaw('count(*)')
-                                    ->whereColumn('target_server_id', 'database_servers.id'),
-                            ]);
-                    }
+                    $query
+                        ->withCount(['snapshots' => function (Builder $q) use ($accesses) {
+                            $q->where(function (Builder $inner) use ($accesses) {
+                                foreach ($accesses as $access) {
+                                    $inner->orWhere(function (Builder $s) use ($access) {
+                                        $s->whereRaw('snapshots.database_server_id = ?', [$access->database_server_id]);
+                                        if ($access->allowed_databases !== null) {
+                                            $s->whereIn('database_name', $access->allowed_databases);
+                                        }
+                                    });
+                                }
+                            });
+                        }])
+                        ->addSelect([
+                            'restores_count' => Restore::selectRaw('count(*)')
+                                ->whereColumn('target_server_id', 'database_servers.id')
+                                ->where(function (Builder $q) use ($accesses) {
+                                    foreach ($accesses as $access) {
+                                        $q->orWhere(function (Builder $s) use ($access) {
+                                            $s->whereRaw('target_server_id = ?', [$access->database_server_id]);
+                                            if ($access->allowed_databases !== null) {
+                                                $s->whereIn('schema_name', $access->allowed_databases);
+                                            }
+                                        });
+                                    }
+                                }),
+                        ]);
                 },
                 fn (Builder $query) => $query
                     ->withCount('snapshots')

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -3,6 +3,7 @@
 namespace App\Queries;
 
 use App\Models\Snapshot;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\AllowedSort;
@@ -55,10 +56,12 @@ class SnapshotQuery
         ?string $search = null,
         string $statusFilter = 'all',
         string $sortColumn = 'started_at',
-        string $sortDirection = 'desc'
+        string $sortDirection = 'desc',
+        ?User $scopedUser = null,
     ): Builder {
         return Snapshot::query()
             ->with(self::RELATIONSHIPS)
+            ->when($scopedUser, fn (Builder $q) => $scopedUser->applyScopedSnapshotFilter($q))
             ->when($search, function (Builder $query) use ($search) {
                 self::applySearch($query, $search);
             })

--- a/database/factories/UserServerAccessFactory.php
+++ b/database/factories/UserServerAccessFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DatabaseServer;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\UserServerAccess>
+ */
+class UserServerAccessFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'database_server_id' => DatabaseServer::factory(),
+            'allowed_databases' => null,
+            'can_download' => true,
+            'can_backup' => false,
+            'can_restore' => false,
+        ];
+    }
+
+    public function withDatabases(string ...$databases): static
+    {
+        return $this->state(['allowed_databases' => array_values($databases)]);
+    }
+
+    public function canBackup(): static
+    {
+        return $this->state(['can_backup' => true]);
+    }
+
+    public function canRestore(): static
+    {
+        return $this->state(['can_restore' => true]);
+    }
+
+    public function cannotDownload(): static
+    {
+        return $this->state(['can_download' => false]);
+    }
+}

--- a/database/migrations/2026_05_02_000001_create_user_server_accesses_table.php
+++ b/database/migrations/2026_05_02_000001_create_user_server_accesses_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_server_accesses', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('database_server_id', 26);
+            $table->foreign('database_server_id')->references('id')->on('database_servers')->cascadeOnDelete();
+            $table->json('allowed_databases')->nullable()->comment('Null means all databases on this server');
+            $table->boolean('can_download')->default(true);
+            $table->boolean('can_restore')->default(false);
+            $table->timestamps();
+
+            $table->unique(['user_id', 'database_server_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_server_accesses');
+    }
+};

--- a/database/migrations/2026_05_02_000002_add_can_backup_to_user_server_accesses_table.php
+++ b/database/migrations/2026_05_02_000002_add_can_backup_to_user_server_accesses_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_server_accesses', function (Blueprint $table) {
+            $table->boolean('can_backup')->default(false)->after('can_download');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_server_accesses', function (Blueprint $table) {
+            $table->dropColumn('can_backup');
+        });
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - .:/app
       - app-data:/data
     command: sh -c "php artisan db:wait --check-migrations && php artisan queue:work --queue=backups,default --tries=3 --timeout=3600 --sleep=3 --max-jobs=1000"
+    user: "1000:1000"
     restart: unless-stopped
     environment:
       TZ: UTC

--- a/resources/views/livewire/backup-job/index.blade.php
+++ b/resources/views/livewire/backup-job/index.blade.php
@@ -141,6 +141,16 @@
                                 class="btn-ghost btn-sm text-info"
                             />
                         @endcan
+                        @if($job->snapshot->databaseServer)
+                            @can('restore', $job->snapshot->databaseServer)
+                                <x-button
+                                    icon="o-arrow-path"
+                                    wire:click="confirmRestoreFromJob('{{ $job->snapshot->databaseServer->id }}', '{{ $job->snapshot->id }}')"
+                                    tooltip="{{ __('Restore') }}"
+                                    class="btn-ghost btn-sm text-success"
+                                />
+                            @endcan
+                        @endif
                     @endif
                     <x-button
                         icon="o-document-text"
@@ -174,6 +184,9 @@
             @endscope
         </x-table>
     </x-card>
+
+    <!-- RESTORE MODAL -->
+    <livewire:database-server.restore-modal />
 
     <!-- LOGS MODAL -->
     @include('livewire.backup-job._logs-modal')

--- a/resources/views/livewire/backup-job/index.blade.php
+++ b/resources/views/livewire/backup-job/index.blade.php
@@ -146,7 +146,7 @@
                                 <x-button
                                     icon="o-arrow-path"
                                     wire:click="confirmRestoreFromJob('{{ $job->snapshot->databaseServer->id }}', '{{ $job->snapshot->id }}')"
-                                    tooltip="{{ __('Restore') }}"
+                                    :tooltip="__('Restore')"
                                     class="btn-ghost btn-sm text-success"
                                 />
                             @endcan

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -125,10 +125,15 @@
                     <x-button icon="o-arrow-down-tray" wire:click="runBackupAll('{{ $server->id }}')" spinner
                               tooltip="{{ __('Backup now') }}" class="btn-ghost btn-sm text-info" />
                 @endcan
-                @can('restore', $server)
+                @if($server->database_type === \App\Enums\DatabaseType::REDIS)
                     <x-button icon="o-arrow-up-tray" wire:click="confirmRestore('{{ $server->id }}')" spinner
-                              tooltip="{{ __('Restore') }}" class="btn-ghost btn-sm text-success" />
-                @endcan
+                              :tooltip="__('View Restore Instructions')" class="btn-ghost btn-sm text-success" />
+                @else
+                    @can('restore', $server)
+                        <x-button icon="o-arrow-up-tray" wire:click="confirmRestore('{{ $server->id }}')" spinner
+                                  :tooltip="__('Restore')" class="btn-ghost btn-sm text-success" />
+                    @endcan
+                @endif
             </div>
             <div>
                 @can('viewForm', $server)

--- a/resources/views/livewire/user/edit.blade.php
+++ b/resources/views/livewire/user/edit.blade.php
@@ -72,4 +72,6 @@
             </div>
         </form>
     </x-card>
+
+    <livewire:user.server-access :user="$form->user" />
 </div>

--- a/resources/views/livewire/user/server-access.blade.php
+++ b/resources/views/livewire/user/server-access.blade.php
@@ -67,13 +67,21 @@
                         </div>
 
                         @can('update', $user)
-                            <x-button
-                                icon="o-trash"
-                                wire:click="revokeAccess({{ $access->id }})"
-                                tooltip="{{ __('Revoke Access') }}"
-                                class="btn-ghost btn-sm text-error"
-                                wire:confirm="{{ __('Revoke access to this server?') }}"
-                            />
+                            <div class="flex gap-1">
+                                <x-button
+                                    icon="o-pencil"
+                                    wire:click="openGrantModal({{ $access->id }})"
+                                    :tooltip="__('Edit Access')"
+                                    class="btn-ghost btn-sm"
+                                />
+                                <x-button
+                                    icon="o-trash"
+                                    wire:click="revokeAccess({{ $access->id }})"
+                                    :tooltip="__('Revoke Access')"
+                                    class="btn-ghost btn-sm text-error"
+                                    wire:confirm="{{ __('Revoke access to this server?') }}"
+                                />
+                            </div>
                         @endcan
                     </div>
                 @endforeach

--- a/resources/views/livewire/user/server-access.blade.php
+++ b/resources/views/livewire/user/server-access.blade.php
@@ -14,7 +14,7 @@
             @if(!$user->isAdmin() && !$user->isMember())
                 @can('update', $user)
                     <x-button
-                        label="{{ __('Grant Access') }}"
+                        :label="__('Grant Access')"
                         icon="o-plus"
                         class="btn-primary btn-sm"
                         wire:click="openGrantModal"
@@ -94,9 +94,9 @@
         <div class="space-y-4">
             <x-select
                 wire:model.live="selectedServerId"
-                label="{{ __('Database Server') }}"
+                :label="__('Database Server')"
                 :options="$availableServers"
-                placeholder="{{ __('Select a server…') }}"
+                :placeholder="__('Select a server…')"
                 required
             />
 
@@ -122,13 +122,13 @@
                 <div class="flex gap-2">
                     <x-input
                         wire:model.live="databaseSearch"
-                        placeholder="{{ __('Search or type a database name…') }}"
+                        :placeholder="__('Search or type a database name…')"
                         class="flex-1"
                         wire:keydown.enter.prevent="addSearchedDatabase"
                         :disabled="$selectedServerId === ''"
                     />
                     <x-button
-                        label="{{ __('Add') }}"
+                        :label="__('Add')"
                         wire:click="addSearchedDatabase"
                         class="btn-ghost btn-sm"
                         :disabled="$databaseSearch === ''"
@@ -160,15 +160,15 @@
 
             <div class="space-y-2">
                 <label class="label label-text font-semibold">{{ __('Permissions') }}</label>
-                <x-checkbox wire:model="canDownload" label="{{ __('Allow downloading snapshots') }}" />
-                <x-checkbox wire:model="canBackup" label="{{ __('Allow triggering manual backups') }}" />
-                <x-checkbox wire:model="canRestore" label="{{ __('Allow restoring snapshots') }}" />
+                <x-checkbox wire:model="canDownload" :label="__('Allow downloading snapshots')" />
+                <x-checkbox wire:model="canBackup" :label="__('Allow triggering manual backups')" />
+                <x-checkbox wire:model="canRestore" :label="__('Allow restoring snapshots')" />
             </div>
         </div>
 
         <x-slot:actions>
-            <x-button label="{{ __('Cancel') }}" wire:click="$set('showGrantModal', false)" />
-            <x-button label="{{ __('Grant Access') }}" class="btn-primary" wire:click="grantAccess" spinner="grantAccess" />
+            <x-button :label="__('Cancel')" wire:click="$set('showGrantModal', false)" />
+            <x-button :label="__('Grant Access')" class="btn-primary" wire:click="grantAccess" spinner="grantAccess" />
         </x-slot:actions>
     </x-modal>
 </div>

--- a/resources/views/livewire/user/server-access.blade.php
+++ b/resources/views/livewire/user/server-access.blade.php
@@ -1,0 +1,166 @@
+<div>
+    <x-card class="mt-6">
+        <div class="flex items-center justify-between mb-4">
+            <div>
+                <h3 class="font-semibold text-base">{{ __('Server Access') }}</h3>
+                <p class="text-sm text-base-content/60 mt-0.5">
+                    @if($user->isAdmin() || $user->isMember())
+                        {{ __('This user has full access to all servers based on their role.') }}
+                    @else
+                        {{ __('Restrict this user to specific servers and databases. Without any grants, viewers see all servers.') }}
+                    @endif
+                </p>
+            </div>
+            @if(!$user->isAdmin() && !$user->isMember())
+                @can('update', $user)
+                    <x-button
+                        label="{{ __('Grant Access') }}"
+                        icon="o-plus"
+                        class="btn-primary btn-sm"
+                        wire:click="openGrantModal"
+                    />
+                @endcan
+            @endif
+        </div>
+
+        @if($user->isAdmin() || $user->isMember())
+            {{-- No grants UI for privileged roles --}}
+        @elseif($accesses->isEmpty())
+            <div class="text-sm text-base-content/50 py-4 text-center">
+                {{ __('No server access grants. This user can view all servers as a Viewer.') }}
+            </div>
+        @else
+            <div class="space-y-2">
+                @foreach($accesses as $access)
+                    <div class="flex items-start justify-between gap-4 p-3 rounded-lg bg-base-200">
+                        <div class="flex-1 min-w-0">
+                            <div class="font-medium text-sm">{{ $access->databaseServer->name }}</div>
+                            <div class="text-xs text-base-content/60 mt-0.5">{{ $access->databaseServer->host }}</div>
+
+                            @if($access->allowed_databases)
+                                <div class="flex flex-wrap gap-1 mt-1.5">
+                                    @foreach($access->allowed_databases as $db)
+                                        <x-badge :value="$db" class="badge-outline badge-sm" />
+                                    @endforeach
+                                </div>
+                            @else
+                                <div class="text-xs text-base-content/50 mt-1">{{ __('All databases') }}</div>
+                            @endif
+
+                            <div class="flex gap-3 mt-1.5">
+                                @if($access->can_download)
+                                    <span class="text-xs text-success flex items-center gap-1">
+                                        <x-icon name="o-arrow-down-tray" class="w-3 h-3" /> {{ __('Download') }}
+                                    </span>
+                                @endif
+                                @if($access->can_backup)
+                                    <span class="text-xs text-warning flex items-center gap-1">
+                                        <x-icon name="o-circle-stack" class="w-3 h-3" /> {{ __('Backup') }}
+                                    </span>
+                                @endif
+                                @if($access->can_restore)
+                                    <span class="text-xs text-info flex items-center gap-1">
+                                        <x-icon name="o-arrow-path" class="w-3 h-3" /> {{ __('Restore') }}
+                                    </span>
+                                @endif
+                            </div>
+                        </div>
+
+                        @can('update', $user)
+                            <x-button
+                                icon="o-trash"
+                                wire:click="revokeAccess({{ $access->id }})"
+                                tooltip="{{ __('Revoke Access') }}"
+                                class="btn-ghost btn-sm text-error"
+                                wire:confirm="{{ __('Revoke access to this server?') }}"
+                            />
+                        @endcan
+                    </div>
+                @endforeach
+            </div>
+        @endif
+    </x-card>
+
+    <!-- GRANT ACCESS MODAL -->
+    <x-modal wire:model="showGrantModal" :title="__('Grant Server Access')" class="backdrop-blur">
+        <div class="space-y-4">
+            <x-select
+                wire:model.live="selectedServerId"
+                label="{{ __('Database Server') }}"
+                :options="$availableServers"
+                placeholder="{{ __('Select a server…') }}"
+                required
+            />
+
+            <div>
+                <label class="label label-text font-semibold mb-1">{{ __('Allowed Databases') }}</label>
+                <p class="text-xs text-base-content/60 mb-2">{{ __('Leave empty to allow access to all databases on this server.') }}</p>
+
+                @if(count($allowedDatabases) > 0)
+                    <div class="flex flex-wrap gap-1.5 mb-2">
+                        @foreach($allowedDatabases as $db)
+                            <span class="badge badge-outline gap-1 text-sm">
+                                {{ $db }}
+                                <button
+                                    type="button"
+                                    wire:click="removeDatabase('{{ $db }}')"
+                                    class="ml-0.5 hover:text-error leading-none"
+                                >×</button>
+                            </span>
+                        @endforeach
+                    </div>
+                @endif
+
+                <div class="flex gap-2">
+                    <x-input
+                        wire:model.live="databaseSearch"
+                        placeholder="{{ __('Search or type a database name…') }}"
+                        class="flex-1"
+                        wire:keydown.enter.prevent="addSearchedDatabase"
+                        :disabled="$selectedServerId === ''"
+                    />
+                    <x-button
+                        label="{{ __('Add') }}"
+                        wire:click="addSearchedDatabase"
+                        class="btn-ghost btn-sm"
+                        :disabled="$databaseSearch === ''"
+                    />
+                </div>
+
+                @if($selectedServerId !== '' && count($this->knownDatabases) > 0)
+                    <div class="mt-2 border border-base-300 rounded-lg overflow-hidden">
+                        <div class="text-xs text-base-content/50 px-3 py-1.5 bg-base-200">
+                            {{ __('Known databases from past snapshots') }}
+                        </div>
+                        @foreach($this->knownDatabases as $db)
+                            <button
+                                type="button"
+                                wire:click="addDatabase('{{ $db }}')"
+                                class="w-full text-left px-3 py-2 text-sm hover:bg-base-200 flex items-center gap-2 border-t border-base-300 first:border-0"
+                            >
+                                <x-icon name="o-circle-stack" class="w-3.5 h-3.5 text-base-content/40" />
+                                {{ $db }}
+                            </button>
+                        @endforeach
+                    </div>
+                @elseif($selectedServerId !== '' && $databaseSearch !== '' && count($this->knownDatabases) === 0)
+                    <p class="text-xs text-base-content/50 mt-1.5">{{ __('No matching databases found in snapshot history. Press Add or Enter to add it anyway.') }}</p>
+                @elseif($selectedServerId !== '')
+                    <p class="text-xs text-base-content/50 mt-1.5">{{ __('Start typing to search databases from past snapshots.') }}</p>
+                @endif
+            </div>
+
+            <div class="space-y-2">
+                <label class="label label-text font-semibold">{{ __('Permissions') }}</label>
+                <x-checkbox wire:model="canDownload" label="{{ __('Allow downloading snapshots') }}" />
+                <x-checkbox wire:model="canBackup" label="{{ __('Allow triggering manual backups') }}" />
+                <x-checkbox wire:model="canRestore" label="{{ __('Allow restoring snapshots') }}" />
+            </div>
+        </div>
+
+        <x-slot:actions>
+            <x-button label="{{ __('Cancel') }}" wire:click="$set('showGrantModal', false)" />
+            <x-button label="{{ __('Grant Access') }}" class="btn-primary" wire:click="grantAccess" spinner="grantAccess" />
+        </x-slot:actions>
+    </x-modal>
+</div>

--- a/tests/Feature/User/ServerAccessTest.php
+++ b/tests/Feature/User/ServerAccessTest.php
@@ -1,0 +1,264 @@
+<?php
+
+use App\Livewire\BackupJob\Index as BackupJobIndex;
+use App\Livewire\DatabaseServer\Index as DatabaseServerIndex;
+use App\Livewire\User\ServerAccess;
+use App\Models\DatabaseServer;
+use App\Models\User;
+use App\Models\UserServerAccess;
+use Livewire\Livewire;
+
+// ── Scoped visibility ────────────────────────────────────────────────────────
+
+test('viewer without grants sees all servers', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create(['name' => 'Production DB']);
+
+    Livewire::actingAs($viewer)
+        ->test(DatabaseServerIndex::class)
+        ->assertSee('Production DB');
+});
+
+test('viewer with grants only sees granted servers', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $granted = DatabaseServer::factory()->create(['name' => 'Client DB']);
+    $hidden = DatabaseServer::factory()->create(['name' => 'Other Client DB']);
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $granted->id,
+    ]);
+
+    Livewire::actingAs($viewer)
+        ->test(DatabaseServerIndex::class)
+        ->assertSee('Client DB')
+        ->assertDontSee('Other Client DB');
+});
+
+test('member sees all servers regardless of grants', function () {
+    $member = User::factory()->create(['role' => 'member']);
+    $server = DatabaseServer::factory()->create(['name' => 'All Servers DB']);
+
+    // Grant to a different server only — member should still see both
+    UserServerAccess::factory()->create([
+        'user_id' => $member->id,
+        'database_server_id' => DatabaseServer::factory()->create()->id,
+    ]);
+
+    Livewire::actingAs($member)
+        ->test(DatabaseServerIndex::class)
+        ->assertSee('All Servers DB');
+});
+
+test('admin sees all servers regardless of grants', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    DatabaseServer::factory()->create(['name' => 'Admin Visible DB']);
+
+    Livewire::actingAs($admin)
+        ->test(DatabaseServerIndex::class)
+        ->assertSee('Admin Visible DB');
+});
+
+// ── Policy: DatabaseServerPolicy ────────────────────────────────────────────
+
+test('scoped viewer cannot view server they have no grant for', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    // Grant access to a different server so viewer becomes scoped
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => DatabaseServer::factory()->create()->id,
+    ]);
+
+    expect($viewer->isScopedUser())->toBeTrue();
+    expect($viewer->can('view', $server))->toBeFalse();
+});
+
+test('scoped viewer can view server they have a grant for', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $server->id,
+    ]);
+
+    expect($viewer->can('view', $server))->toBeTrue();
+});
+
+test('scoped viewer without can_restore cannot restore', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $server->id,
+        'can_restore' => false,
+    ]);
+
+    expect($viewer->can('restore', $server))->toBeFalse();
+});
+
+test('scoped viewer with can_restore can restore', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $server->id,
+        'can_restore' => true,
+    ]);
+
+    expect($viewer->can('restore', $server))->toBeTrue();
+});
+
+// ── Policy: SnapshotPolicy ───────────────────────────────────────────────────
+
+test('scoped viewer cannot download snapshot from ungranted server', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    // Make viewer scoped by granting a different server
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => DatabaseServer::factory()->create()->id,
+        'can_download' => true,
+    ]);
+
+    $snapshot = \App\Models\Snapshot::factory()->forServer($server)->create();
+
+    expect($viewer->can('download', $snapshot))->toBeFalse();
+});
+
+test('scoped viewer can download snapshot when grant allows all databases', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $server->id,
+        'allowed_databases' => null,
+        'can_download' => true,
+    ]);
+
+    $snapshot = \App\Models\Snapshot::factory()->forServer($server)->create(['database_name' => 'any_db']);
+
+    expect($viewer->can('download', $snapshot))->toBeTrue();
+});
+
+test('scoped viewer cannot download snapshot for unallowed database', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $server->id,
+        'allowed_databases' => ['allowed_db'],
+        'can_download' => true,
+    ]);
+
+    $snapshot = \App\Models\Snapshot::factory()->forServer($server)->create(['database_name' => 'other_db']);
+
+    expect($viewer->can('download', $snapshot))->toBeFalse();
+});
+
+test('scoped viewer can download snapshot for allowed database', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $server->id,
+        'allowed_databases' => ['client_db'],
+        'can_download' => true,
+    ]);
+
+    $snapshot = \App\Models\Snapshot::factory()->forServer($server)->create(['database_name' => 'client_db']);
+
+    expect($viewer->can('download', $snapshot))->toBeTrue();
+});
+
+// ── Admin UI: ServerAccess component ────────────────────────────────────────
+
+test('admin can grant server access to a viewer', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    Livewire::actingAs($admin)
+        ->test(ServerAccess::class, ['user' => $viewer])
+        ->call('openGrantModal')
+        ->set('selectedServerId', $server->id)
+        ->set('canDownload', true)
+        ->set('canRestore', false)
+        ->call('grantAccess');
+
+    expect(UserServerAccess::where('user_id', $viewer->id)
+        ->where('database_server_id', $server->id)
+        ->exists()
+    )->toBeTrue();
+});
+
+test('admin can revoke server access', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $access = UserServerAccess::factory()->create(['user_id' => $viewer->id]);
+
+    Livewire::actingAs($admin)
+        ->test(ServerAccess::class, ['user' => $viewer])
+        ->call('revokeAccess', $access->id);
+
+    expect(UserServerAccess::find($access->id))->toBeNull();
+});
+
+test('non-admin cannot manage server access grants', function () {
+    $member = User::factory()->create(['role' => 'member']);
+    $viewer = User::factory()->create(['role' => 'viewer']);
+
+    Livewire::actingAs($member)
+        ->test(ServerAccess::class, ['user' => $viewer])
+        ->call('openGrantModal')
+        ->assertForbidden();
+});
+
+test('granting access with specific databases restricts to those databases', function () {
+    $admin = User::factory()->create(['role' => 'admin']);
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $server = DatabaseServer::factory()->create();
+
+    Livewire::actingAs($admin)
+        ->test(ServerAccess::class, ['user' => $viewer])
+        ->call('openGrantModal')
+        ->set('selectedServerId', $server->id)
+        ->set('allowedDatabases', ['client_db', 'shop_db'])
+        ->call('grantAccess');
+
+    $access = UserServerAccess::where('user_id', $viewer->id)
+        ->where('database_server_id', $server->id)
+        ->first();
+
+    expect($access)->not->toBeNull();
+    expect($access->allowed_databases)->toBe(['client_db', 'shop_db']);
+});
+
+// ── BackupJob scoping ────────────────────────────────────────────────────────
+
+test('scoped viewer only sees backup jobs for their granted servers', function () {
+    $viewer = User::factory()->create(['role' => 'viewer']);
+    $grantedServer = DatabaseServer::factory()->create(['name' => 'Granted Server']);
+    $otherServer = DatabaseServer::factory()->create(['name' => 'Hidden Server']);
+
+    UserServerAccess::factory()->create([
+        'user_id' => $viewer->id,
+        'database_server_id' => $grantedServer->id,
+    ]);
+
+    \App\Models\Snapshot::factory()->forServer($grantedServer)->create();
+    \App\Models\Snapshot::factory()->forServer($otherServer)->create();
+
+    Livewire::actingAs($viewer)
+        ->test(BackupJobIndex::class)
+        ->assertSee('Granted Server')
+        ->assertDontSee('Hidden Server');
+});


### PR DESCRIPTION
## Context

This is a proof-of-concept implementation for [#257](https://github.com/David-Crty/databasement/issues/257).

The use case comes from hosting companies and MSPs running Databasement as a shared platform: they need to give individual clients (or teams) access to only their own database servers and databases — without promoting them to the Member role, which grants global access.

Currently the only options are:
- **Viewer** — read-only, but sees _everything_
- **Member** — can act, but sees _everything_
- **Admin** — full control

There is no middle ground for "this user may only see Server A and only the `prod` database within it, and may download/restore but not delete."

This PR implements exactly that. It has been built and tested locally against the full test suite. It is presented as a starting point for the maintainers to validate, polish, and adapt to their standards before merging.

---

## What this adds

### `user_server_accesses` table (new migration)

A pivot table linking users to database servers with fine-grained control:

| Column | Type | Description |
|---|---|---|
| `user_id` | FK | The user being granted access |
| `database_server_id` | FK (ULID) | The server they may access |
| `allowed_databases` | JSON / null | Specific database names, or `null` for all databases on the server |
| `can_download` | bool | May download snapshot files (default `true`) |
| `can_backup` | bool | May trigger manual backups (default `false`) |
| `can_restore` | bool | May restore snapshots (default `false`) |
| unique | — | One grant per user/server pair |

### Scoping behaviour

The logic follows a simple principle: **Admin and Member roles are completely unaffected.** Only Viewer/Demo users with at least one grant become "scoped users". A Viewer with _no_ grants retains the existing read-only-everything behaviour.

When a user is scoped, every listing query is filtered:

- **Server index** — only shows granted servers
- **Snapshot/job index** — shows only snapshots from granted servers, further filtered to `allowed_databases` when set
- **Restore modal** — server dropdown and snapshot list both respect grants

### Per-grant action permissions

Policy checks for `backup`, `restore`, and `download` now consult the grant for scoped users:

```php
// DatabaseServerPolicy
public function backup(User $user, DatabaseServer $server): bool
{
    if ($user->isScopedUser()) {
        $access = $user->getServerAccess($server);
        return $access !== null && $access->can_backup;
    }
    return $user->isDemo() || $user->canPerformActions();
}
```

### Server Access UI (admin side)

A new `livewire:user.server-access` component is embedded at the bottom of the user edit page. Admins can:

- Grant access to a server (servers already granted are excluded from the dropdown)
- Optionally restrict to specific databases — with live autocomplete from past snapshot history (no live DB connection required)
- Toggle download / backup / restore permissions per grant
- Revoke access with one click

### Restore from jobs list

A restore button has been added to each completed backup job row (gated by `@can('restore', $server)`). Clicking it opens the restore modal with the snapshot pre-selected, skipping the snapshot-selection step.

### Docker worker user fix

The queue worker was running as `root`, causing backup files to be created with `700 root` permissions in `/data/backups`. The PHP process (running as `application`) could not read them, resulting in 404 on download. Fixed by adding `user: "1000:1000"` to the worker service in `docker-compose.yml`.

---

## Files changed

**New files:**
- `database/migrations/2026_05_02_000001_create_user_server_accesses_table.php`
- `database/migrations/2026_05_02_000002_add_can_backup_to_user_server_accesses_table.php`
- `app/Models/UserServerAccess.php`
- `database/factories/UserServerAccessFactory.php`
- `app/Livewire/User/ServerAccess.php`
- `resources/views/livewire/user/server-access.blade.php`
- `tests/Feature/User/ServerAccessTest.php`

**Modified files:**
- `app/Models/User.php` — `serverAccesses()`, `isScopedUser()`, `getAccessibleServerIds()`, `getServerAccess()`, `applyScopedSnapshotFilter()`
- `app/Models/DatabaseServer.php` — `userAccesses()` relationship
- `app/Policies/DatabaseServerPolicy.php` — `view()`, `backup()`, `restore()` honour grants for scoped users
- `app/Policies/SnapshotPolicy.php` — `view()`, `download()` honour grants and `allowed_databases` for scoped users
- `app/Queries/DatabaseServerQuery.php` — `scopedUser` parameter
- `app/Queries/SnapshotQuery.php` — `scopedUser` parameter
- `app/Queries/BackupJobQuery.php` — `scopedUser` parameter with per-database filtering
- `app/Livewire/DatabaseServer/Index.php` — passes `scopedUser` to query
- `app/Livewire/DatabaseServer/RestoreModal.php` — `open-restore-from-snapshot` event listener; snapshot/server lists respect grants
- `app/Livewire/BackupJob/Index.php` — `confirmRestoreFromJob()`, passes `scopedUser` to query
- `resources/views/livewire/backup-job/index.blade.php` — restore button per job row, includes restore modal
- `resources/views/livewire/user/edit.blade.php` — embeds `server-access` component
- `docker-compose.yml` — worker runs as `user: "1000:1000"`

---

## Testing

All 914 existing tests pass. A dedicated test file covers:

- Viewer without grants sees all servers/snapshots (unchanged behaviour)
- Viewer with grants sees only granted servers and databases
- Policy checks: view, backup, restore, download — scoped and unscoped
- Database-level filtering (`allowed_databases`)
- Admin UI: grant, revoke
- BackupJob scoping

```
Tests: 914 passed (2711 assertions)
```

---

## Notes for maintainers

This is a PoC and may need polishing before merge:

- Migration timestamps use a fixed date — these should be adjusted to `date('Y_m_d_His')` format before merging to avoid ordering conflicts
- The `docker-compose.yml` change (worker user) is a local dev fix — may warrant a separate PR
- `UserServerAccess` has no soft-deletes; revoking a grant is a hard delete
- The `isScopedUser()` method makes a DB query on every call — a cached version may be desirable for high-traffic installs
- The dashboard (storage card, latest jobs widget) is not yet scoped for scoped users — snapshots/sizes shown there still reflect global state
- Consider whether `can_backup` should default to `true` or remain `false` (currently `false` to be conservative)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user server access management with configurable permissions (download, backup, restore) and UI on the user edit page
  * Restore-from-snapshot flow accessible from backup job rows and an enhanced restore modal

* **Improvements**
  * Scoped visibility: restricted users now see only granted servers, snapshots, and backup jobs
  * Specialized restore handling for Redis/Valkey targets

* **Tests**
  * End-to-end feature and policy tests covering access grants and scoped behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->