### PR TITLE
feat: detect OS light/dark preference for default theme

### DIFF
--- a/app/Livewire/Settings/Preferences.php
+++ b/app/Livewire/Settings/Preferences.php
@@ -14,13 +14,9 @@ class Preferences extends Component
 
     public string $locale = '';
 
-    public string $theme = 'dark';
-
     public function mount(): void
     {
         $this->locale = app()->getLocale();
-        $theme = request()->cookie('theme');
-        $this->theme = is_string($theme) ? $theme : 'dark';
     }
 
     public function setLocale(string $locale): void
@@ -40,15 +36,6 @@ class Preferences extends Component
             title: __('Preference saved successfully!'),
             redirectTo: route('preferences.edit')
         );
-    }
-
-    public function setTheme(string $theme): void
-    {
-        $this->theme = $theme;
-
-        cookie()->queue('theme', $theme, 60 * 24 * 365);
-
-        $this->skipRender();
     }
 
     public function render(): View

--- a/resources/views/layouts/_theme-init.blade.php
+++ b/resources/views/layouts/_theme-init.blade.php
@@ -1,0 +1,14 @@
+<meta name="theme-legacy" content="{{ request()->cookie('theme', '') }}">
+<script>
+    function applyTheme() {
+        var legacy = document.querySelector('meta[name="theme-legacy"]');
+        if (legacy && legacy.content && !localStorage.getItem('theme')) {
+            localStorage.setItem('theme', legacy.content);
+        }
+        var theme = localStorage.getItem('theme') ||
+            (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+        document.documentElement.setAttribute('data-theme', theme);
+    }
+    applyTheme();
+    document.addEventListener('livewire:navigated', applyTheme);
+</script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ request()->cookie('theme', 'dark') }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
@@ -7,6 +7,7 @@
     <title>{{ isset($title) ? $title.' - '.config('app.name') : config('app.name') }}</title>
     <link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('apple-touch-icon.png') }}/">
+    @include('layouts._theme-init')
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body class="min-h-screen font-sans antialiased bg-base-200">

--- a/resources/views/layouts/auth.blade.php
+++ b/resources/views/layouts/auth.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" data-theme="{{ request()->cookie('theme', 'dark') }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover">
@@ -7,6 +7,7 @@
     <title>{{ isset($title) ? $title.' - '.config('app.name') : config('app.name') }}</title>
     <link rel="icon" href="{{ asset('favicon.svg') }}" type="image/svg+xml">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('apple-touch-icon.png') }}/">
+    @include('layouts._theme-init')
     @vite(['resources/css/app.css', 'resources/js/app.js'])
 </head>
 <body class="min-h-screen bg-base-200 antialiased">

--- a/resources/views/livewire/settings/preferences.blade.php
+++ b/resources/views/livewire/settings/preferences.blade.php
@@ -1,9 +1,10 @@
 <div x-data="{
-    currentTheme: @js($theme),
+    currentTheme: localStorage.getItem('theme') ||
+        (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'),
     setTheme(theme) {
         this.currentTheme = theme;
+        localStorage.setItem('theme', theme);
         document.documentElement.setAttribute('data-theme', theme);
-        $wire.setTheme(theme);
     },
     isActive(theme) {
         return this.currentTheme === theme;

--- a/tests/Feature/LocaleTest.php
+++ b/tests/Feature/LocaleTest.php
@@ -82,29 +82,6 @@ test('preferences page shows language selector', function () {
         ->assertSee('Français');
 });
 
-test('setting theme via component sets cookie', function () {
-    $user = User::factory()->create();
-
-    Livewire::actingAs($user)
-        ->test(Preferences::class)
-        ->call('setTheme', 'cyberpunk')
-        ->assertSet('theme', 'cyberpunk');
-
-    $cookie = Cookie::queued('theme');
-    expect($cookie)->not->toBeNull()
-        ->and($cookie->getValue())->toBe('cyberpunk');
-});
-
-test('theme cookie is applied to layout', function () {
-    $user = User::factory()->create();
-
-    $this->actingAs($user)
-        ->withCookie('theme', 'cyberpunk')
-        ->get(route('preferences.edit'))
-        ->assertOk()
-        ->assertSee('data-theme="cyberpunk"', false);
-});
-
 test('french translations are applied when locale is fr', function () {
     $user = User::factory()->create();
 


### PR DESCRIPTION
## Summary

Inspired by #260, which proposed auto-switching between two user-selected themes based on OS preference. While we appreciated the idea, we wanted to keep things simpler — both in code complexity and user experience.

Instead of adding a full auto/manual toggle with dual theme pickers, this PR takes a minimal approach:

- **New users** get a theme matching their OS preference (`light` or `dark`) instead of always defaulting to `dark`
- **Existing users** who already picked a theme are unaffected — their choice is migrated from the server-side cookie to `localStorage` on first visit
- **Theme management moved entirely client-side** — no more server-side cookies, no Livewire round-trips just to change a visual preference

This keeps the UI unchanged (single theme picker, no new options to learn) while still respecting the user's OS preference out of the box.

## Changes

| File | What changed |
|---|---|
| `resources/views/layouts/_theme-init.blade.php` | New partial: reads `localStorage`, falls back to OS `prefers-color-scheme`, migrates legacy cookie |
| `resources/views/layouts/app.blade.php` | Removed server-side `data-theme`, includes `_theme-init` partial |
| `resources/views/layouts/auth.blade.php` | Same as above |
| `app/Livewire/Settings/Preferences.php` | Removed `$theme` property, `setTheme()` method, and cookie logic |
| `resources/views/livewire/settings/preferences.blade.php` | Alpine reads/writes `localStorage` directly, no `$wire` call |
| `tests/Feature/LocaleTest.php` | Removed 2 theme cookie tests (no longer applicable) |

## Test plan

- [ ] New user (no cookie, no localStorage): theme matches OS preference
- [ ] Existing user with theme cookie: theme is preserved after upgrade
- [ ] Picking a theme in Preferences: saves to localStorage, applies immediately
- [ ] Page reload: no flash of wrong theme
- [ ] `wire:navigate` navigation: theme persists correctly
- [ ] All 895 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Transitioned theme management from server-side to client-side using browser storage for instant, seamless theme switching without server requests.
  * Theme initialization now occurs in the browser using localStorage with automatic fallback to system preferences.

* **Tests**
  * Removed theme-related test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->