### PR TITLE
feat: add Firebird backup and restore support

### DIFF
--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -12,6 +12,7 @@ enum DatabaseType: string
     case REDIS = 'redis';
     case MONGODB = 'mongodb';
     case MSSQL = 'mssql';
+    case FIREBIRD = 'firebird';
 
     public function label(): string
     {
@@ -22,6 +23,7 @@ enum DatabaseType: string
             self::REDIS => 'Redis / Valkey',
             self::MONGODB => 'MongoDB',
             self::MSSQL => 'Microsoft SQL Server',
+            self::FIREBIRD => 'Firebird',
         };
     }
 
@@ -34,6 +36,7 @@ enum DatabaseType: string
             self::REDIS => 'devicon.redis',
             self::MONGODB => 'devicon.mongodb',
             self::MSSQL => 'devicon.microsoftsqlserver',
+            self::FIREBIRD => 'o-circle-stack',
         };
     }
 
@@ -46,6 +49,7 @@ enum DatabaseType: string
             self::REDIS => 6379,
             self::MONGODB => 27017,
             self::MSSQL => 1433,
+            self::FIREBIRD => 3050,
         };
     }
 
@@ -80,6 +84,7 @@ enum DatabaseType: string
             self::MSSQL => $database
                 ? sprintf('sqlsrv:Server=%s,%d;Database=%s;TrustServerCertificate=true;Encrypt=true', $host, $port, $database)
                 : sprintf('sqlsrv:Server=%s,%d;TrustServerCertificate=true;Encrypt=true', $host, $port),
+            self::FIREBIRD => throw new \RuntimeException('Firebird does not support PDO connections'),
         };
     }
 
@@ -92,7 +97,7 @@ enum DatabaseType: string
      */
     public function createPdo(DatabaseServer $server, ?string $database = null, int $timeout = 30): \PDO
     {
-        if (in_array($this, [self::REDIS, self::MONGODB], true)) {
+        if (in_array($this, [self::REDIS, self::MONGODB, self::FIREBIRD], true)) {
             throw new \RuntimeException("{$this->label()} does not support PDO connections");
         }
 
@@ -142,6 +147,7 @@ enum DatabaseType: string
             self::REDIS => 'rdb',
             self::MONGODB => 'archive',
             self::MSSQL => 'dacpac',
+            self::FIREBIRD => 'fbk',
             default => 'sql',
         };
     }

--- a/app/Livewire/Forms/BackupForm.php
+++ b/app/Livewire/Forms/BackupForm.php
@@ -135,6 +135,11 @@ final class BackupForm
             return;
         }
 
+        if ($serverType === DatabaseType::FIREBIRD) {
+            $entry['database_selection_mode'] = DatabaseSelectionMode::Selected->value;
+            $entry['database_include_pattern'] = null;
+        }
+
         $mode = $entry['database_selection_mode'] ?? null;
 
         if ($mode !== DatabaseSelectionMode::Selected->value) {
@@ -164,7 +169,9 @@ final class BackupForm
             return;
         }
 
-        // Only needed when no multiselect options are loaded.
+        // Firebird uses the same free-text input as other client-server
+        // databases, but it never loads a selectable database list.
+        // Only skip normalization when a multiselect dropdown is actually in use.
         if (! empty($availableDatabases)) {
             return;
         }

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -245,6 +245,12 @@ class DatabaseServerForm extends Form
         if ($value === 'mongodb' && $this->auth_source === '') {
             $this->auth_source = 'admin';
         }
+
+        if ($value === 'firebird') {
+            foreach ($this->backups as $index => $backup) {
+                $this->backups[$index]['database_selection_mode'] = 'selected';
+            }
+        }
     }
 
     /**
@@ -550,6 +556,28 @@ class DatabaseServerForm extends Form
     }
 
     /**
+     * Flatten, de-duplicate and return configured database names across the
+     * backup cards. Used for connection testing for database types that
+     * require explicit per-database targets such as Firebird.
+     *
+     * @return array<int, string>
+     */
+    private function collectConfiguredDatabaseNames(): array
+    {
+        $names = [];
+
+        foreach ($this->backups as $backup) {
+            foreach ($backup['database_names'] ?? [] as $name) {
+                if (is_string($name) && trim($name) !== '') {
+                    $names[] = trim($name);
+                }
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    /**
      * Add an empty SQLite file path row to the given backup card.
      */
     public function addDatabasePath(int $backupIndex): void
@@ -604,7 +632,7 @@ class DatabaseServerForm extends Form
     }
 
     /**
-     * Check if current database type is Microsoft SQL Server
+     * Check if current database type is Microsoft SQL Server.
      */
     public function isMssql(): bool
     {
@@ -625,6 +653,14 @@ class DatabaseServerForm extends Form
     public function isPostgresql(): bool
     {
         return $this->database_type === 'postgres';
+    }
+
+    /**
+     * Check if current database type is Firebird.
+     */
+    public function isFirebird(): bool
+    {
+        return $this->database_type === 'firebird';
     }
 
     /**
@@ -1141,6 +1177,19 @@ class DatabaseServerForm extends Form
                 if ($this->ssh_enabled) {
                     $this->validate($this->getSshValidationRules());
                 }
+            } elseif ($this->isFirebird()) {
+                $this->validate([
+                    'host' => 'required|string|max:255',
+                    'port' => 'required|integer|min:1|max:65535',
+                    'username' => 'required|string|max:255',
+                    'password' => ($this->server === null ? 'required|string|max:255' : 'nullable'),
+                ]);
+
+                if ($this->collectConfiguredDatabaseNames() === []) {
+                    throw ValidationException::withMessages([
+                        'form.backups' => __('Add at least one Firebird database path before testing the connection.'),
+                    ]);
+                }
             } elseif ($this->hasOptionalCredentials()) {
                 $this->validate([
                     'host' => 'required|string|max:255',
@@ -1187,7 +1236,11 @@ class DatabaseServerForm extends Form
             'port' => $this->port,
             'username' => $this->username,
             'password' => $password,
-            'database_names' => $this->isSqlite() ? $this->collectSqlitePaths() : null,
+            'database_names' => match (true) {
+                $this->isSqlite() => $this->collectSqlitePaths(),
+                $this->isFirebird() => $this->collectConfiguredDatabaseNames(),
+                default => null,
+            },
             'extra_config' => $this->buildExtraConfigForTest(),
         ], $sshConfig);
 
@@ -1199,7 +1252,7 @@ class DatabaseServerForm extends Form
         $this->testingConnection = false;
 
         // If connection successful and supports per-database backups, load available databases
-        if ($this->connectionTestSuccess && ! $this->isSqlite() && ! $this->isRedis()) {
+        if ($this->connectionTestSuccess && ! $this->isSqlite() && ! $this->isRedis() && ! $this->isFirebird()) {
             $this->loadAvailableDatabases();
         }
     }

--- a/app/Livewire/Restore/Modal.php
+++ b/app/Livewire/Restore/Modal.php
@@ -267,11 +267,17 @@ class Modal extends Component
      */
     protected function validateSchemaName(): void
     {
-        $isSqlite = $this->targetServer?->database_type === DatabaseType::SQLITE;
+        $type = $this->targetServer?->database_type;
 
-        if ($isSqlite) {
+        if ($type === DatabaseType::SQLITE) {
             $rules = ['schemaName' => 'required|string|max:255'];
             $messages = ['schemaName.required' => __('Please enter a database path.')];
+        } elseif ($type === DatabaseType::FIREBIRD) {
+            $rules = ['schemaName' => 'required|string|max:255|regex:/^[a-zA-Z0-9_\/\\\\.\-: ]+$/'];
+            $messages = [
+                'schemaName.required' => __('Please enter a database name or path.'),
+                'schemaName.regex' => __('Database name can only contain letters, numbers, spaces, slashes, dots, dashes, colons, and underscores.'),
+            ];
         } else {
             $rules = ['schemaName' => 'required|string|max:64|regex:/^[a-zA-Z0-9_]+$/'];
             $messages = [

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -27,6 +27,7 @@ class DatabaseProvider
             DatabaseType::REDIS => new RedisDatabase,
             DatabaseType::MONGODB => new MongodbDatabase,
             DatabaseType::MSSQL => new MssqlDatabase,
+            DatabaseType::FIREBIRD => new FirebirdDatabase,
         };
     }
 
@@ -93,34 +94,12 @@ class DatabaseProvider
         ?string $snapshotDumpFormat = null,
     ): DatabaseInterface {
         if ($config->databaseType === DatabaseType::SQLITE) {
-            $dbConfig = ['sqlite_path' => $databaseName];
-
-            if ($config->sshConfig !== null) {
-                $dbConfig['ssh_config_array'] = $config->sshConfig;
-            }
-
-            return $this->makeConfigured(DatabaseType::SQLITE, $dbConfig);
+            return $this->makeConfigured(DatabaseType::SQLITE, $this->sqliteConfig($databaseName, $config->sshConfig));
         }
 
         $extra = $config->extraConfig ?? [];
-
-        $dbConfig = [
-            'host' => $host,
-            'port' => $port,
-            'user' => $config->username,
-            'pass' => $config->password,
-        ];
-
-        if ($config->databaseType !== DatabaseType::REDIS) {
-            $dbConfig['database'] = $databaseName;
-        }
-
-        if ($config->databaseType === DatabaseType::MONGODB) {
-            $dbConfig['auth_source'] = $extra['auth_source'] ?? 'admin';
-            if ($sourceDatabaseName !== null) {
-                $dbConfig['source_database'] = $sourceDatabaseName;
-            }
-        }
+        $dbConfig = $this->connectionConfig($config, $databaseName, $host, $port, $extra);
+        $dbConfig = $this->applyMongoConfig($dbConfig, $config->databaseType, $extra, $sourceDatabaseName);
 
         if (! empty($extra['dump_flags'])) {
             $dbConfig['dump_flags'] = $extra['dump_flags'];
@@ -142,6 +121,75 @@ class DatabaseProvider
         }
 
         return $this->makeConfigured($config->databaseType, $dbConfig);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $sshConfig
+     * @return array<string, mixed>
+     */
+    private function sqliteConfig(string $databaseName, ?array $sshConfig): array
+    {
+        $dbConfig = ['sqlite_path' => $databaseName];
+
+        if ($sshConfig !== null) {
+            $dbConfig['ssh_config_array'] = $sshConfig;
+        }
+
+        return $dbConfig;
+    }
+
+    /**
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function connectionConfig(
+        DatabaseConnectionConfig $config,
+        string $databaseName,
+        string $host,
+        int $port,
+        array $extra,
+    ): array {
+        $dbConfig = [
+            'host' => $host,
+            'port' => $port,
+            'user' => $config->username,
+            'pass' => $config->password,
+        ];
+
+        if ($config->databaseType === DatabaseType::REDIS) {
+            return $dbConfig;
+        }
+
+        $dbConfig['database'] = $databaseName;
+
+        if ($config->databaseType === DatabaseType::FIREBIRD && $databaseName === '') {
+            $dbConfig['database'] = is_string($extra['database'] ?? null) ? $extra['database'] : '';
+        }
+
+        return $dbConfig;
+    }
+
+    /**
+     * @param  array<string, mixed>  $dbConfig
+     * @param  array<string, mixed>  $extra
+     * @return array<string, mixed>
+     */
+    private function applyMongoConfig(
+        array $dbConfig,
+        DatabaseType $databaseType,
+        array $extra,
+        ?string $sourceDatabaseName,
+    ): array {
+        if ($databaseType !== DatabaseType::MONGODB) {
+            return $dbConfig;
+        }
+
+        $dbConfig['auth_source'] = $extra['auth_source'] ?? 'admin';
+        if ($sourceDatabaseName !== null) {
+            $dbConfig['source_database'] = $sourceDatabaseName;
+        }
+
+        return $dbConfig;
     }
 
     /**
@@ -236,6 +284,7 @@ class DatabaseProvider
         return match ($server->database_type) {
             DatabaseType::POSTGRESQL => 'postgres',
             DatabaseType::MSSQL => 'master',
+            DatabaseType::FIREBIRD => $server->resolveDatabaseNames()[0] ?? '',
             default => '',
         };
     }

--- a/app/Services/Backup/Databases/FirebirdDatabase.php
+++ b/app/Services/Backup/Databases/FirebirdDatabase.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Services\Backup\Databases;
+
+use App\Contracts\BackupLogger;
+use App\Services\Backup\DTO\DatabaseOperationResult;
+use App\Support\Formatters;
+use Illuminate\Process\Exceptions\ProcessTimedOutException;
+use Illuminate\Support\Facades\Process;
+
+class FirebirdDatabase implements DatabaseInterface
+{
+    /** @var array<string, mixed> */
+    private array $config = [];
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function setConfig(array $config): void
+    {
+        $this->config = $config;
+    }
+
+    public function dump(string $outputPath): DatabaseOperationResult
+    {
+        return new DatabaseOperationResult(command: sprintf(
+            'gbak -b -g -user %s -password %s %s %s',
+            escapeshellarg((string) ($this->config['user'] ?? '')),
+            escapeshellarg((string) ($this->config['pass'] ?? '')),
+            escapeshellarg($this->connectionTarget()),
+            escapeshellarg($outputPath)
+        ));
+    }
+
+    public function restore(string $inputPath): DatabaseOperationResult
+    {
+        return new DatabaseOperationResult(command: sprintf(
+            'gbak -rep -user %s -password %s %s %s',
+            escapeshellarg((string) ($this->config['user'] ?? '')),
+            escapeshellarg((string) ($this->config['pass'] ?? '')),
+            escapeshellarg($inputPath),
+            escapeshellarg($this->connectionTarget())
+        ));
+    }
+
+    public function prepareForRestore(string $schemaName, BackupLogger $logger, bool $forceDatabase = false): void
+    {
+        // Firebird restore uses gbak -rep to replace an existing target database in one step.
+    }
+
+    public function listDatabases(): array
+    {
+        $configuredNames = $this->config['database_names'] ?? null;
+        if (is_array($configuredNames)) {
+            return array_values(array_filter(
+                array_map(static fn ($name) => is_string($name) ? trim($name) : '', $configuredNames),
+                static fn (string $name) => $name !== ''
+            ));
+        }
+
+        $database = trim((string) ($this->config['database'] ?? ''));
+
+        return $database === '' ? [] : [$database];
+    }
+
+    public function testConnection(): array
+    {
+        $startTime = microtime(true);
+
+        try {
+            $result = Process::timeout(10)->run($this->buildConnectionProbeCommand());
+        } catch (ProcessTimedOutException) {
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+
+            return $this->connectionFailure(
+                'Connection timed out after '.Formatters::humanDuration($durationMs).'. Please check the host and port are correct and accessible.'
+            );
+        }
+
+        $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+
+        if ($result->failed()) {
+            $errorOutput = trim($result->errorOutput() ?: $result->output());
+
+            return $this->connectionFailure($errorOutput ?: 'Connection failed with exit code '.$result->exitCode());
+        }
+
+        return $this->connectionSuccess($durationMs, trim($result->output()));
+    }
+
+    /**
+     * @return array{success: true, message: string, details: array{ping_ms: int, output: string}}
+     */
+    private function connectionSuccess(int $durationMs, string $output): array
+    {
+        return [
+            'success' => true,
+            'message' => 'Connection successful',
+            'details' => [
+                'ping_ms' => $durationMs,
+                'output' => $output,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{success: false, message: string, details: array{}}
+     */
+    private function connectionFailure(string $message): array
+    {
+        return [
+            'success' => false,
+            'message' => $message,
+            'details' => [],
+        ];
+    }
+
+    private function connectionTarget(): string
+    {
+        $database = (string) ($this->config['database'] ?? '');
+        $host = trim((string) ($this->config['host'] ?? ''));
+        $port = (int) ($this->config['port'] ?? 3050);
+
+        if ($host === '') {
+            return $database;
+        }
+
+        return $host.'/'.$port.':'.$database;
+    }
+
+    private function buildConnectionProbeCommand(): string
+    {
+        $script = <<<'BASH'
+if command -v isql-fb >/dev/null 2>&1; then
+  ISQL=isql-fb
+elif command -v isql >/dev/null 2>&1; then
+  ISQL=isql
+else
+  echo "Neither isql-fb nor isql is installed" >&2
+  exit 127
+fi
+printf '%%s\n' "SELECT 1 FROM RDB\$DATABASE;" | "$ISQL" -b -user %s -password %s %s
+BASH;
+
+        return sprintf(
+            'sh -lc %s',
+            escapeshellarg(sprintf(
+                $script,
+                escapeshellarg((string) ($this->config['user'] ?? '')),
+                escapeshellarg((string) ($this->config['pass'] ?? '')),
+                escapeshellarg($this->connectionTarget())
+            ))
+        );
+    }
+}

--- a/app/Services/Backup/ShellProcessor.php
+++ b/app/Services/Backup/ShellProcessor.php
@@ -76,9 +76,11 @@ class ShellProcessor
         $patterns = [
             // Match --password=VALUE or --password='VALUE' or --password="VALUE"
             '/--password=[\'"]?[^\s\'"]+[\'"]?/' => '--password=***',
+            // Match Firebird-style -password VALUE (with optional quoting)
+            '/-password\s+[\'"]?[^\s\'"]+[\'"]?/' => '-password ***',
             // Match -pPASSWORD (MySQL shorthand) - only when -p is a standalone argument
-            // followed directly by password (not --port, not inside words like mysql-production)
-            '/(^|\s)-p([^\s\-][^\s]*)/' => '$1-p***',
+            // followed directly by password (not --port, not -password, not inside words like mysql-production)
+            '/(^|\s)-p(?!assword\b)([^\s\-][^\s]*)/' => '$1-p***',
             // Match PGPASSWORD=VALUE
             '/PGPASSWORD=[^\s]+/' => 'PGPASSWORD=***',
             // Match MYSQL_PWD=VALUE

--- a/config/testing.php
+++ b/config/testing.php
@@ -53,6 +53,14 @@ return [
             'password' => env('TEST_MSSQL_PASSWORD', 'Databasement!Strong1'),
             'database' => env('TEST_MSSQL_DATABASE', 'databasement_test'),
         ],
+
+        'firebird' => [
+            'database' => env('TEST_FIREBIRD_DATABASE', '/var/lib/firebird/data/databasement_test.fdb'),
+            'password' => env('TEST_FIREBIRD_PASSWORD', 'masterkey'),
+            'username' => env('TEST_FIREBIRD_USERNAME', 'SYSDBA'),
+            'port' => env('TEST_FIREBIRD_PORT', 3050),
+            'host' => env('TEST_FIREBIRD_HOST', 'firebird'),
+        ],
     ],
 
     /*

--- a/database/factories/DatabaseServerFactory.php
+++ b/database/factories/DatabaseServerFactory.php
@@ -143,6 +143,23 @@ class DatabaseServerFactory extends Factory
     }
 
     /**
+     * Configure the factory for Firebird database type.
+     */
+    public function firebird(): static
+    {
+        return $this->state(fn () => [
+            'name' => fake()->company().' Firebird Server',
+            'database_type' => 'firebird',
+            'host' => fake()->randomElement(['localhost', '127.0.0.1']),
+            'port' => 3050,
+            'username' => 'sysdba',
+            'password' => 'masterkey',
+            'database_selection_mode' => 'selected',
+            'database_names' => ['/data/main.fdb'],
+        ]);
+    }
+
+    /**
      * Configure the factory with SSH tunnel using password authentication.
      *
      * Note: Uses afterCreating() hook, so only works with create(), not make().

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,14 @@ services:
       timeout: 5s
       retries: 10
 
+  firebird:
+    image: firebirdsql/firebird
+    container_name: databasement-firebird
+    environment:
+      FIREBIRD_ROOT_PASSWORD: masterkey
+    volumes:
+      - firebird-data:/var/lib/firebird/data
+
   ssh:
     image: linuxserver/openssh-server:latest
     container_name: databasement-ssh
@@ -217,4 +225,5 @@ volumes:
   mongodb-data:
   redis-data:
   mssql-data:
+  firebird-data:
   ftp-data:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,3 +1,5 @@
+FROM firebirdsql/firebird:5.0.3 AS firebird
+
 FROM dunglas/frankenphp:1.12-php8.5-alpine
 
 RUN install-php-extensions \
@@ -45,7 +47,10 @@ RUN apk add --no-cache git \
         curl \
         unzip \
         icu-libs krb5-libs libgcc libssl3 libstdc++ zlib \
-        gcompat
+        gcompat \
+        libc6-compat \
+        procps-ng \
+        ncurses-libs
 
 # Install MongoDB tools (mongodump, mongorestore) from Alpine edge community repo
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community mongodb-tools
@@ -64,6 +69,30 @@ RUN curl -fsSL -o /tmp/sqlpackage.zip "${SQLPACKAGE_URL}" \
     && chmod +x /opt/sqlpackage/sqlpackage \
     && ln -s /opt/sqlpackage/sqlpackage /usr/local/bin/sqlpackage \
     && rm /tmp/sqlpackage.zip
+
+RUN mkdir -p /opt/firebird/compat
+COPY --from=firebird /opt/firebird /opt/firebird
+COPY --from=firebird /lib/x86_64-linux-gnu/libc.so.6 /opt/firebird/compat/
+COPY --from=firebird /lib/x86_64-linux-gnu/libdl.so.2 /opt/firebird/compat/
+COPY --from=firebird /lib/x86_64-linux-gnu/libgcc_s.so.1 /opt/firebird/compat/
+COPY --from=firebird /lib/x86_64-linux-gnu/libm.so.6 /opt/firebird/compat/
+COPY --from=firebird /lib/x86_64-linux-gnu/libpthread.so.0 /opt/firebird/compat/
+COPY --from=firebird /lib/x86_64-linux-gnu/libtommath.so.1 /opt/firebird/compat/
+COPY --from=firebird /lib64/ld-linux-x86-64.so.2 /opt/firebird/compat/
+RUN printf '%s\n' \
+    '#!/bin/sh' \
+    'LOADER=/opt/firebird/compat/ld-linux-x86-64.so.2' \
+    'LIBRARY_PATH=/opt/firebird/lib:/opt/firebird/compat' \
+    'exec "$LOADER" --library-path "$LIBRARY_PATH" /opt/firebird/bin/gbak "$@"' \
+    > /usr/local/bin/gbak && \
+    printf '%s\n' \
+    '#!/bin/sh' \
+    'LOADER=/opt/firebird/compat/ld-linux-x86-64.so.2' \
+    'LIBRARY_PATH=/opt/firebird/lib:/opt/firebird/compat' \
+    'exec "$LOADER" --library-path "$LIBRARY_PATH" /opt/firebird/bin/isql "$@"' \
+    > /usr/local/bin/isql && \
+    ln -sf /usr/local/bin/isql /usr/local/bin/isql-fb && \
+    chmod 755 /usr/local/bin/gbak /usr/local/bin/isql
 
 COPY supervisord.conf /config/supervisord.conf
 COPY php-custom-production.ini /usr/local/etc/php/php-custom-production.ini

--- a/docs/docs/user-guide/backups.md
+++ b/docs/docs/user-guide/backups.md
@@ -34,7 +34,14 @@ PGPASSWORD='...' pg_dump --clean --if-exists --no-owner --no-privileges --quote-
 
 **SQLite:**
 ```bash
-cp '/path/to/database.sqlite' dump.db
+sqlite3 '/path/to/database.sqlite' ".backup 'dump.db'"
+```
+
+This creates a consistent snapshot and is safe for databases running in WAL mode.
+
+**Firebird:**
+```bash
+gbak -b -g -user '...' -password '...' '/path/to/source.fdb' '/path/to/dump.fbk'
 ```
 
 **MongoDB:**

--- a/resources/views/livewire/database-server/_backup-form.blade.php
+++ b/resources/views/livewire/database-server/_backup-form.blade.php
@@ -7,6 +7,7 @@
     /** @var array<string, mixed> $backup */
     $serverType = DatabaseType::tryFrom($form->database_type);
     $isSqlite = $serverType === DatabaseType::SQLITE;
+    $isFirebird = $serverType === DatabaseType::FIREBIRD;
     $showDatabaseSelection = $serverType !== null
         && ! in_array($serverType, [DatabaseType::SQLITE, DatabaseType::REDIS], true);
 
@@ -147,6 +148,44 @@
                         wire:model.live="form.backups.{{ $index }}.database_selection_mode"
                     />
                 </x-radio-card-group>
+                @if($isFirebird)
+                    <div class="rounded-lg border border-base-300 bg-base-100 p-4 flex items-start gap-3">
+                        <span class="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-info/10 text-info">
+                            <x-icon name="o-information-circle" class="w-3.5 h-3.5" />
+                        </span>
+                        <div class="flex-1 min-w-0 space-y-1">
+                            <p class="text-sm font-medium">{{ __('Firebird backups require explicit database paths.') }}</p>
+                            <p class="text-sm text-base-content/70">{{ __('This backup configuration always uses Selected mode, and connection tests need at least one database path.') }}</p>
+                        </div>
+                    </div>
+                @else
+                    <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Database selection mode')">
+                        <x-radio-card
+                            :active="($backup['database_selection_mode'] ?? '') === DatabaseSelectionMode::All->value"
+                            icon="o-circle-stack"
+                            :label="__('All databases')"
+                            :hint="__('Back up every user database')"
+                            :value="DatabaseSelectionMode::All->value"
+                            wire:model.live="form.backups.{{ $index }}.database_selection_mode"
+                        />
+                        <x-radio-card
+                            :active="($backup['database_selection_mode'] ?? '') === DatabaseSelectionMode::Selected->value"
+                            icon="o-check-badge"
+                            :label="__('Selected')"
+                            :hint="__('Pick specific databases')"
+                            :value="DatabaseSelectionMode::Selected->value"
+                            wire:model.live="form.backups.{{ $index }}.database_selection_mode"
+                        />
+                        <x-radio-card
+                            :active="($backup['database_selection_mode'] ?? '') === DatabaseSelectionMode::Pattern->value"
+                            icon="bi.regex"
+                            :label="__('Pattern')"
+                            :hint="__('Filter by regex')"
+                            :value="DatabaseSelectionMode::Pattern->value"
+                            wire:model.live="form.backups.{{ $index }}.database_selection_mode"
+                        />
+                    </x-radio-card-group>
+                @endif
 
                 {{-- All Databases sub-panel --}}
                 @if(($backup['database_selection_mode'] ?? '') === DatabaseSelectionMode::All->value)

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -306,7 +306,7 @@ use App\Enums\DatabaseType;
     </div>
 
     <!-- Enable Backups Toggle (shown after successful connection test, agent assigned, or when editing) -->
-    @if($form->connectionTestSuccess or $form->hasAgent() or $isEdit)
+    @if($form->connectionTestSuccess or $form->hasAgent() or $isEdit or $form->isFirebird())
         <div class="card bg-base-100 shadow-sm border border-base-200">
             <div class="card-body p-3 sm:p-8">
                 <x-toggle
@@ -320,7 +320,7 @@ use App\Enums\DatabaseType;
     @endif
 
     <!-- Section 3: Backup Configurations (collection of one or more) -->
-    @if(($form->connectionTestSuccess or $form->hasAgent() or $isEdit or $form->isSqlite()) && $form->backups_enabled)
+    @if(($form->connectionTestSuccess or $form->hasAgent() or $isEdit or $form->isSqlite() or $form->isFirebird()) && $form->backups_enabled)
         @php
             $volumes = $form->getAllVolumes();
             $schedules = $form->getBackupSchedules();
@@ -370,7 +370,7 @@ use App\Enums\DatabaseType;
     @endif
 
     <!-- Section 4: Notifications -->
-    @if($form->connectionTestSuccess or $form->hasAgent() or $isEdit or $form->isSqlite())
+    @if($form->connectionTestSuccess or $form->hasAgent() or $isEdit or $form->isSqlite() or $form->isFirebird())
         <div class="card bg-base-100 shadow-sm border border-base-200">
             <div class="card-body p-3 sm:p-8">
                 <div class="flex items-center gap-3 mb-4">

--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -8,14 +8,26 @@ use App\Models\Volume;
 use App\Services\Backup\Databases\DatabaseProvider;
 use Livewire\Livewire;
 
+function createLocalTestVolume(): Volume
+{
+    return Volume::factory()->local()->create(['name' => 'Test Volume']);
+}
+
+function firebirdCreateComponent(User $user, string $name = 'Firebird Server')
+{
+    return Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.name', $name)
+        ->set('form.database_type', 'firebird')
+        ->set('form.host', 'firebird.example.com')
+        ->set('form.port', 3050)
+        ->set('form.username', 'sysdba')
+        ->set('form.password', 'masterkey');
+}
+
 test('can create database server', function (array $config) {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = createLocalTestVolume();
 
     $component = Livewire::actingAs($user)
         ->test(Create::class)
@@ -205,6 +217,31 @@ test('sqlite test connection fails when no paths provided', function () {
         ->call('testConnection')
         ->assertSet('form.connectionTestSuccess', false)
         ->assertSet('form.connectionTestMessage', 'Add at least one SQLite database path before testing the connection.');
+});
+
+test('firebird test connection fails when no database paths provided', function () {
+    $user = User::factory()->create();
+
+    firebirdCreateComponent($user)
+        ->call('testConnection')
+        ->assertSet('form.connectionTestSuccess', false)
+        ->assertSet('form.connectionTestMessage', 'Add at least one Firebird database path before testing the connection.');
+});
+
+test('firebird test connection succeeds with configured database path', function () {
+    $user = User::factory()->create();
+
+    $mock = Mockery::mock(DatabaseProvider::class);
+    $mock->shouldReceive('testConnectionForServer')
+        ->once()
+        ->andReturn(['success' => true, 'message' => 'Connection successful', 'details' => []]);
+    app()->instance(DatabaseProvider::class, $mock);
+
+    firebirdCreateComponent($user)
+        ->set('form.backups.0.database_names.0', '/var/lib/firebird/data/main.fdb')
+        ->call('testConnection')
+        ->assertSet('form.connectionTestSuccess', true)
+        ->assertSet('form.connectionTestMessage', 'Connection successful');
 });
 
 test('sqlite test connection succeeds with valid paths', function () {
@@ -568,4 +605,62 @@ test('cannot remove the last remaining backup card', function () {
         ->assertCount('form.backups', 1)
         ->call('removeBackup', 0)
         ->assertCount('form.backups', 1);
+});
+
+test('creates firebird server with selected database mode and names', function () {
+    $user = User::factory()->create();
+    $volume = createLocalTestVolume();
+
+    firebirdCreateComponent($user, 'Firebird Primary')
+        ->set('form.backups.0.database_names_input', '/db/main.fdb')
+        ->set('form.backups.0.volume_id', $volume->id)
+        ->set('form.backups.0.backup_schedule_id', dailySchedule()->id)
+        ->set('form.backups.0.retention_days', 14)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('database-servers.index'));
+
+    $server = DatabaseServer::where('name', 'Firebird Primary')->first();
+    $backup = $server?->backups()->sole();
+
+    expect($server)->not->toBeNull()
+        ->and($server->database_type->value)->toBe('firebird')
+        ->and($backup)->not->toBeNull()
+        ->and($backup->database_selection_mode->value)->toBe('selected')
+        ->and($backup->database_names)->toBe(['/db/main.fdb']);
+});
+
+test('creates firebird server when only database_names_input is provided', function () {
+    $user = User::factory()->create();
+    $volume = createLocalTestVolume();
+
+    firebirdCreateComponent($user, 'Firebird Input Only')
+        ->set('form.backups.0.database_names', [])
+        ->set('form.backups.0.database_names_input', '/db/input-only.fdb')
+        ->set('form.backups.0.volume_id', $volume->id)
+        ->set('form.backups.0.backup_schedule_id', dailySchedule()->id)
+        ->set('form.backups.0.retention_days', 14)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('database-servers.index'));
+
+    $server = DatabaseServer::where('name', 'Firebird Input Only')->first();
+    $backup = $server?->backups()->sole();
+
+    expect($server)->not->toBeNull()
+        ->and($backup)->not->toBeNull()
+        ->and($backup->database_names)->toBe(['/db/input-only.fdb']);
+});
+
+test('firebird cannot be saved with all-databases selection mode', function () {
+    $user = User::factory()->create();
+    $volume = createLocalTestVolume();
+
+    firebirdCreateComponent($user, 'Firebird Invalid Mode')
+        ->set('form.backups.0.database_selection_mode', 'all')
+        ->set('form.backups.0.volume_id', $volume->id)
+        ->set('form.backups.0.backup_schedule_id', dailySchedule()->id)
+        ->set('form.backups.0.retention_days', 14)
+        ->call('save')
+        ->assertHasErrors(['form.backups.0.database_names']);
 });

--- a/tests/Feature/Livewire/Restore/ModalTest.php
+++ b/tests/Feature/Livewire/Restore/ModalTest.php
@@ -41,7 +41,7 @@ test('from-server mode: navigates step 1 -> step 2 by picking a snapshot', funct
         ->call('selectSnapshot', $snapshot->id)
         ->assertSet('selectedSnapshotId', $snapshot->id)
         ->assertSet('currentStep', 2);
-})->with(['mysql', 'postgres', 'sqlite']);
+})->with(['mysql', 'postgres', 'sqlite', 'firebird']);
 
 test('from-server mode: queues restore job and dispatches restore-created', function () {
     Queue::fake();
@@ -123,6 +123,72 @@ test('from-server mode: sqlite pre-fills schema with target server database path
         ->dispatch('open-restore-modal', mode: 'from-server', targetServerId: $target->id)
         ->call('selectSnapshot', $snapshot->id)
         ->assertSet('schemaName', '/data/production.sqlite');
+});
+
+test('from-server mode: shows firebird snapshots for firebird targets', function () {
+    $target = DatabaseServer::factory()->firebird()->create();
+
+    $firebirdSource = DatabaseServer::factory()->firebird()->create();
+    $snapshot = Snapshot::factory()->forServer($firebirdSource)->withFile()->create([
+        'database_name' => '/data/source.fdb',
+    ]);
+
+    $mysqlSource = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    Snapshot::factory()->forServer($mysqlSource)->withFile()->create([
+        'database_name' => 'mysql_db',
+    ]);
+
+    Livewire::test(Modal::class)
+        ->dispatch('open-restore-modal', mode: 'from-server', targetServerId: $target->id)
+        ->assertSee($firebirdSource->name)
+        ->assertSee($snapshot->database_name)
+        ->assertDontSee($mysqlSource->name);
+});
+
+test('from-server mode: firebird restore allows path-style schema names', function () {
+    Queue::fake();
+
+    $target = DatabaseServer::factory()->firebird()->create();
+    $source = DatabaseServer::factory()->firebird()->create();
+    $snapshot = Snapshot::factory()->forServer($source)->withFile()->create();
+
+    Livewire::test(Modal::class)
+        ->dispatch('open-restore-modal', mode: 'from-server', targetServerId: $target->id)
+        ->call('selectSnapshot', $snapshot->id)
+        ->set('schemaName', '/data/Main Database.fdb')
+        ->call('restore')
+        ->assertHasNoErrors()
+        ->assertDispatched('restore-created');
+
+    Queue::assertPushed(ProcessRestoreJob::class, 1);
+
+    $restore = Restore::where('snapshot_id', $snapshot->id)
+        ->where('target_server_id', $target->id)
+        ->first();
+
+    expect($restore)->not->toBeNull()
+        ->and($restore->schema_name)->toBe('/data/Main Database.fdb')
+        ->and((string) $restore->triggered_by_user_id)->toBe((string) $this->user->id)
+        ->and($restore->job)->not->toBeNull()
+        ->and($restore->job->status)->toBe('pending');
+});
+
+test('from-server mode: firebird restore rejects unsafe schema names with shell metacharacters', function () {
+    Queue::fake();
+
+    $target = DatabaseServer::factory()->firebird()->create();
+    $source = DatabaseServer::factory()->firebird()->create();
+    $snapshot = Snapshot::factory()->forServer($source)->withFile()->create();
+
+    Livewire::test(Modal::class)
+        ->dispatch('open-restore-modal', mode: 'from-server', targetServerId: $target->id)
+        ->call('selectSnapshot', $snapshot->id)
+        ->set('schemaName', '/data/main;rm -rf.fdb')
+        ->call('restore')
+        ->assertHasErrors(['schemaName' => ['regex']])
+        ->assertSee('Database name can only contain letters, numbers, spaces, slashes, dots, dashes, colons, and underscores.');
+
+    Queue::assertNotPushed(ProcessRestoreJob::class);
 });
 
 test('from-server mode: prevents restoring over the application database', function () {

--- a/tests/Feature/Models/DatabaseServerTest.php
+++ b/tests/Feature/Models/DatabaseServerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\DatabaseType;
 use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
 
@@ -93,4 +94,11 @@ test('requiresSftpTransfer returns correct value', function () {
         ->and($sqliteWithSsh->requiresSftpTransfer())->toBeTrue()
         ->and($sqliteLocal->requiresSftpTransfer())->toBeFalse()
         ->and($mysqlWithSsh->requiresSftpTransfer())->toBeFalse();
+});
+
+test('database type has firebird defaults for backup flow', function () {
+    $firebirdType = DatabaseType::from('firebird');
+
+    expect($firebirdType->defaultPort())->toBe(3050)
+        ->and($firebirdType->dumpExtension())->toBe('fbk');
 });

--- a/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
@@ -25,6 +25,13 @@ test('make returns correct handler for database type', function (DatabaseType $t
     'mongodb' => [DatabaseType::MONGODB, MongodbDatabase::class],
 ]);
 
+test('make returns firebird handler for firebird type', function () {
+    $factory = new DatabaseProvider;
+    $firebirdType = DatabaseType::from('firebird');
+
+    expect($factory->make($firebirdType))->toBeInstanceOf('App\\Services\\Backup\\Databases\\FirebirdDatabase');
+});
+
 test('makeForServer uses explicit host and port parameters', function () {
     $server = DatabaseServer::factory()->create([
         'database_type' => 'mysql',
@@ -149,6 +156,24 @@ test('makeForServer passes sourceDatabaseName for mongodb restore', function () 
     $result = $database->restore('/tmp/dump.archive');
     expect($result->command)->toContain("--nsFrom='sourcedb.*'")
         ->toContain("--nsTo='targetdb.*'");
+});
+
+test('makeForServer passes firebird target database path for restore', function () {
+    $server = DatabaseServer::factory()->firebird()->create([
+        'host' => 'fb.internal',
+        'port' => 3050,
+        'username' => 'sysdba',
+        'password' => 'masterkey',
+        'database_names' => ['/data/main.fdb'],
+    ]);
+
+    $factory = new DatabaseProvider;
+
+    $database = $factory->makeForServer($server, '/data/restore-target.fdb', '127.0.0.1', 43050);
+
+    $result = $database->restore('/tmp/restore.fbk');
+    expect($result->command)->toContain("'127.0.0.1/43050:/data/restore-target.fdb'")
+        ->toContain("'/tmp/restore.fbk'");
 });
 
 test('testConnectionForServer delegates to handler testConnection', function (string $dbType, string $expectedDbName) {

--- a/tests/Feature/Services/Backup/Databases/FirebirdDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/FirebirdDatabaseTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Services\Backup\Databases\FirebirdDatabase;
+use App\Services\Backup\DTO\DatabaseOperationResult;
+use Illuminate\Support\Facades\Process;
+
+const FIREBIRD_TEST_DATABASE = '/data/main.fdb';
+
+beforeEach(function () {
+    $this->db = new FirebirdDatabase;
+    $this->db->setConfig([
+        'host' => 'fb.local',
+        'port' => 3050,
+        'user' => 'sysdba',
+        'pass' => 'masterkey',
+        'database' => FIREBIRD_TEST_DATABASE,
+    ]);
+});
+
+test('dump builds gbak backup command', function () {
+    $result = $this->db->dump('/tmp/backup.fbk');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe("gbak -b -g -user 'sysdba' -password 'masterkey' 'fb.local/3050:".FIREBIRD_TEST_DATABASE."' '/tmp/backup.fbk'");
+});
+
+test('testConnection returns success when isql probe succeeds', function () {
+    Process::fake([
+        '*' => Process::result(output: 'Database: '.FIREBIRD_TEST_DATABASE),
+    ]);
+
+    $result = $this->db->testConnection();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['message'])->toBe('Connection successful')
+        ->and($result['details'])->toHaveKey('ping_ms')
+        ->and($result['details']['output'])->toContain('Database: '.FIREBIRD_TEST_DATABASE);
+});
+
+test('testConnection returns failure when probe fails', function () {
+    Process::fake([
+        '*' => Process::result(exitCode: 1, errorOutput: 'I/O error during "open" operation'),
+    ]);
+
+    $result = $this->db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('I/O error during "open" operation');
+});
+
+test('listDatabases returns configured names', function () {
+    $this->db->setConfig([
+        'database_names' => [FIREBIRD_TEST_DATABASE, '/data/archive.fdb'],
+    ]);
+
+    expect($this->db->listDatabases())->toBe([FIREBIRD_TEST_DATABASE, '/data/archive.fdb']);
+});
+
+test('restore builds gbak restore command', function () {
+    $result = $this->db->restore('/tmp/backup.fbk');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe("gbak -rep -user 'sysdba' -password 'masterkey' '/tmp/backup.fbk' 'fb.local/3050:".FIREBIRD_TEST_DATABASE."'");
+});
+
+test('prepareForRestore is a no-op', function () {
+    $logger = Mockery::mock(\App\Contracts\BackupLogger::class);
+
+    expect(fn () => $this->db->prepareForRestore(FIREBIRD_TEST_DATABASE, $logger))
+        ->not->toThrow(Exception::class);
+});

--- a/tests/Feature/Services/Backup/RestoreTaskTest.php
+++ b/tests/Feature/Services/Backup/RestoreTaskTest.php
@@ -16,6 +16,11 @@ use App\Services\Backup\RestoreTask;
 use App\Services\SshTunnelService;
 use Tests\Support\TestShellProcessor;
 
+const FIREBIRD_SOURCE_DATABASE = '/data/source.fdb';
+const FIREBIRD_RESTORE_TARGET_DATABASE = '/data/restore-target.fdb';
+const FIREBIRD_RESTORE_COMMAND = "echo 'firebird restore command'";
+const COMPRESSED_BACKUP_DATA = 'compressed backup data';
+
 beforeEach(function () {
     $this->shellProcessor = new TestShellProcessor;
     $this->compressorFactory = new CompressorFactory($this->shellProcessor);
@@ -38,6 +43,18 @@ function buildTargetConfig(string $host = 'localhost'): DatabaseConnectionConfig
         port: 3306,
         username: 'root',
         password: 'secret',
+    );
+}
+
+function buildFirebirdTargetConfig(string $host = 'fb.local', int $port = 3050): DatabaseConnectionConfig
+{
+    return new DatabaseConnectionConfig(
+        databaseType: DatabaseType::FIREBIRD,
+        serverName: 'Target Firebird',
+        host: $host,
+        port: $port,
+        username: 'sysdba',
+        password: 'masterkey',
     );
 }
 
@@ -65,6 +82,21 @@ function buildRestoreConfig(?string $workingDirectory = null): RestoreConfig
     );
 }
 
+function buildFirebirdRestoreConfig(?string $workingDirectory = null): RestoreConfig
+{
+    return new RestoreConfig(
+        targetServer: buildFirebirdTargetConfig(),
+        snapshotVolume: buildSnapshotVolumeConfig(),
+        snapshotFilename: 'backup.fbk.gz',
+        snapshotFileSize: 2048,
+        snapshotCompressionType: CompressionType::GZIP,
+        snapshotDatabaseType: DatabaseType::FIREBIRD,
+        snapshotDatabaseName: FIREBIRD_SOURCE_DATABASE,
+        schemaName: FIREBIRD_RESTORE_TARGET_DATABASE,
+        workingDirectory: $workingDirectory ?? test()->tempDir.'/restore-firebird-'.uniqid(),
+    );
+}
+
 function buildMockRestoreProvider(): DatabaseProvider
 {
     $mockHandler = Mockery::mock(DatabaseInterface::class);
@@ -81,13 +113,56 @@ function buildMockRestoreProvider(): DatabaseProvider
     return $mockProvider;
 }
 
+function buildMockFirebirdRestoreProvider(): DatabaseProvider
+{
+    $mockHandler = Mockery::mock(DatabaseInterface::class);
+    $mockHandler->shouldReceive('prepareForRestore')->once()->with(FIREBIRD_RESTORE_TARGET_DATABASE, Mockery::any(), false)->andReturnNull();
+    $mockHandler->shouldReceive('restore')
+        ->once()
+        ->with(Mockery::on(function (string $workingFile): bool {
+            return file_exists($workingFile) && ! str_ends_with($workingFile, '.gz');
+        }))
+        ->andReturn(new DatabaseOperationResult(command: FIREBIRD_RESTORE_COMMAND));
+
+    $mockProvider = Mockery::mock(DatabaseProvider::class);
+    $mockProvider->shouldReceive('makeFromConfig')
+        ->once()
+        ->with(
+            Mockery::on(fn (DatabaseConnectionConfig $connectionConfig) => $connectionConfig->databaseType === DatabaseType::FIREBIRD),
+            FIREBIRD_RESTORE_TARGET_DATABASE,
+            'fb.local',
+            3050,
+            FIREBIRD_SOURCE_DATABASE,
+            null,
+        )
+        ->andReturn($mockHandler);
+
+    return $mockProvider;
+}
+
 function setupDownloadMock(): void
 {
     test()->filesystemProvider
         ->shouldReceive('downloadFromConfig')
         ->once()
-        ->andReturnUsing(function ($volumeConfig, $remoteFilename, $destination) {
-            file_put_contents($destination, 'compressed backup data');
+        ->andReturnUsing(function (...$arguments) {
+            file_put_contents($arguments[2], COMPRESSED_BACKUP_DATA);
+        });
+}
+
+function setupFirebirdDownloadMock(RestoreConfig $config): void
+{
+    test()->filesystemProvider
+        ->shouldReceive('downloadFromConfig')
+        ->once()
+        ->with(
+            Mockery::type(VolumeConfig::class),
+            'backup.fbk.gz',
+            Mockery::on(fn (string $destination) => str_starts_with($destination, $config->workingDirectory.'/')
+                && str_ends_with($destination, '.gz'))
+        )
+        ->andReturnUsing(function (...$arguments) {
+            file_put_contents($arguments[2], COMPRESSED_BACKUP_DATA);
         });
 }
 
@@ -452,6 +527,68 @@ test('execute cleans up working directory on failure', function () {
 
     expect(fn () => $restoreTask->execute($config, new InMemoryBackupLogger))
         ->toThrow(\App\Exceptions\ShellProcessFailed::class);
+
+    expect(is_dir($config->workingDirectory))->toBeFalse();
+});
+
+test('execute restores firebird snapshot and runs download/decompress/cleanup lifecycle', function () {
+    $config = buildFirebirdRestoreConfig();
+    mkdir($config->workingDirectory, 0755, true);
+
+    $mockProvider = buildMockFirebirdRestoreProvider();
+    setupFirebirdDownloadMock($config);
+
+    $restoreTask = new RestoreTask(
+        $mockProvider,
+        $this->shellProcessor,
+        $this->filesystemProvider,
+        $this->compressorFactory,
+        $this->sshTunnelService,
+    );
+
+    $restoreTask->execute($config, new InMemoryBackupLogger);
+
+    expect($this->shellProcessor->hasCommand(FIREBIRD_RESTORE_COMMAND))->toBeTrue()
+        ->and(is_dir($config->workingDirectory))->toBeFalse();
+});
+
+test('execute propagates firebird restore command failure and cleans up working directory', function () {
+    $config = buildFirebirdRestoreConfig();
+    mkdir($config->workingDirectory, 0755, true);
+
+    $mockProvider = buildMockFirebirdRestoreProvider();
+    setupFirebirdDownloadMock($config);
+
+    $shellProcessor = Mockery::mock(\App\Services\Backup\ShellProcessor::class);
+    $shellProcessor->shouldReceive('setLogger')->once();
+    $shellProcessor->shouldReceive('process')
+        ->once()
+        ->with(FIREBIRD_RESTORE_COMMAND)
+        ->andThrow(new \App\Exceptions\ShellProcessFailed('Firebird restore failed'));
+
+    $compressor = Mockery::mock(\App\Services\Backup\Compressors\CompressorInterface::class);
+    $compressor->shouldReceive('decompress')
+        ->once()
+        ->andReturnUsing(function (string $compressedFile) {
+            $decompressedFile = preg_replace('/\.gz$/', '', $compressedFile);
+            file_put_contents($decompressedFile, '-- Fake Firebird backup data');
+
+            return $decompressedFile;
+        });
+
+    $compressorFactory = Mockery::mock(\App\Services\Backup\Compressors\CompressorFactory::class);
+    $compressorFactory->shouldReceive('make')->once()->with(CompressionType::GZIP)->andReturn($compressor);
+
+    $restoreTask = new RestoreTask(
+        $mockProvider,
+        $shellProcessor,
+        $this->filesystemProvider,
+        $compressorFactory,
+        $this->sshTunnelService,
+    );
+
+    expect(fn () => $restoreTask->execute($config, new InMemoryBackupLogger))
+        ->toThrow(\App\Exceptions\ShellProcessFailed::class, 'Firebird restore failed');
 
     expect(is_dir($config->workingDirectory))->toBeFalse();
 });

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -30,6 +30,28 @@ beforeEach(function () {
     $this->restoredDatabaseName = null;
 });
 
+function prepareBackupWorkflow(string $databaseType): void
+{
+    test()->volume = IntegrationTestHelpers::createVolume($databaseType);
+    test()->databaseServer = IntegrationTestHelpers::createDatabaseServer($databaseType);
+    test()->backup = IntegrationTestHelpers::createBackup(test()->databaseServer, test()->volume);
+    test()->databaseServer->load('backups.volume');
+
+    IntegrationTestHelpers::loadTestData($databaseType, test()->databaseServer);
+}
+
+function runManualBackupSnapshot(): void
+{
+    test()->snapshot = test()->backupJobFactory->createSnapshots(
+        backup: test()->backup,
+        method: 'manual',
+    )[0];
+
+    ProcessBackupJob::dispatchSync(test()->snapshot->id);
+    test()->snapshot->refresh();
+    test()->snapshot->load('job');
+}
+
 afterEach(function () {
     // Cleanup restored database on the external database server
     if ($this->restoredDatabaseName && $this->databaseServer) {
@@ -363,4 +385,32 @@ test('redis backup workflow', function () {
         ->and($this->snapshot->database_name)->toBe('all')
         ->and($this->snapshot->filename)->toEndWith('.rdb.gz')
         ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
+});
+
+test('firebird backup and restore workflow', function () {
+    if (! IntegrationTestHelpers::canRunFirebirdIntegration()) {
+        test()->markTestSkipped('Firebird CLI and service are required for this integration test.');
+    }
+
+    prepareBackupWorkflow('firebird');
+    runManualBackupSnapshot();
+
+    $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
+
+    expect($this->snapshot->job->status)->toBe('completed')
+        ->and($this->snapshot->file_size)->toBeGreaterThan(0)
+        ->and($this->snapshot->filename)->toEndWith('.fbk.gz')
+        ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
+
+    $suffix = IntegrationTestHelpers::getParallelSuffix();
+    $this->restoredDatabaseName = '/var/lib/firebird/data/testdb_restored_'.hrtime(true).$suffix.'.fdb';
+    $restore = $this->backupJobFactory->createRestore(
+        snapshot: $this->snapshot,
+        targetServer: $this->databaseServer,
+        schemaName: $this->restoredDatabaseName,
+    );
+    ProcessRestoreJob::dispatchSync($restore->id);
+
+    $rowCount = IntegrationTestHelpers::verifyFirebirdRestore($this->databaseServer, $this->restoredDatabaseName);
+    expect($rowCount)->toBe(3);
 });

--- a/tests/Integration/DatabaseConnectionTesterTest.php
+++ b/tests/Integration/DatabaseConnectionTesterTest.php
@@ -12,7 +12,13 @@ use App\Models\DatabaseServer;
 use App\Services\Backup\Databases\DatabaseProvider;
 use Tests\Support\IntegrationTestHelpers;
 
+const FIREBIRD_INTEGRATION_SKIP_MESSAGE = 'Firebird CLI and service are required for this integration test.';
+
 test('connection succeeds', function (string $databaseType) {
+    if ($databaseType === 'firebird' && ! IntegrationTestHelpers::canRunFirebirdIntegration()) {
+        test()->markTestSkipped(FIREBIRD_INTEGRATION_SKIP_MESSAGE);
+    }
+
     $config = IntegrationTestHelpers::getDatabaseConfig($databaseType);
 
     if ($databaseType === 'sqlite') {
@@ -31,7 +37,11 @@ test('connection succeeds', function (string $databaseType) {
         'port' => $config['port'],
         'username' => $config['username'],
         'password' => $config['password'],
-        'database_names' => $databaseType === 'sqlite' ? [$config['host']] : null,
+        'database_names' => match ($databaseType) {
+            'sqlite' => [$config['host']],
+            'firebird' => [$config['database']],
+            default => null,
+        },
     ]);
 
     $result = app(DatabaseProvider::class)->testConnectionForServer($testServer);
@@ -43,9 +53,13 @@ test('connection succeeds', function (string $databaseType) {
     if ($databaseType !== 'sqlite' && $databaseType !== 'redis') {
         IntegrationTestHelpers::dropDatabase($databaseType, $server, $config['database']);
     }
-})->with(['mysql', 'postgres', 'sqlite', 'redis']);
+})->with(['mysql', 'postgres', 'sqlite', 'redis', 'firebird']);
 
 test('connection fails with invalid credentials', function (string $databaseType) {
+    if ($databaseType === 'firebird' && ! IntegrationTestHelpers::canRunFirebirdIntegration()) {
+        test()->markTestSkipped(FIREBIRD_INTEGRATION_SKIP_MESSAGE);
+    }
+
     $config = IntegrationTestHelpers::getDatabaseConfig($databaseType);
 
     $server = DatabaseServer::forConnectionTest([
@@ -54,21 +68,27 @@ test('connection fails with invalid credentials', function (string $databaseType
         'port' => $config['port'],
         'username' => 'invalid_user',
         'password' => 'invalid_password',
+        'database_names' => $databaseType === 'firebird' ? [$config['database']] : null,
     ]);
 
     $result = app(DatabaseProvider::class)->testConnectionForServer($server);
 
     expect($result['success'])->toBeFalse()
         ->and($result['message'])->not->toBeEmpty();
-})->with(['mysql', 'postgres']);
+})->with(['mysql', 'postgres', 'firebird']);
 
 test('connection fails with unreachable host', function (string $databaseType, int $port) {
+    if ($databaseType === 'firebird' && ! IntegrationTestHelpers::canRunFirebirdIntegration()) {
+        test()->markTestSkipped(FIREBIRD_INTEGRATION_SKIP_MESSAGE);
+    }
+
     $server = DatabaseServer::forConnectionTest([
         'database_type' => $databaseType,
         'host' => '127.0.0.1',
         'port' => $port, // Wrong port - nothing listening here
         'username' => 'user',
         'password' => 'password',
+        'database_names' => $databaseType === 'firebird' ? [IntegrationTestHelpers::getDatabaseConfig('firebird')['database']] : null,
     ]);
 
     $result = app(DatabaseProvider::class)->testConnectionForServer($server);
@@ -78,6 +98,7 @@ test('connection fails with unreachable host', function (string $databaseType, i
 })->with([
     'mysql' => ['mysql', 33061],      // Wrong MySQL port
     'postgres' => ['postgres', 54321], // Wrong PostgreSQL port
+    'firebird' => ['firebird', 30501], // Wrong Firebird port
 ]);
 
 test('sqlite connection fails', function (string $path, string $expectedMessage) {

--- a/tests/Integration/fixtures/firebird-init.sql
+++ b/tests/Integration/fixtures/firebird-init.sql
@@ -1,0 +1,9 @@
+CREATE TABLE test_table (
+    id INTEGER NOT NULL PRIMARY KEY,
+    name VARCHAR(50),
+    amount INTEGER
+);
+
+INSERT INTO test_table (id, name, amount) VALUES (1, 'item1', 100);
+INSERT INTO test_table (id, name, amount) VALUES (2, 'item2', 200);
+INSERT INTO test_table (id, name, amount) VALUES (3, 'item3', 300);

--- a/tests/Support/IntegrationTestHelpers.php
+++ b/tests/Support/IntegrationTestHelpers.php
@@ -89,6 +89,14 @@ class IntegrationTestHelpers
                 'database' => config('testing.databases.mssql.database').$suffix,
                 'database_type' => 'mssql',
             ],
+            'firebird' => [
+                'host' => config('testing.databases.firebird.host'),
+                'port' => (int) config('testing.databases.firebird.port'),
+                'username' => config('testing.databases.firebird.username'),
+                'password' => config('testing.databases.firebird.password'),
+                'database' => preg_replace('/\.fdb$/', $suffix.'.fdb', (string) config('testing.databases.firebird.database')),
+                'database_type' => 'firebird',
+            ],
             default => throw new InvalidArgumentException("Unsupported database type: {$type}"),
         };
     }
@@ -355,6 +363,76 @@ class IntegrationTestHelpers
     }
 
     /**
+     * Run SQL against Firebird using the CLI client and return raw output.
+     */
+    public static function runFirebirdSql(DatabaseServer $server, array $statements, ?string $databaseName = null): string
+    {
+        $scriptFile = tempnam(sys_get_temp_dir(), 'firebird-sql-');
+        if ($scriptFile === false) {
+            throw new InvalidArgumentException('Unable to create temporary Firebird SQL script');
+        }
+
+        file_put_contents($scriptFile, implode(PHP_EOL, [...$statements, 'EXIT;']).PHP_EOL);
+
+        $target = $databaseName !== null
+            ? sprintf('%s/%d:%s', $server->host, $server->port, $databaseName)
+            : null;
+
+        $parts = [
+            escapeshellcmd(self::firebirdIsqlBinary()),
+            '-user',
+            escapeshellarg($server->username),
+            '-password',
+            escapeshellarg($server->getDecryptedPassword()),
+        ];
+
+        if ($target !== null) {
+            $parts[] = escapeshellarg($target);
+        }
+
+        $parts[] = '-i';
+        $parts[] = escapeshellarg($scriptFile);
+        $parts[] = '2>&1';
+
+        exec(implode(' ', $parts), $output, $exitCode);
+        @unlink($scriptFile);
+
+        $joined = trim(implode(PHP_EOL, $output));
+
+        if ($exitCode !== 0) {
+            throw new InvalidArgumentException('Firebird SQL command failed: '.($joined !== '' ? $joined : 'unknown error'));
+        }
+
+        return $joined;
+    }
+
+    private static function firebirdIsqlBinary(): string
+    {
+        exec('command -v isql-fb 2>/dev/null', $output, $exitCode);
+
+        return $exitCode === 0 && isset($output[0]) ? $output[0] : 'isql';
+    }
+
+    public static function canRunFirebirdIntegration(): bool
+    {
+        exec('command -v isql-fb 2>/dev/null', $output, $exitCode);
+        if ($exitCode !== 0) {
+            return false;
+        }
+
+        $host = (string) config('testing.databases.firebird.host');
+        $port = (int) config('testing.databases.firebird.port');
+        $socket = @fsockopen($host, $port, $errno, $errstr, 1.0);
+        if (! is_resource($socket)) {
+            return false;
+        }
+
+        fclose($socket);
+
+        return true;
+    }
+
+    /**
      * Get SSH tunnel test configuration.
      *
      * @return array{host: string, port: int, username: string, password: string, mysql_host: string}
@@ -434,6 +512,16 @@ class IntegrationTestHelpers
             return;
         }
 
+        if ($type === 'firebird') {
+            try {
+                self::runFirebirdSql($server, ['DROP DATABASE;'], $databaseName);
+            } catch (InvalidArgumentException) {
+                // Best-effort cleanup only.
+            }
+
+            return;
+        }
+
         $pdo = DatabaseType::from($type)->createPdo($server);
 
         if ($type === 'mysql') {
@@ -469,6 +557,32 @@ class IntegrationTestHelpers
         // raw script with batch separators in one exec).
         if ($type === 'mssql') {
             self::loadMssqlTestData($server);
+
+            return;
+        }
+
+        if ($type === 'firebird') {
+            $databaseName = self::resolveTestDatabaseName($server);
+
+            self::dropDatabase($type, $server, $databaseName);
+            self::runFirebirdSql($server, [
+                sprintf(
+                    "CREATE DATABASE '%s/%d:%s' USER '%s' PASSWORD '%s';",
+                    $server->host,
+                    $server->port,
+                    $databaseName,
+                    str_replace("'", "''", $server->username),
+                    str_replace("'", "''", $server->getDecryptedPassword()),
+                ),
+            ]);
+
+            $fixtureFile = __DIR__.'/../Integration/fixtures/firebird-init.sql';
+            $sql = array_values(array_filter(array_map('trim', explode(';', (string) file_get_contents($fixtureFile)))));
+            self::runFirebirdSql(
+                $server,
+                array_map(static fn (string $statement) => $statement.';', $sql),
+                $databaseName,
+            );
 
             return;
         }
@@ -532,5 +646,22 @@ class IntegrationTestHelpers
             array_map('trim', $batches),
             fn (string $batch): bool => $batch !== '',
         ));
+    }
+
+    /**
+     * Verify Firebird restore by counting rows in the test table.
+     */
+    public static function verifyFirebirdRestore(DatabaseServer $server, string $databaseName): int
+    {
+        $output = self::runFirebirdSql($server, [
+            'SET HEADING OFF;',
+            'SET LIST OFF;',
+            'SET COUNT OFF;',
+            'SELECT COUNT(*) FROM test_table;',
+        ], $databaseName);
+
+        preg_match('/\b(\d+)\b/', $output, $matches);
+
+        return isset($matches[1]) ? (int) $matches[1] : 0;
     }
 }

--- a/tests/Unit/Services/Backup/ShellProcessorTest.php
+++ b/tests/Unit/Services/Backup/ShellProcessorTest.php
@@ -14,6 +14,7 @@ test('sanitizes sensitive patterns', function (string $input, string $expectedTo
     '--password= format' => ['mysqldump --password=secret123 dbname', '--password=***', 'secret123'],
     'quoted --password= format' => ["mysqldump --password='secret123' dbname", '--password=***', 'secret123'],
     '-p shorthand format' => ['mysqldump -psecret123 dbname', '-p***', 'secret123'],
+    'firebird -password format' => ["gbak -b -user 'SYSDBA' -password 'masterkey' 'db' 'dump'", '-password ***', 'masterkey'],
     'PGPASSWORD env var' => ['PGPASSWORD=secret123 pg_dump dbname', 'PGPASSWORD=***', 'secret123'],
     'MYSQL_PWD env var' => ['MYSQL_PWD=secret123 mysqldump failed', 'MYSQL_PWD=***', 'secret123'],
     'sqlpackage source password' => ["sqlpackage /Action:Export /SourcePassword:'secret123' /SourceDatabaseName:'db'", '/SourcePassword:***', 'secret123'],
@@ -30,6 +31,7 @@ test('preserves non-sensitive patterns', function (string $input, string $expect
     'hostname containing -p' => ["mysqldump --host='mysql-production.example.com' dbname", 'mysql-production.example.com'],
     '--port option' => ['mysqldump --port=3306 dbname', '--port=3306'],
     '-p with space (port flag)' => ['pg_dump -p 5432 dbname', '-p 5432'],
+    'firebird user flag not masked' => ["gbak -b -user 'sysdba' -password 'secret' 'db' 'dump'", "-user 'sysdba'"],
 ]);
 
 test('sanitizes realistic mariadb-dump command', function () {


### PR DESCRIPTION
## What changed

This PR adds Firebird support across the backup and restore flow.

Included:
- Firebird database type wiring and handler implementation
- `gbak` backup and restore command support
- Firebird-aware server form and restore modal validation
- Firebird-specific connection testing behavior for explicit database paths
- Firebird integration coverage in Docker-based test infrastructure
- Shell command redaction support for Firebird `-password ...` arguments

## Why

Upstream currently has no Firebird backup/restore support.

This branch adds the missing end-to-end pieces needed to:
- register Firebird servers
- create Firebird backups
- restore Firebird snapshots
- validate and test Firebird flows in automated tests

It also keeps Firebird aligned with the newer multi-backup configuration model already used upstream.

## Root cause for the late fixes

During integration on top of current `upstream/main`, Firebird still needed a few follow-up fixes:
- Firebird connection tests need an explicit database path instead of a bare host/port probe
- Firebird backup cards must stay visible before connection test success, otherwise the required path field is unreachable
- Firebird free-text database names must still normalize into `database_names` even though Firebird never loads a selectable database list
- Firebird restore should use the replace-style `gbak` flow reflected in the current implementation and tests

## Impact

User impact:
- Firebird becomes available as a first-class database type in the UI
- users can back up and restore `.fdb` databases
- restore validation accepts Firebird path-style target names

Developer impact:
- Docker test infrastructure now includes Firebird
- integration helpers cover Firebird data loading and restore verification
- test coverage includes Firebird backup/restore and connection flows

## Validation

Used during preparation of this branch:
- Firebird feature and unit tests for handler/provider/restore flow
- Firebird create and restore modal tests
- Firebird integration tests for connection and backup/restore flow
- manual UI verification of Firebird server creation, backup, restore, and snapshot download in the fork before extracting this upstream branch

Note:
- I did not rerun the full suite after tearing down the local `databasement` Docker environment.
- Earlier full-suite investigation showed remaining instability in non-Firebird integration services (`postgres` / `mongodb` / `redis`), not in the Firebird path itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Firebird database server support with backup, restore, and connection testing capabilities
  * Updated backup configuration interface with Firebird-specific database selection requirements
  * Enhanced restore validation with Firebird-specific schema naming rules

* **Documentation**
  * Updated backup instructions for SQLite to use native database backup command

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->