### PR TITLE
feat: add multi-organization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@
 
 ## Features
 
-- **Multi-database support** — Manage MySQL, PostgreSQL, MariaDB, MongoDB, SQLite, and Redis/Valkey servers from a single interface
-- **SSH tunnel support** — Connect to databases in private networks through a bastion/jump server with password or key-based authentication
-- **Automated backups** — Schedule recurring backups on daily or weekly intervals. Flexible retention policies: simple time-based (days) or GFS (grandfather-father-son)
-- **Multiple compression options** — gzip, zstd (20-40% better compression), or encrypted (AES-256 for sensitive data)
-- **Cross-server restore** — Restore snapshots from production to staging, or between any compatible servers
-- **Flexible storage** — Store backups locally, on S3-compatible storage (AWS S3, MinIO, etc.), or remote servers via SFTP/FTP
-- **Real-time monitoring** — Track backup and restore progress with detailed job logs
-- **Failure notifications** — Get alerted via Email, Slack, Discord, Telegram, Pushover, Gotify, or Webhook when jobs fail
-- **Team ready** — Multi-user support with role-based access and optional two-factor authentication
-- **Automation** — REST API and MCP server for scripting, CI/CD, and AI assistant integration
-- **Simple deployment** — Single Docker container with built-in web server, queue worker, and scheduler
+- **Multi-database support** - Manage MySQL, PostgreSQL, MariaDB, MongoDB, SQLite, and Redis/Valkey servers from a single interface
+- **SSH tunnel support** - Connect to databases in private networks through a bastion/jump server with password or key-based authentication
+- **Automated backups** - Schedule recurring backups on daily or weekly intervals. Flexible retention policies: simple time-based (days) or GFS (grandfather-father-son)
+- **Multiple compression options** - gzip, zstd (20-40% better compression), or encrypted (AES-256 for sensitive data)
+- **Cross-server restore** - Restore snapshots from production to staging, or between any compatible servers
+- **Flexible storage** - Store backups locally, on S3-compatible storage (AWS S3, MinIO, etc.), or remote servers via SFTP/FTP
+- **Real-time monitoring** - Track backup and restore progress with detailed job logs
+- **Failure notifications** - Get alerted via Email, Slack, Discord, Telegram, Pushover, Gotify, or Webhook when jobs fail
+- **Team ready** - Multi-tenant organizations with isolated workspaces, role-based access control, OAuth/SSO login (Google, GitHub, GitLab, OpenID Connect), and optional two-factor authentication
+- **Automation** - REST API and MCP server for scripting, CI/CD, and AI assistant integration
+- **Simple deployment** - Single Docker container with built-in web server, queue worker, and scheduler
 
 > **Try it out!** Explore the [live demo](https://databasement-demo.crty.dev/) to see Databasement in action before installing.
 
@@ -99,8 +99,8 @@ See the [Database Servers documentation](https://david-crty.github.io/databaseme
 
 Databasement can be managed programmatically through its **REST API** and **MCP server**, enabling integration with scripts, CI/CD pipelines, and AI assistants.
 
-- **REST API** — Full API for managing servers, backups, and restores. See the [API documentation](https://david-crty.github.io/databasement/user-guide/api).
-- **MCP Server** — Connect AI assistants (Claude Code, Cursor, VS Code Copilot, etc.) to manage backups through natural language. See the [MCP documentation](https://david-crty.github.io/databasement/user-guide/mcp).
+- **REST API** - Full API for managing servers, backups, and restores. See the [API documentation](https://david-crty.github.io/databasement/user-guide/api).
+- **MCP Server** - Connect AI assistants (Claude Code, Cursor, VS Code Copilot, etc.) to manage backups through natural language. See the [MCP documentation](https://david-crty.github.io/databasement/user-guide/mcp).
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in Databasement, please report it responsibly:
 
 1. **Do not** open a public GitHub issue for security vulnerabilities
-2. Email the details to the maintainers (include steps to reproduce if possible)
+2. Use [GitHub's private vulnerability reporting](https://github.com/David-Crty/databasement/security/advisories/new) to submit the details (include steps to reproduce if possible)
 3. Allow reasonable time for a fix before public disclosure
 
 We appreciate your help in keeping Databasement secure.

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -2,6 +2,8 @@
 
 namespace App\Actions\Fortify;
 
+use App\Enums\UserRole;
+use App\Models\Organization;
 use App\Models\User;
 use App\Services\DemoBackupService;
 use Illuminate\Support\Facades\Log;
@@ -46,13 +48,23 @@ class CreateNewUser implements CreatesNewUsers
 
         $createDemoBackup = ! empty($input['create_demo_backup']);
 
+        // Ensure main org exists (migration creates it, but handle fresh install)
+        $mainOrg = Organization::firstOrCreate(
+            ['is_main' => true],
+            ['name' => 'Main']
+        );
+
+        // First user is always super_admin
         $user = User::create([
             'name' => $input['name'],
             'email' => $input['email'],
             'password' => $input['password'],
-            'role' => User::ROLE_ADMIN, // First user is always admin
+            'super_admin' => true,
             'invitation_accepted_at' => now(),
         ]);
+
+        // Attach to main org as admin
+        $user->organizations()->attach($mainOrg->id, ['role' => UserRole::Admin->value]);
 
         if ($createDemoBackup) {
             try {

--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case Demo = 'demo';
+    case Viewer = 'viewer';
+    case Member = 'member';
+    case Admin = 'admin';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Admin => __('Admin'),
+            self::Member => __('Member'),
+            self::Viewer => __('Viewer'),
+            self::Demo => __('Demo'),
+        };
+    }
+
+    public function icon(): string
+    {
+        return match ($this) {
+            self::Admin => 'o-shield-check',
+            self::Member => 'o-pencil-square',
+            self::Viewer => 'o-eye',
+            self::Demo => 'o-beaker',
+        };
+    }
+
+    public function badgeClass(): string
+    {
+        return match ($this) {
+            self::Admin => 'badge-primary',
+            self::Member => 'badge-info',
+            self::Viewer => 'badge-neutral',
+            self::Demo => 'badge-ghost',
+        };
+    }
+
+    /**
+     * Roles that can be assigned through the UI (excludes Demo).
+     *
+     * @return list<self>
+     */
+    public static function assignable(): array
+    {
+        return [self::Viewer, self::Member, self::Admin];
+    }
+
+    /**
+     * Validation rule string for assignable roles.
+     */
+    public static function validationRule(): string
+    {
+        return 'in:'.implode(',', array_map(fn (self $r) => $r->value, self::assignable()));
+    }
+}

--- a/app/Http/Controllers/Api/V1/DatabaseServerController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerController.php
@@ -16,6 +16,7 @@ use App\Services\Backup\BackupJobFactory;
 use App\Services\Backup\Databases\DatabaseProvider;
 use App\Services\Backup\SyncBackupConfigurationsAction;
 use App\Services\Backup\TriggerBackupAction;
+use App\Services\CurrentOrganization;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -71,6 +72,8 @@ class DatabaseServerController extends Controller
         }
 
         DatabaseServer::buildExtraConfig($validated);
+
+        $validated['organization_id'] = app(CurrentOrganization::class)->id();
 
         $server = DatabaseServer::create($validated);
         $this->syncBackupConfigurations($server, $backupsPayload, $hasBackupsPayload);

--- a/app/Http/Controllers/Api/V1/UserOrganizationController.php
+++ b/app/Http/Controllers/Api/V1/UserOrganizationController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\OrganizationResource;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+
+/**
+ * @tags User
+ */
+class UserOrganizationController extends Controller
+{
+    /**
+     * List the authenticated user's organizations.
+     *
+     * Returns all organizations the current user belongs to, including their
+     * role in each. Use the `id` from the response as the `org_id` query
+     * parameter or `X-Organization-Id` header to scope requests to a
+     * specific organization.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        return OrganizationResource::collection(
+            $user->organizations()->orderByPivot('created_at')->get()
+        );
+    }
+}

--- a/app/Http/Controllers/Api/V1/VolumeController.php
+++ b/app/Http/Controllers/Api/V1/VolumeController.php
@@ -12,6 +12,7 @@ use App\Http\Requests\Api\V1\Volume\StoreVolumeRequest;
 use App\Http\Resources\VolumeResource;
 use App\Models\Volume;
 use App\Queries\VolumeQuery;
+use App\Services\CurrentOrganization;
 use App\Services\VolumeConnectionTester;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
@@ -120,6 +121,7 @@ class VolumeController extends Controller
         $volumeType = VolumeType::from($validated['type']);
 
         $validated['config'] = $volumeType->encryptSensitiveFields($validated['config']);
+        $validated['organization_id'] = app(CurrentOrganization::class)->id();
 
         $volume = Volume::create($validated);
 

--- a/app/Http/Middleware/DemoModeMiddleware.php
+++ b/app/Http/Middleware/DemoModeMiddleware.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Middleware;
 
+use App\Enums\UserRole;
+use App\Models\Organization;
 use App\Models\User;
 use Closure;
 use Illuminate\Http\Request;
@@ -48,17 +50,21 @@ class DemoModeMiddleware
 
     /**
      * Create the demo user if it doesn't exist.
+     * Attaches to main org with demo role.
      */
     protected function ensureDemoUserExists(): void
     {
-        User::firstOrCreate(
+        $user = User::firstOrCreate(
             ['email' => config('app.demo_user_email')],
             [
                 'name' => 'Demo User',
                 'password' => bcrypt(config('app.demo_user_password')),
-                'role' => User::ROLE_DEMO,
                 'invitation_accepted_at' => now(),
             ]
         );
+
+        $user->organizations()->syncWithoutDetaching([
+            Organization::main()->id => ['role' => UserRole::Demo->value],
+        ]);
     }
 }

--- a/app/Http/Middleware/SetCurrentOrganization.php
+++ b/app/Http/Middleware/SetCurrentOrganization.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Agent;
+use App\Models\User;
+use App\Services\CurrentOrganization;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Session;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetCurrentOrganization
+{
+    public function __construct(
+        private readonly CurrentOrganization $currentOrganization
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        /** @var User|Agent|null $authenticatable */
+        $authenticatable = $request->user();
+
+        if ($authenticatable instanceof Agent) {
+            $this->currentOrganization->set($authenticatable->organization);
+        } elseif ($authenticatable instanceof User) {
+            $this->currentOrganization->reset();
+
+            if ($request->is('api/*') || $request->is('mcp*')) {
+                $this->resolveApiOrganization($request, $authenticatable);
+            } else {
+                /** @var string|null $cookieOrgId */
+                $cookieOrgId = $request->cookie(CurrentOrganization::COOKIE_NAME);
+                $this->currentOrganization->resolveForUser($authenticatable, $cookieOrgId);
+            }
+
+            if (! $this->currentOrganization->isResolved()) {
+                if ($request->expectsJson()) {
+                    abort(401, __('Your account is not a member of any organization. Please contact an administrator.'));
+                }
+
+                Auth::guard('web')->logout();
+                Session::invalidate();
+                Session::regenerateToken();
+                session()->flash('error', __('Your account is not a member of any organization. Please contact an administrator.'));
+
+                return redirect()->route('login');
+            }
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Resolve organization for API requests.
+     * Aborts with 403 when the client explicitly requests an org that is invalid or inaccessible.
+     */
+    private function resolveApiOrganization(Request $request, User $user): void
+    {
+        /** @var string|null $orgId */
+        $orgId = $request->query('org_id') ?? $request->header('X-Organization-Id');
+
+        $this->currentOrganization->resolveForUser($user, $orgId);
+
+        if ($orgId && (! $this->currentOrganization->isResolved() || $this->currentOrganization->id() !== $orgId)) {
+            abort(403, 'The requested organization is not accessible.');
+        }
+    }
+}

--- a/app/Http/Resources/OrganizationResource.php
+++ b/app/Http/Resources/OrganizationResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Organization;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Organization
+ */
+class OrganizationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'is_main' => $this->is_main,
+            'role' => $this->whenPivotLoaded('organization_user', fn () => $this->pivot->role), // @phpstan-ignore property.notFound
+        ];
+    }
+}

--- a/app/Jobs/VerifySnapshotFileJob.php
+++ b/app/Jobs/VerifySnapshotFileJob.php
@@ -17,13 +17,14 @@ class VerifySnapshotFileJob implements ShouldQueue
 
     public int $tries = 1;
 
-    public function __construct()
-    {
+    public function __construct(
+        public readonly ?string $organizationId = null
+    ) {
         $this->onQueue('backups');
     }
 
     public function handle(SnapshotVerificationService $service): void
     {
-        $service->run();
+        $service->run($this->organizationId);
     }
 }

--- a/app/Livewire/Configuration/Authentication.php
+++ b/app/Livewire/Configuration/Authentication.php
@@ -58,6 +58,11 @@ class Authentication extends Component
                 'description' => __('Default role for new OAuth users: viewer, member, or admin.'),
             ],
             [
+                'env' => 'OAUTH_DEFAULT_ORGANIZATION_ID',
+                'value' => config('oauth.default_organization_id') ?: '-',
+                'description' => __('Organization ID for auto-created OAuth users (defaults to main org).'),
+            ],
+            [
                 'env' => 'OAUTH_AUTO_LINK_BY_EMAIL',
                 'value' => config('oauth.auto_link_by_email') ? 'true' : 'false',
                 'description' => __('Link OAuth logins to existing users with matching email.'),

--- a/app/Livewire/Configuration/Backup.php
+++ b/app/Livewire/Configuration/Backup.php
@@ -7,6 +7,7 @@ use App\Jobs\VerifySnapshotFileJob;
 use App\Livewire\Forms\ConfigurationForm;
 use App\Models\BackupSchedule;
 use App\Services\Backup\TriggerBackupAction;
+use App\Services\CurrentOrganization;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
@@ -69,7 +70,7 @@ class Backup extends Component
     {
         abort_unless(auth()->user()->isAdmin(), Response::HTTP_FORBIDDEN);
 
-        VerifySnapshotFileJob::dispatch();
+        VerifySnapshotFileJob::dispatch(app(CurrentOrganization::class)->id());
 
         $this->success(__('Snapshot file verification job dispatched.'));
     }

--- a/app/Livewire/Configuration/Organization.php
+++ b/app/Livewire/Configuration/Organization.php
@@ -32,6 +32,8 @@ class Organization extends Component
 
     public ?string $deleteOrgId = null;
 
+    public bool $deleteOrgHasResources = false;
+
     public function mount(): void
     {
         $this->authorize('viewAny', OrganizationModel::class);
@@ -115,27 +117,26 @@ class Organization extends Component
 
     public function confirmDelete(string $orgId): void
     {
-        $org = OrganizationModel::withCount([
-            'databaseServers' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
-            'volumes' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
-            'agents' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
-        ])->findOrFail($orgId);
+        $org = OrganizationModel::findOrFail($orgId);
 
         $this->authorize('delete', $org);
 
         $this->deleteOrgId = $orgId;
+        $this->deleteOrgHasResources = $org->hasResources();
         $this->showDeleteModal = true;
     }
 
     public function deleteOrganization(): mixed
     {
-        $org = OrganizationModel::withCount([
-            'databaseServers' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
-            'volumes' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
-            'agents' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
-        ])->findOrFail($this->deleteOrgId);
+        $org = OrganizationModel::findOrFail($this->deleteOrgId);
 
         $this->authorize('delete', $org);
+
+        if ($org->hasResources()) {
+            $this->error(__('This organization still has resources and cannot be deleted.'));
+
+            return null;
+        }
 
         $org->delete();
 

--- a/app/Livewire/Configuration/Organization.php
+++ b/app/Livewire/Configuration/Organization.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace App\Livewire\Configuration;
+
+use App\Models\Organization as OrganizationModel;
+use App\Models\Scopes\OrganizationScope;
+use App\Traits\Toast;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('Configuration')]
+class Organization extends Component
+{
+    use AuthorizesRequests;
+    use Toast;
+
+    public bool $showCreateModal = false;
+
+    public string $newOrgName = '';
+
+    public bool $showEditModal = false;
+
+    public ?string $editingOrgId = null;
+
+    public string $editOrgName = '';
+
+    public bool $showDeleteModal = false;
+
+    public ?string $deleteOrgId = null;
+
+    public function mount(): void
+    {
+        $this->authorize('viewAny', OrganizationModel::class);
+    }
+
+    /**
+     * @return Collection<int, OrganizationModel>
+     */
+    #[Computed]
+    public function organizations(): Collection
+    {
+        return OrganizationModel::withCount([
+            'users',
+            'databaseServers' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+            'volumes' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+            'agents' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+        ])
+            ->orderByDesc('is_main')
+            ->orderBy('name')
+            ->get();
+    }
+
+    public function openCreateModal(): void
+    {
+        $this->newOrgName = '';
+        $this->resetValidation();
+        $this->showCreateModal = true;
+    }
+
+    public function createOrganization(): mixed
+    {
+        $this->authorize('create', OrganizationModel::class);
+
+        $this->validate([
+            'newOrgName' => 'required|string|max:255|unique:organizations,name',
+        ]);
+
+        OrganizationModel::create([
+            'name' => $this->newOrgName,
+        ]);
+
+        $this->showCreateModal = false;
+        $this->newOrgName = '';
+
+        $this->success(__('Organization created.'));
+
+        return $this->redirect(route('configuration.organizations'), navigate: true);
+    }
+
+    public function openEditModal(string $orgId): void
+    {
+        $org = OrganizationModel::findOrFail($orgId);
+
+        $this->authorize('update', $org);
+
+        $this->editingOrgId = $orgId;
+        $this->editOrgName = $org->name;
+        $this->resetValidation();
+        $this->showEditModal = true;
+    }
+
+    public function updateOrganization(): mixed
+    {
+        $org = OrganizationModel::findOrFail($this->editingOrgId);
+
+        $this->authorize('update', $org);
+
+        $this->validate([
+            'editOrgName' => 'required|string|max:255|unique:organizations,name,'.$org->id,
+        ]);
+
+        $org->update(['name' => $this->editOrgName]);
+
+        $this->showEditModal = false;
+        $this->editingOrgId = null;
+
+        $this->success(__('Organization updated.'));
+
+        return $this->redirect(route('configuration.organizations'), navigate: true);
+    }
+
+    public function confirmDelete(string $orgId): void
+    {
+        $org = OrganizationModel::withCount([
+            'databaseServers' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+            'volumes' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+            'agents' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+        ])->findOrFail($orgId);
+
+        $this->authorize('delete', $org);
+
+        $this->deleteOrgId = $orgId;
+        $this->showDeleteModal = true;
+    }
+
+    public function deleteOrganization(): mixed
+    {
+        $org = OrganizationModel::withCount([
+            'databaseServers' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+            'volumes' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+            'agents' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
+        ])->findOrFail($this->deleteOrgId);
+
+        $this->authorize('delete', $org);
+
+        $org->delete();
+
+        $this->showDeleteModal = false;
+        $this->deleteOrgId = null;
+
+        $this->success(__('Organization deleted.'));
+
+        return $this->redirect(route('configuration.organizations'), navigate: true);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.configuration.organization', [
+            'organizations' => $this->organizations(),
+            'headers' => [
+                ['key' => 'name', 'label' => __('Name')],
+                ['key' => 'id', 'label' => __('ID')],
+                ['key' => 'users_count', 'label' => __('Users')],
+                ['key' => 'database_servers_count', 'label' => __('Servers')],
+                ['key' => 'volumes_count', 'label' => __('Volumes')],
+                ['key' => 'agents_count', 'label' => __('Agents')],
+                ['key' => 'actions', 'label' => '', 'class' => 'w-32'],
+            ],
+        ]);
+    }
+}

--- a/app/Livewire/Dashboard/JobStatusGrid.php
+++ b/app/Livewire/Dashboard/JobStatusGrid.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -15,6 +16,7 @@ class JobStatusGrid extends Component
 {
     public bool $showLogsModal = false;
 
+    #[Locked]
     public ?string $selectedJobId = null;
 
     /**
@@ -23,7 +25,7 @@ class JobStatusGrid extends Component
     #[Computed]
     public function jobs(): Collection
     {
-        return BackupJob::query()
+        return BackupJob::forCurrentOrg()
             ->select(['id', 'status', 'duration_ms', 'created_at'])
             ->with([
                 'snapshot:id,backup_job_id,database_name,database_server_id' => [
@@ -72,7 +74,7 @@ class JobStatusGrid extends Component
             return null;
         }
 
-        return BackupJob::with([
+        return BackupJob::forCurrentOrg()->with([
             'snapshot.databaseServer',
             'snapshot.triggeredBy',
             'restore.snapshot.databaseServer',

--- a/app/Livewire/Dashboard/JobsActivityChart.php
+++ b/app/Livewire/Dashboard/JobsActivityChart.php
@@ -20,7 +20,7 @@ class JobsActivityChart extends Component
         $days = 14;
         $startDate = Carbon::now()->subDays($days - 1)->startOfDay();
 
-        $jobs = BackupJob::where('created_at', '>=', $startDate)
+        $jobs = BackupJob::forCurrentOrg()->where('created_at', '>=', $startDate)
             ->get()
             ->groupBy(fn ($job) => $job->created_at->format('Y-m-d'));
 

--- a/app/Livewire/Dashboard/LatestJobs.php
+++ b/app/Livewire/Dashboard/LatestJobs.php
@@ -6,6 +6,7 @@ use App\Models\BackupJob;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Lazy;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
 
@@ -19,6 +20,7 @@ class LatestJobs extends Component
 
     public bool $showLogsModal = false;
 
+    #[Locked]
     public ?string $selectedJobId = null;
 
     public function mount(): void
@@ -61,7 +63,7 @@ class LatestJobs extends Component
             return null;
         }
 
-        return BackupJob::with([
+        return BackupJob::forCurrentOrg()->with([
             'snapshot.databaseServer',
             'snapshot.triggeredBy',
             'restore.snapshot.databaseServer',
@@ -72,7 +74,7 @@ class LatestJobs extends Component
 
     public function fetchJobs(): void
     {
-        $query = BackupJob::query()
+        $query = BackupJob::forCurrentOrg()
             ->with([
                 'snapshot.databaseServer',
                 'restore.targetServer',

--- a/app/Livewire/Dashboard/SnapshotsCard.php
+++ b/app/Livewire/Dashboard/SnapshotsCard.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Dashboard;
 
 use App\Jobs\VerifySnapshotFileJob;
 use App\Models\Snapshot;
+use App\Services\CurrentOrganization;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Cache;
@@ -36,7 +37,7 @@ class SnapshotsCard extends Component
 
     private function loadData(): void
     {
-        $baseQuery = Snapshot::whereRelation('job', 'status', 'completed');
+        $baseQuery = Snapshot::forCurrentOrg()->whereRelation('job', 'status', 'completed');
 
         $this->totalSnapshots = $baseQuery->count();
         $this->verifiedSnapshots = (clone $baseQuery)->whereNotNull('file_verified_at')->count();
@@ -52,7 +53,9 @@ class SnapshotsCard extends Component
     {
         abort_unless(auth()->user()->isAdmin(), Response::HTTP_FORBIDDEN);
 
-        $lock = Cache::lock('verify-snapshot-files', 300);
+        $currentOrg = app(CurrentOrganization::class);
+        $lockKey = 'verify-snapshot-files:'.$currentOrg->id();
+        $lock = Cache::lock($lockKey, 300);
 
         if (! $lock->get()) {
             $this->warning(__('File verification is already running.'));
@@ -60,7 +63,7 @@ class SnapshotsCard extends Component
             return;
         }
 
-        VerifySnapshotFileJob::dispatch();
+        VerifySnapshotFileJob::dispatch($currentOrg->id());
 
         $this->success(__('File verification job dispatched.'));
     }

--- a/app/Livewire/Dashboard/StorageCard.php
+++ b/app/Livewire/Dashboard/StorageCard.php
@@ -27,7 +27,7 @@ class StorageCard extends Component
 
     private function loadData(): void
     {
-        $totalBytes = Snapshot::whereRelation('job', 'status', 'completed')->sum('file_size');
+        $totalBytes = Snapshot::forCurrentOrg()->whereRelation('job', 'status', 'completed')->sum('file_size');
         $this->totalStorage = Formatters::humanFileSize((int) $totalBytes);
     }
 

--- a/app/Livewire/Dashboard/StorageDistributionChart.php
+++ b/app/Livewire/Dashboard/StorageDistributionChart.php
@@ -19,7 +19,7 @@ class StorageDistributionChart extends Component
     public function mount(): void
     {
         /** @var \Illuminate\Support\Collection<int, object{name: string, total_size: int}> $storageByVolume */
-        $storageByVolume = Snapshot::query()
+        $storageByVolume = Snapshot::forCurrentOrg()
             ->join('volumes', 'snapshots.volume_id', '=', 'volumes.id')
             ->selectRaw('volumes.name, SUM(snapshots.file_size) as total_size')
             ->groupBy('volumes.id', 'volumes.name')

--- a/app/Livewire/Dashboard/SuccessRateCard.php
+++ b/app/Livewire/Dashboard/SuccessRateCard.php
@@ -32,7 +32,7 @@ class SuccessRateCard extends Component
     {
         $thirtyDaysAgo = Carbon::now()->subDays(30);
 
-        $counts = BackupJob::query()
+        $counts = BackupJob::forCurrentOrg()
             ->toBase()
             ->where('created_at', '>=', $thirtyDaysAgo)
             ->whereIn('status', ['completed', 'failed'])
@@ -48,7 +48,7 @@ class SuccessRateCard extends Component
             $this->successRate = round(($completed / $total) * 100, 1);
         }
 
-        $this->runningJobs = BackupJob::where('status', 'running')->count();
+        $this->runningJobs = BackupJob::forCurrentOrg()->where('status', 'running')->count();
     }
 
     public function placeholder(): View

--- a/app/Livewire/Forms/AgentForm.php
+++ b/app/Livewire/Forms/AgentForm.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Forms;
 
 use App\Models\Agent;
+use App\Services\CurrentOrganization;
 use Livewire\Form;
 
 class AgentForm extends Form
@@ -33,6 +34,7 @@ class AgentForm extends Form
 
         return Agent::create([
             'name' => $this->name,
+            'organization_id' => app(CurrentOrganization::class)->id(),
         ]);
     }
 

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -14,6 +14,7 @@ use App\Models\DatabaseServerSshConfig;
 use App\Models\NotificationChannel;
 use App\Services\Backup\Databases\DatabaseProvider;
 use App\Services\Backup\SyncBackupConfigurationsAction;
+use App\Services\CurrentOrganization;
 use App\Services\SshTunnelService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rule;
@@ -881,6 +882,8 @@ class DatabaseServerForm extends Form
         $serverData['ssh_config_id'] = $this->createOrUpdateSshConfig();
         DatabaseServer::buildExtraConfig($serverData);
 
+        $serverData['organization_id'] = app(CurrentOrganization::class)->id();
+
         DB::transaction(function () use ($serverData): void {
             $server = DatabaseServer::create($serverData);
             $this->syncBackupConfigurations($server);
@@ -996,7 +999,8 @@ class DatabaseServerForm extends Form
             }
         }
 
-        // Create new config
+        $sshData['organization_id'] = app(CurrentOrganization::class)->id();
+
         return DatabaseServerSshConfig::create($sshData)->id;
     }
 

--- a/app/Livewire/Forms/UserForm.php
+++ b/app/Livewire/Forms/UserForm.php
@@ -2,7 +2,9 @@
 
 namespace App\Livewire\Forms;
 
+use App\Enums\UserRole;
 use App\Models\User;
+use App\Services\CurrentOrganization;
 use Livewire\Attributes\Validate;
 use Livewire\Form;
 
@@ -16,15 +18,22 @@ class UserForm extends Form
     #[Validate('required|string|email|max:255')]
     public string $email = '';
 
+    /** Per-org role (for the current org context) */
     #[Validate('required|in:viewer,member,admin')]
-    public string $role = User::ROLE_MEMBER;
+    public string $role = UserRole::Member->value;
+
+    /** Super admin flag (only super admins can set this) */
+    public bool $superAdmin = false;
 
     public function setUser(User $user): void
     {
         $this->user = $user;
         $this->name = $user->name;
         $this->email = $user->email;
-        $this->role = $user->role;
+        $this->superAdmin = $user->super_admin;
+
+        $currentOrg = app(CurrentOrganization::class);
+        $this->role = ($user->roleIn($currentOrg->model()) ?? UserRole::Member)->value;
     }
 
     public function store(): User
@@ -32,15 +41,18 @@ class UserForm extends Form
         $this->validate([
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users,email',
-            'role' => 'required|in:viewer,member,admin',
+            'role' => 'required|'.UserRole::validationRule(),
         ]);
 
         $user = User::create([
             'name' => $this->name,
             'email' => $this->email,
-            'role' => $this->role,
             'password' => null,
+            'super_admin' => auth()->user()->isSuperAdmin() ? $this->superAdmin : false,
         ]);
+
+        $currentOrg = app(CurrentOrganization::class);
+        $user->organizations()->attach($currentOrg->id(), ['role' => $this->role]);
 
         $user->generateInvitationToken();
 
@@ -49,25 +61,34 @@ class UserForm extends Form
 
     public function update(): bool
     {
+        $isOAuthUser = $this->user->isOAuth();
+
         $this->validate([
             'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:users,email,'.$this->user->id,
-            'role' => 'required|in:viewer,member,admin',
+            'email' => $isOAuthUser ? '' : 'required|string|email|max:255|unique:users,email,'.$this->user->id,
+            'role' => 'required|'.UserRole::validationRule(),
         ]);
 
-        // Check if trying to change role from admin and this is the last admin
-        if ($this->user->isAdmin() && $this->role !== User::ROLE_ADMIN) {
-            $adminCount = User::where('role', User::ROLE_ADMIN)->count();
-            if ($adminCount === 1) {
-                return false;
+        $data = $isOAuthUser
+            ? ['name' => $this->name]
+            : ['name' => $this->name, 'email' => $this->email];
+
+        // Super admin flag — only super admins can change it
+        if (auth()->user()->isSuperAdmin()) {
+            // Cannot remove the last super admin
+            if ($this->user->isSuperAdmin() && ! $this->superAdmin) {
+                if (User::where('super_admin', true)->count() === 1) {
+                    return false;
+                }
             }
+
+            $this->user->update([...$data, 'super_admin' => $this->superAdmin]);
+        } else {
+            $this->user->update($data);
         }
 
-        $this->user->update([
-            'name' => $this->name,
-            'email' => $this->email,
-            'role' => $this->role,
-        ]);
+        $currentOrg = app(CurrentOrganization::class);
+        $this->user->organizations()->updateExistingPivot($currentOrg->id(), ['role' => $this->role]);
 
         return true;
     }
@@ -77,10 +98,16 @@ class UserForm extends Form
      */
     public function roleOptions(): array
     {
-        return [
-            ['id' => User::ROLE_VIEWER, 'name' => __('Viewer'), 'description' => __('Read-only access to all resources'), 'icon' => User::roleIcon(User::ROLE_VIEWER)],
-            ['id' => User::ROLE_MEMBER, 'name' => __('Member'), 'description' => __('Full access except user management'), 'icon' => User::roleIcon(User::ROLE_MEMBER)],
-            ['id' => User::ROLE_ADMIN, 'name' => __('Admin'), 'description' => __('Full access including user management'), 'icon' => User::roleIcon(User::ROLE_ADMIN)],
-        ];
+        return array_map(fn (UserRole $role) => [
+            'id' => $role->value,
+            'name' => $role->label(),
+            'description' => match ($role) {
+                UserRole::Viewer => __('Read-only access to all resources'),
+                UserRole::Member => __('Full access except user management'),
+                UserRole::Admin => __('Full access including user management'),
+                default => '',
+            },
+            'icon' => $role->icon(),
+        ], UserRole::assignable());
     }
 }

--- a/app/Livewire/Forms/VolumeForm.php
+++ b/app/Livewire/Forms/VolumeForm.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Forms;
 
 use App\Enums\VolumeType;
 use App\Models\Volume;
+use App\Services\CurrentOrganization;
 use App\Services\VolumeConnectionTester;
 use Illuminate\Validation\ValidationException;
 use Livewire\Component;
@@ -95,11 +96,15 @@ class VolumeForm extends Form
 
         $this->validate($rules);
 
-        Volume::create([
+        $data = [
             'name' => $this->name,
             'type' => $this->type,
             'config' => $this->buildConfig(),
-        ]);
+        ];
+
+        $data['organization_id'] = app(CurrentOrganization::class)->id();
+
+        Volume::create($data);
     }
 
     public function update(): void

--- a/app/Livewire/OrganizationSwitcher.php
+++ b/app/Livewire/OrganizationSwitcher.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Organization;
+use App\Services\CurrentOrganization;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+
+class OrganizationSwitcher extends Component
+{
+    public string $currentOrgId = '';
+
+    public function mount(): void
+    {
+        $this->currentOrgId = app(CurrentOrganization::class)->id();
+    }
+
+    public function switchOrg(string $orgId): void
+    {
+        $org = Organization::findOrFail($orgId);
+
+        $user = auth()->user();
+        if (! $user->isSuperAdmin() && ! $user->belongsToOrganization($org)) {
+            return;
+        }
+
+        $currentOrg = app(CurrentOrganization::class);
+        $currentOrg->switchTo($org);
+
+        $this->redirect(route('dashboard'), navigate: true);
+    }
+
+    /**
+     * @return array<int, array{id: string, name: string}>
+     */
+    public function getOrganizations(): array
+    {
+        $user = auth()->user();
+
+        if ($user->isSuperAdmin()) {
+            return Organization::orderByDesc('is_main')->orderBy('name')->get(['id', 'name'])->toArray();
+        }
+
+        return $user->organizations()->orderByDesc('organizations.is_main')->orderBy('organizations.name')->get(['organizations.id', 'organizations.name'])->toArray();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.organization-switcher', [
+            'organizations' => $this->getOrganizations(),
+        ]);
+    }
+}

--- a/app/Livewire/Settings/DeleteUserForm.php
+++ b/app/Livewire/Settings/DeleteUserForm.php
@@ -3,35 +3,35 @@
 namespace App\Livewire\Settings;
 
 use App\Livewire\Actions\Logout;
-use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
-use Livewire\Attributes\Validate;
 use Livewire\Component;
 
 class DeleteUserForm extends Component
 {
-    use Toast;
-
-    #[Validate('required|string|current_password')]
     public string $password = '';
 
     public bool $showDeleteModal = false;
 
     public function deleteUser(Logout $logout): void
     {
-        $this->validate();
+        if (! Auth::user()->isOAuth()) {
+            $this->validate([
+                'password' => ['required', 'string', 'current_password'],
+            ]);
+        }
 
         tap(Auth::user(), $logout(...))->delete();
 
-        $this->success(
-            title: __('Your account has been deleted.'),
-            redirectTo: '/'
-        );
+        session()->flash('status', __('Your account has been deleted.'));
+
+        $this->redirect(route('login'), navigate: false);
     }
 
     public function render(): View
     {
-        return view('livewire.settings.delete-user-form');
+        return view('livewire.settings.delete-user-form', [
+            'isOAuthUser' => Auth::user()->isOAuth(),
+        ]);
     }
 }

--- a/app/Livewire/Settings/Password.php
+++ b/app/Livewire/Settings/Password.php
@@ -24,7 +24,7 @@ class Password extends Component
     public function mount(): void
     {
         // OAuth-only users don't have a password to change
-        if (Auth::user()->isOAuthOnly()) {
+        if (Auth::user()->isOAuth()) {
             abort(403, __('Password settings are not available for OAuth users.'));
         }
     }

--- a/app/Livewire/Settings/Profile.php
+++ b/app/Livewire/Settings/Profile.php
@@ -28,18 +28,24 @@ class Profile extends Component
     public function updateProfileInformation(): void
     {
         $user = Auth::user();
+        $isOAuth = $user->isOAuth();
 
-        $validated = $this->validate([
+        $rules = [
             'name' => ['required', 'string', 'max:255'],
-            'email' => [
+        ];
+
+        if (! $isOAuth) {
+            $rules['email'] = [
                 'required',
                 'string',
                 'lowercase',
                 'email',
                 'max:255',
                 Rule::unique(User::class)->ignore($user->id),
-            ],
-        ]);
+            ];
+        }
+
+        $validated = $this->validate($rules);
 
         $user->fill($validated);
 
@@ -50,6 +56,8 @@ class Profile extends Component
 
     public function render(): View
     {
-        return view('livewire.settings.profile');
+        return view('livewire.settings.profile', [
+            'isOAuthUser' => Auth::user()->isOAuth(),
+        ]);
     }
 }

--- a/app/Livewire/Settings/TwoFactor.php
+++ b/app/Livewire/Settings/TwoFactor.php
@@ -44,7 +44,7 @@ class TwoFactor extends Component
         abort_unless(Features::enabled(Features::twoFactorAuthentication()), Response::HTTP_FORBIDDEN);
 
         // OAuth-only users don't have a password to use 2FA
-        if (Auth::user()->isOAuthOnly()) {
+        if (Auth::user()->isOAuth()) {
             abort(403, __('Two-factor settings are not available for OAuth users.'));
         }
 

--- a/app/Livewire/User/Create.php
+++ b/app/Livewire/User/Create.php
@@ -2,20 +2,31 @@
 
 namespace App\Livewire\User;
 
+use App\Enums\UserRole;
 use App\Livewire\Forms\UserForm;
+use App\Models\Organization;
+use App\Models\Scopes\OrganizationScope;
 use App\Models\User;
+use App\Services\CurrentOrganization;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Computed;
 use Livewire\Attributes\Title;
 use Livewire\Component;
 
-#[Title('Create User')]
+#[Title('Add User')]
 class Create extends Component
 {
     use AuthorizesRequests, Toast;
 
     public UserForm $form;
+
+    public string $mode = 'invite';
+
+    public string $existingUserId = '';
+
+    public string $existingUserRole = UserRole::Member->value;
 
     public bool $showCopyModal = false;
 
@@ -36,6 +47,31 @@ class Create extends Component
         $this->showCopyModal = true;
     }
 
+    public function addExisting(CurrentOrganization $currentOrg): void
+    {
+        $this->authorize('manageOrgMembership', User::class);
+
+        $this->validate([
+            'existingUserId' => 'required|exists:users,id',
+            'existingUserRole' => 'required|'.UserRole::validationRule(),
+        ]);
+
+        $user = User::findOrFail($this->existingUserId);
+
+        if ($user->belongsToOrganization($currentOrg->model())) {
+            $this->addError('existingUserId', __('This user is already a member of this organization.'));
+
+            return;
+        }
+
+        $user->organizations()->attach($currentOrg->id(), ['role' => $this->existingUserRole]);
+
+        $this->success(
+            title: __('User added to organization.'),
+            redirectTo: route('users.index')
+        );
+    }
+
     public function closeAndRedirect(): void
     {
         $this->success(
@@ -44,10 +80,35 @@ class Create extends Component
         );
     }
 
+    /**
+     * @return array<int, array{id: string|int, name: string}>
+     */
+    #[Computed]
+    public function availableUsers(): array
+    {
+        $currentOrg = app(CurrentOrganization::class);
+
+        return User::withoutGlobalScope(OrganizationScope::class)
+            ->whereDoesntHave('organizations', function ($query) use ($currentOrg) {
+                $query->where('organizations.id', $currentOrg->id());
+            })
+            ->orderBy('name')
+            ->get()
+            ->map(fn (User $user) => ['id' => $user->id, 'name' => "{$user->name} ({$user->email})"])
+            ->all();
+    }
+
+    #[Computed]
+    public function hasMultipleOrganizations(): bool
+    {
+        return Organization::count() > 1;
+    }
+
     public function render(): View
     {
         return view('livewire.user.create', [
             'roleOptions' => $this->form->roleOptions(),
+            'availableUsers' => $this->availableUsers(),
         ]);
     }
 }

--- a/app/Livewire/User/Edit.php
+++ b/app/Livewire/User/Edit.php
@@ -29,7 +29,7 @@ class Edit extends Component
         $this->authorize('update', $this->form->user);
 
         if (! $this->form->update()) {
-            $this->error(__('Cannot change role. At least one administrator is required.'));
+            $this->error(__('Cannot change role. At least one super administrator is required.'));
 
             return;
         }
@@ -44,6 +44,8 @@ class Edit extends Component
     {
         return view('livewire.user.edit', [
             'roleOptions' => $this->form->roleOptions(),
+            'isSuperAdmin' => auth()->user()->isSuperAdmin(),
+            'isOAuthUser' => $this->form->user->isOAuth(),
         ]);
     }
 }

--- a/app/Livewire/User/Index.php
+++ b/app/Livewire/User/Index.php
@@ -36,10 +36,14 @@ class Index extends Component
 
     public bool $showDeleteModal = false;
 
+    public string $deleteBlockReason = '';
+
     #[Locked]
     public ?int $removeId = null;
 
     public bool $showRemoveModal = false;
+
+    public string $removeBlockReason = '';
 
     public bool $showCopyModal = false;
 
@@ -125,6 +129,7 @@ class Index extends Component
         $this->authorize('delete', $user);
 
         $this->deleteId = $id;
+        $this->deleteBlockReason = $this->getDeleteBlockReason($user);
         $this->showDeleteModal = true;
     }
 
@@ -137,6 +142,10 @@ class Index extends Component
         $user = User::findOrFail($this->deleteId);
 
         $this->authorize('delete', $user);
+
+        if ($this->getDeleteBlockReason($user) !== '') {
+            return;
+        }
 
         $user->delete();
         $this->deleteId = null;
@@ -152,6 +161,7 @@ class Index extends Component
         $this->authorize('removeFromOrganization', $user);
 
         $this->removeId = $id;
+        $this->removeBlockReason = $this->getRemoveBlockReason($user);
         $this->showRemoveModal = true;
     }
 
@@ -165,6 +175,10 @@ class Index extends Component
 
         $this->authorize('removeFromOrganization', $user);
 
+        if ($this->getRemoveBlockReason($user) !== '') {
+            return;
+        }
+
         $currentOrg = app(CurrentOrganization::class);
         $user->organizations()->detach($currentOrg->id());
 
@@ -172,6 +186,28 @@ class Index extends Component
         $this->showRemoveModal = false;
 
         $this->success(__('User removed from organization.'));
+    }
+
+    private function getDeleteBlockReason(User $user): string
+    {
+        if ($user->isSuperAdmin() && User::where('super_admin', true)->count() === 1) {
+            return __('This is the only super admin account. It cannot be deleted.');
+        }
+
+        if (! auth()->user()->isSuperAdmin() && $user->organizations()->count() > 1) {
+            return __('This user belongs to multiple organizations. Remove them from this organization instead.');
+        }
+
+        return '';
+    }
+
+    private function getRemoveBlockReason(User $user): string
+    {
+        if ($user->organizations()->count() <= 1) {
+            return __('This user only belongs to this organization. Removing them would leave them without access.');
+        }
+
+        return '';
     }
 
     public function render(): View

--- a/app/Livewire/User/Index.php
+++ b/app/Livewire/User/Index.php
@@ -2,7 +2,9 @@
 
 namespace App\Livewire\User;
 
+use App\Enums\UserRole;
 use App\Models\User;
+use App\Services\CurrentOrganization;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -34,9 +36,19 @@ class Index extends Component
 
     public bool $showDeleteModal = false;
 
+    #[Locked]
+    public ?int $removeId = null;
+
+    public bool $showRemoveModal = false;
+
     public bool $showCopyModal = false;
 
     public string $invitationUrl = '';
+
+    public function mount(): void
+    {
+        $this->authorize('viewAny', User::class);
+    }
 
     public function updatingSearch(): void
     {
@@ -79,11 +91,10 @@ class Index extends Component
      */
     public function roleFilterOptions(): array
     {
-        return [
-            ['id' => User::ROLE_ADMIN, 'name' => __('Admin')],
-            ['id' => User::ROLE_MEMBER, 'name' => __('Member')],
-            ['id' => User::ROLE_VIEWER, 'name' => __('Viewer')],
-        ];
+        return array_map(fn (UserRole $role) => [
+            'id' => $role->value,
+            'name' => $role->label(),
+        ], UserRole::assignable());
     }
 
     /**
@@ -134,17 +145,53 @@ class Index extends Component
         $this->success(__('User deleted successfully.'));
     }
 
+    public function confirmRemoveFromOrg(int $id): void
+    {
+        $user = User::findOrFail($id);
+
+        $this->authorize('removeFromOrganization', $user);
+
+        $this->removeId = $id;
+        $this->showRemoveModal = true;
+    }
+
+    public function removeFromOrg(): void
+    {
+        if (! $this->removeId) {
+            return;
+        }
+
+        $user = User::findOrFail($this->removeId);
+
+        $this->authorize('removeFromOrganization', $user);
+
+        $currentOrg = app(CurrentOrganization::class);
+        $user->organizations()->detach($currentOrg->id());
+
+        $this->removeId = null;
+        $this->showRemoveModal = false;
+
+        $this->success(__('User removed from organization.'));
+    }
+
     public function render(): View
     {
-        $users = User::query()
+        $currentOrg = app(CurrentOrganization::class);
+
+        $query = User::query();
+
+        $query->whereRelation('organizations', 'organization_id', $currentOrg->id());
+
+        $users = $query
+            ->with('organizations')
             ->when($this->search, function ($query) {
                 $query->where(function ($q) {
                     $q->where('name', 'like', '%'.$this->search.'%')
                         ->orWhere('email', 'like', '%'.$this->search.'%');
                 });
             })
-            ->when($this->roleFilter !== '', function ($query) {
-                $query->where('role', $this->roleFilter);
+            ->when($this->roleFilter !== '', function ($query) use ($currentOrg) {
+                $query->whereHas('organizations', fn ($q) => $q->whereRaw('organization_id = ? and role = ?', [$currentOrg->id(), $this->roleFilter]));
             })
             ->when($this->statusFilter !== '', function ($query) {
                 if ($this->statusFilter === 'active') {
@@ -161,6 +208,7 @@ class Index extends Component
             'headers' => $this->headers(),
             'roleFilterOptions' => $this->roleFilterOptions(),
             'statusFilterOptions' => $this->statusFilterOptions(),
+            'canManageOrgMembership' => auth()->user()->can('manageOrgMembership', User::class),
         ]);
     }
 }

--- a/app/Mcp/Servers/DatabasementServer.php
+++ b/app/Mcp/Servers/DatabasementServer.php
@@ -4,6 +4,7 @@ namespace App\Mcp\Servers;
 
 use App\Mcp\Tools\GetJobStatusTool;
 use App\Mcp\Tools\ListDatabaseServersTool;
+use App\Mcp\Tools\ListOrganizationsTool;
 use App\Mcp\Tools\ListSnapshotsTool;
 use App\Mcp\Tools\TriggerBackupTool;
 use App\Mcp\Tools\TriggerRestoreTool;
@@ -14,13 +15,14 @@ use Laravel\Mcp\Server\Attributes\Version;
 
 #[Name('Databasement')]
 #[Version('1.0.0')]
-#[Instructions('Databasement manages database server backups. Use the provided tools to list database servers and their snapshots, trigger backups, restore snapshots to a target server, and check job status. Backup and restore operations are asynchronous — use get-job-status to poll for completion.')]
+#[Instructions('Databasement manages database server backups. Use the provided tools to list database servers and their snapshots, trigger backups, restore snapshots to a target server, and check job status. Backup and restore operations are asynchronous — use get-job-status to poll for completion. All data is scoped to the current organization. Use list-organizations to discover your organizations, then pass org_id as a query parameter on the MCP endpoint URL or set the X-Organization-Id header to switch context. If omitted, Main organization is used.')]
 class DatabasementServer extends Server
 {
     /**
      * @var array<int, class-string<\Laravel\Mcp\Server\Tool>>
      */
     protected array $tools = [
+        ListOrganizationsTool::class,
         ListDatabaseServersTool::class,
         ListSnapshotsTool::class,
         TriggerBackupTool::class,

--- a/app/Mcp/Tools/ListOrganizationsTool.php
+++ b/app/Mcp/Tools/ListOrganizationsTool.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Mcp\Tools;
+
+use App\Models\User;
+use App\Services\CurrentOrganization;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+#[Description('List the organizations you belong to and which one is currently active. Use the returned ID as the org_id query parameter or X-Organization-Id header to switch organization context. If omitted, the main organization is used by default.')]
+#[IsReadOnly]
+class ListOrganizationsTool extends Tool
+{
+    public function handle(Request $request): Response
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $currentOrgId = app(CurrentOrganization::class)->id();
+
+        $orgs = $user->organizations()->orderByPivot('created_at')->get();
+
+        if ($orgs->isEmpty()) {
+            return Response::text('You are not a member of any organization.');
+        }
+
+        $lines = $orgs->map(function ($org) use ($currentOrgId) {
+            $active = $org->id === $currentOrgId ? ' **(active)**' : '';
+            $role = $org->pivot->role ?? 'unknown';
+
+            return "- **{$org->name}** (ID: {$org->id}){$active}\n  Role: {$role}".($org->is_main ? ' | Main organization' : '');
+        });
+
+        return Response::text("Your Organizations ({$orgs->count()}):\n\n".implode("\n\n", $lines->all()));
+    }
+}

--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Scopes\OrganizationScope;
 use Database\Factories\AgentFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Laravel\Sanctum\HasApiTokens;
@@ -40,9 +42,15 @@ class Agent extends Model
     /** @use HasFactory<AgentFactory> */
     use HasApiTokens, HasFactory, HasUlids;
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new OrganizationScope);
+    }
+
     protected $fillable = [
         'name',
         'last_heartbeat_at',
+        'organization_id',
     ];
 
     protected function casts(): array
@@ -50,6 +58,14 @@ class Agent extends Model
         return [
             'last_heartbeat_at' => 'datetime',
         ];
+    }
+
+    /**
+     * @return BelongsTo<Organization, Agent>
+     */
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
     }
 
     /**

--- a/app/Models/BackupJob.php
+++ b/app/Models/BackupJob.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Contracts\BackupLogger;
+use App\Models\Scopes\OrganizationScope;
+use App\Services\CurrentOrganization;
 use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
@@ -65,6 +67,28 @@ class BackupJob extends Model implements BackupLogger
             'duration_ms' => 'integer',
             'logs' => 'array',
         ];
+    }
+
+    /**
+     * Scope to filter backup jobs by the current organization.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForCurrentOrg(Builder $query): Builder
+    {
+        $orgId = app(CurrentOrganization::class)->id();
+
+        return $query->where(function (Builder $q) use ($orgId) {
+            $q->whereHas('snapshot.databaseServer', function (Builder $sq) use ($orgId) {
+                $sq->withoutGlobalScope(OrganizationScope::class)
+                    ->whereRaw('organization_id = ?', [$orgId]);
+            })
+                ->orWhereHas('restore.targetServer', function (Builder $sq) use ($orgId) {
+                    $sq->withoutGlobalScope(OrganizationScope::class)
+                        ->whereRaw('organization_id = ?', [$orgId]);
+                });
+        });
     }
 
     /**

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -6,6 +6,7 @@ use App\Enums\DatabaseType;
 use App\Enums\NotificationChannelSelection;
 use App\Enums\NotificationTrigger;
 use App\Exceptions\Backup\EncryptionException;
+use App\Models\Scopes\OrganizationScope;
 use Database\Factories\DatabaseServerFactory;
 use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Database\Eloquent\Builder;
@@ -90,6 +91,8 @@ class DatabaseServer extends Model
 
     protected static function booted(): void
     {
+        static::addGlobalScope(new OrganizationScope);
+
         // Delete snapshots through Eloquent to trigger their deleting events
         // (which clean up associated BackupJobs, Restores, and backup files)
         static::deleting(function (DatabaseServer $server) {
@@ -121,6 +124,7 @@ class DatabaseServer extends Model
         'managed_by',
         'notification_trigger',
         'notification_channel_selection',
+        'organization_id',
     ];
 
     protected $hidden = [
@@ -138,6 +142,14 @@ class DatabaseServer extends Model
             'notification_trigger' => NotificationTrigger::class,
             'notification_channel_selection' => NotificationChannelSelection::class,
         ];
+    }
+
+    /**
+     * @return BelongsTo<Organization, DatabaseServer>
+     */
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
     }
 
     /**

--- a/app/Models/DatabaseServerSshConfig.php
+++ b/app/Models/DatabaseServerSshConfig.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use App\Models\Scopes\OrganizationScope;
 use Database\Factories\DatabaseServerSshConfigFactory;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
@@ -35,6 +37,11 @@ class DatabaseServerSshConfig extends Model
     /** @var array<string> Sensitive fields that contain encrypted data */
     public const SENSITIVE_FIELDS = ['password', 'private_key', 'key_passphrase'];
 
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new OrganizationScope);
+    }
+
     protected $fillable = [
         'host',
         'port',
@@ -43,6 +50,7 @@ class DatabaseServerSshConfig extends Model
         'password',
         'private_key',
         'key_passphrase',
+        'organization_id',
     ];
 
     protected $hidden = [
@@ -59,6 +67,14 @@ class DatabaseServerSshConfig extends Model
             'private_key' => 'encrypted',
             'key_passphrase' => 'encrypted',
         ];
+    }
+
+    /**
+     * @return BelongsTo<Organization, DatabaseServerSshConfig>
+     */
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
     }
 
     /**

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\Scopes\OrganizationScope;
+use Database\Factories\OrganizationFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $name
+ * @property bool $is_main
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Collection<int, User> $users
+ * @property-read int|null $users_count
+ * @property-read Collection<int, DatabaseServer> $databaseServers
+ * @property-read int|null $database_servers_count
+ * @property-read Collection<int, Volume> $volumes
+ * @property-read int|null $volumes_count
+ * @property-read Collection<int, Agent> $agents
+ * @property-read int|null $agents_count
+ *
+ * @method static OrganizationFactory factory($count = null, $state = [])
+ * @method static Builder<static>|Organization newModelQuery()
+ * @method static Builder<static>|Organization newQuery()
+ * @method static Builder<static>|Organization query()
+ *
+ * @mixin \Eloquent
+ */
+class Organization extends Model
+{
+    /** @use HasFactory<OrganizationFactory> */
+    use HasFactory;
+
+    use HasUlids;
+
+    protected $fillable = [
+        'name',
+        'is_main',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'is_main' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsToMany<User, Organization>
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withPivot('role')->withTimestamps();
+    }
+
+    /**
+     * @return HasMany<DatabaseServer, Organization>
+     */
+    public function databaseServers(): HasMany
+    {
+        return $this->hasMany(DatabaseServer::class);
+    }
+
+    /**
+     * @return HasMany<Volume, Organization>
+     */
+    public function volumes(): HasMany
+    {
+        return $this->hasMany(Volume::class);
+    }
+
+    /**
+     * @return HasMany<Agent, Organization>
+     */
+    public function agents(): HasMany
+    {
+        return $this->hasMany(Agent::class);
+    }
+
+    /**
+     * @return HasMany<DatabaseServerSshConfig, Organization>
+     */
+    public function sshConfigs(): HasMany
+    {
+        return $this->hasMany(DatabaseServerSshConfig::class);
+    }
+
+    /**
+     * Get the main organization.
+     */
+    public static function main(): self
+    {
+        return static::where('is_main', true)->firstOrFail();
+    }
+
+    /**
+     * Check if the organization has any resources (servers, volumes, agents).
+     */
+    public function hasResources(): bool
+    {
+        return $this->databaseServers()->withoutGlobalScope(OrganizationScope::class)->exists()
+            || $this->volumes()->withoutGlobalScope(OrganizationScope::class)->exists()
+            || $this->agents()->withoutGlobalScope(OrganizationScope::class)->exists();
+    }
+}

--- a/app/Models/Scopes/OrganizationScope.php
+++ b/app/Models/Scopes/OrganizationScope.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Scopes;
+
+use App\Services\CurrentOrganization;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+/** @implements Scope<Model> */
+class OrganizationScope implements Scope
+{
+    /**
+     * Apply the scope to a given Eloquent query builder.
+     *
+     * In CLI context (artisan commands) no org is resolved, so the scope is
+     * not applied — commands process all orgs.
+     */
+    public function apply(Builder $builder, Model $model): void
+    {
+        $currentOrg = app(CurrentOrganization::class);
+
+        if ($currentOrg->isResolved()) {
+            $builder->where($model->getTable().'.organization_id', $currentOrg->id());
+        }
+    }
+}

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -4,7 +4,9 @@ namespace App\Models;
 
 use App\Enums\CompressionType;
 use App\Enums\DatabaseType;
+use App\Models\Scopes\OrganizationScope;
 use App\Services\Backup\Filesystems\FilesystemProvider;
+use App\Services\CurrentOrganization;
 use App\Support\Formatters;
 use Database\Factories\SnapshotFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -188,6 +190,22 @@ class Snapshot extends Model
 
             // Delete the snapshot's own job
             $snapshot->job->delete();
+        });
+    }
+
+    /**
+     * Scope to filter snapshots by the current organization.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForCurrentOrg(Builder $query): Builder
+    {
+        $orgId = app(CurrentOrganization::class)->id();
+
+        return $query->whereHas('databaseServer', function (Builder $sq) use ($orgId) {
+            $sq->withoutGlobalScope(OrganizationScope::class)
+                ->whereRaw('organization_id = ?', [$orgId]);
         });
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,10 +3,12 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\UserRole;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\DatabaseNotification;
@@ -29,7 +31,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @property string|null $two_factor_secret
  * @property string|null $two_factor_recovery_codes
  * @property string|null $two_factor_confirmed_at
- * @property string $role
+ * @property bool $super_admin
  * @property string|null $invitation_token
  * @property Carbon|null $invitation_accepted_at
  * @property-read DatabaseNotificationCollection<int, DatabaseNotification> $notifications
@@ -38,6 +40,8 @@ use Laravel\Sanctum\HasApiTokens;
  * @property-read int|null $triggered_snapshots_count
  * @property-read Collection<int, OAuthIdentity> $oauthIdentities
  * @property-read int|null $oauth_identities_count
+ * @property-read Collection<int, Organization> $organizations
+ * @property-read int|null $organizations_count
  *
  * @method static Builder<static>|User active()
  * @method static UserFactory factory($count = null, $state = [])
@@ -54,7 +58,7 @@ use Laravel\Sanctum\HasApiTokens;
  * @method static Builder<static>|User whereName($value)
  * @method static Builder<static>|User wherePassword($value)
  * @method static Builder<static>|User whereRememberToken($value)
- * @method static Builder<static>|User whereRole($value)
+ * @method static Builder<static>|User whereSuperAdmin($value)
  * @method static Builder<static>|User whereTwoFactorConfirmedAt($value)
  * @method static Builder<static>|User whereTwoFactorRecoveryCodes($value)
  * @method static Builder<static>|User whereTwoFactorSecret($value)
@@ -70,32 +74,6 @@ class User extends Authenticatable
     /** @use HasFactory<UserFactory> */
     use HasApiTokens, HasFactory, Notifiable, TwoFactorAuthenticatable;
 
-    public const ROLE_DEMO = 'demo';
-
-    public const ROLE_VIEWER = 'viewer';
-
-    public const ROLE_MEMBER = 'member';
-
-    public const ROLE_ADMIN = 'admin';
-
-    public const ROLES = [
-        self::ROLE_DEMO,
-        self::ROLE_VIEWER,
-        self::ROLE_MEMBER,
-        self::ROLE_ADMIN,
-    ];
-
-    public static function roleIcon(string $role): string
-    {
-        return match ($role) {
-            self::ROLE_ADMIN => 'o-shield-check',
-            self::ROLE_MEMBER => 'o-pencil-square',
-            self::ROLE_VIEWER => 'o-eye',
-            self::ROLE_DEMO => 'o-beaker',
-            default => 'o-user',
-        };
-    }
-
     /**
      * The attributes that are mass assignable.
      *
@@ -105,7 +83,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'role',
+        'super_admin',
         'invitation_token',
         'invitation_accepted_at',
     ];
@@ -132,9 +110,13 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'super_admin' => 'boolean',
             'invitation_accepted_at' => 'datetime',
         ];
     }
+
+    /** Transient property used by UserFactory to propagate the pivot role. */
+    public ?UserRole $pendingPivotRole = null;
 
     /**
      * Get the user's initials
@@ -164,24 +146,79 @@ class User extends Authenticatable
         return $this->hasMany(OAuthIdentity::class);
     }
 
-    public function isDemo(): bool
+    /**
+     * @return BelongsToMany<Organization, User>
+     */
+    public function organizations(): BelongsToMany
     {
-        return $this->role === self::ROLE_DEMO;
+        return $this->belongsToMany(Organization::class)->withPivot('role')->withTimestamps();
     }
 
-    public function isViewer(): bool
+    public function isSuperAdmin(): bool
     {
-        return $this->role === self::ROLE_VIEWER;
+        return $this->super_admin;
     }
 
-    public function isMember(): bool
+    /** @var array<string, UserRole|null> */
+    private array $cachedRoles = [];
+
+    /**
+     * @return $this
+     */
+    public function refresh(): static
     {
-        return $this->role === self::ROLE_MEMBER;
+        $this->cachedRoles = [];
+
+        return parent::refresh();
+    }
+
+    /**
+     * Get the user's role in a specific organization.
+     */
+    public function roleIn(Organization $organization): ?UserRole
+    {
+        if (! isset($this->cachedRoles[$organization->id])) {
+            if ($this->relationLoaded('organizations')) {
+                $match = $this->organizations->firstWhere('id', $organization->id);
+                $pivotRole = $match?->pivot?->role; // @phpstan-ignore property.notFound
+            } else {
+                $pivot = $this->organizations()->wherePivot('organization_id', $organization->id)->first();
+                $pivotRole = $pivot?->pivot?->role; // @phpstan-ignore property.notFound
+            }
+            $this->cachedRoles[$organization->id] = $pivotRole ? UserRole::tryFrom($pivotRole) : null;
+        }
+
+        return $this->cachedRoles[$organization->id];
+    }
+
+    /**
+     * Check if user belongs to a given organization.
+     */
+    public function belongsToOrganization(Organization $organization): bool
+    {
+        return $this->organizations()->wherePivot('organization_id', $organization->id)->exists();
+    }
+
+    /**
+     * Get the user's role in the current org context.
+     */
+    private function currentOrgRole(): ?UserRole
+    {
+        return $this->roleIn(app(\App\Services\CurrentOrganization::class)->model());
     }
 
     public function isAdmin(): bool
     {
-        return $this->role === self::ROLE_ADMIN;
+        return $this->isSuperAdmin() || $this->currentOrgRole() === UserRole::Admin;
+    }
+
+    public function canPerformActions(): bool
+    {
+        if ($this->isSuperAdmin()) {
+            return true;
+        }
+
+        return in_array($this->currentOrgRole(), [UserRole::Admin, UserRole::Member]);
     }
 
     public function canManageUsers(): bool
@@ -189,9 +226,9 @@ class User extends Authenticatable
         return $this->isAdmin();
     }
 
-    public function canPerformActions(): bool
+    public function isDemo(): bool
     {
-        return ! $this->isViewer() && ! $this->isDemo();
+        return $this->currentOrgRole() === UserRole::Demo;
     }
 
     public function isPending(): bool
@@ -205,11 +242,11 @@ class User extends Authenticatable
     }
 
     /**
-     * Check if user authenticated only via OAuth (no password set).
+     * Check if user authenticated via OAuth.
      */
-    public function isOAuthOnly(): bool
+    public function isOAuth(): bool
     {
-        return $this->password === null;
+        return $this->oauthIdentities()->exists();
     }
 
     public function generateInvitationToken(): string

--- a/app/Models/Volume.php
+++ b/app/Models/Volume.php
@@ -3,12 +3,14 @@
 namespace App\Models;
 
 use App\Enums\VolumeType;
+use App\Models\Scopes\OrganizationScope;
 use Database\Factories\VolumeFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Crypt;
@@ -49,6 +51,8 @@ class Volume extends Model
 
     protected static function booted(): void
     {
+        static::addGlobalScope(new OrganizationScope);
+
         // Delete snapshots through Eloquent to trigger their deleting events
         // (which clean up associated BackupJobs, Restores, and backup files)
         // Type is immutable after creation — changing it would leave ghost config fields.
@@ -70,6 +74,7 @@ class Volume extends Model
         'name',
         'type',
         'config',
+        'organization_id',
     ];
 
     protected function casts(): array
@@ -77,6 +82,14 @@ class Volume extends Model
         return [
             'config' => 'array',
         ];
+    }
+
+    /**
+     * @return BelongsTo<Organization, Volume>
+     */
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
     }
 
     /**

--- a/app/Policies/OrganizationPolicy.php
+++ b/app/Policies/OrganizationPolicy.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Organization;
+use App\Models\User;
+
+class OrganizationPolicy
+{
+    /**
+     * Determine whether the user can view any organizations.
+     * Only super admins can view the organizations management page.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    /**
+     * Determine whether the user can create organizations.
+     */
+    public function create(User $user): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    /**
+     * Determine whether the user can update the organization.
+     * Super admins can rename non-main orgs.
+     */
+    public function update(User $user, Organization $organization): bool
+    {
+        if (! $user->isSuperAdmin()) {
+            return false;
+        }
+
+        // Main org name cannot be changed
+        return ! $organization->is_main;
+    }
+
+    /**
+     * Determine whether the user can delete the organization.
+     * Only super admins can delete non-main, empty orgs.
+     */
+    public function delete(User $user, Organization $organization): bool
+    {
+        if (! $user->isSuperAdmin()) {
+            return false;
+        }
+
+        // Main org cannot be deleted
+        if ($organization->is_main) {
+            return false;
+        }
+
+        // Org must be empty (no resources)
+        return ! $organization->hasResources();
+    }
+}

--- a/app/Policies/OrganizationPolicy.php
+++ b/app/Policies/OrganizationPolicy.php
@@ -40,7 +40,7 @@ class OrganizationPolicy
 
     /**
      * Determine whether the user can delete the organization.
-     * Only super admins can delete non-main, empty orgs.
+     * Only super admins can delete non-main orgs.
      */
     public function delete(User $user, Organization $organization): bool
     {
@@ -48,12 +48,6 @@ class OrganizationPolicy
             return false;
         }
 
-        // Main org cannot be deleted
-        if ($organization->is_main) {
-            return false;
-        }
-
-        // Org must be empty (no resources)
-        return ! $organization->hasResources();
+        return ! $organization->is_main;
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -57,8 +57,9 @@ class UserPolicy
 
     /**
      * Determine whether the user can delete the model.
-     * Super admins can always delete (except self/last SA).
-     * Org admins can delete users who belong to only one organization.
+     * Super admins can delete any user (except self).
+     * Org admins can delete non-SA users in their org.
+     * Business rules (last SA, multi-org) are checked at action time.
      */
     public function delete(User $user, User $model): bool
     {
@@ -67,10 +68,6 @@ class UserPolicy
         }
 
         if ($user->isSuperAdmin()) {
-            if ($model->isSuperAdmin() && User::where('super_admin', true)->count() === 1) {
-                return false;
-            }
-
             return true;
         }
 
@@ -78,21 +75,16 @@ class UserPolicy
 
         return $currentOrg->isOrgAdmin()
             && ! $model->isSuperAdmin()
-            && $model->belongsToOrganization($currentOrg->model())
-            && $model->organizations()->count() === 1;
+            && $model->belongsToOrganization($currentOrg->model());
     }
 
     /**
      * Determine whether the user can remove the model from the current organization.
-     * Only available when the target belongs to more than one organization.
+     * Business rules (single-org check) are checked at action time.
      */
     public function removeFromOrganization(User $user, User $model): bool
     {
         if ($user->id === $model->id) {
-            return false;
-        }
-
-        if ($model->organizations()->count() <= 1) {
             return false;
         }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -3,16 +3,17 @@
 namespace App\Policies;
 
 use App\Models\User;
+use App\Services\CurrentOrganization;
 
 class UserPolicy
 {
     /**
      * Determine whether the user can view any models.
-     * All authenticated users can view the user list.
+     * Only super admins and org admins can access the user list.
      */
     public function viewAny(User $user): bool
     {
-        return true;
+        return $user->isAdmin();
     }
 
     /**
@@ -26,52 +27,119 @@ class UserPolicy
 
     /**
      * Determine whether the user can create models.
-     * Only admins can create users.
+     * Super admins and org admins can create new users.
      */
     public function create(User $user): bool
     {
-        return $user->isAdmin();
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        return app(CurrentOrganization::class)->isOrgAdmin();
     }
 
     /**
      * Determine whether the user can update the model.
-     * Only admins can update users.
+     * Super admins can update any user. Org admins can update users in their org.
      */
     public function update(User $user, User $model): bool
     {
-        return $user->isAdmin();
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        $currentOrg = app(CurrentOrganization::class);
+
+        return $currentOrg->isOrgAdmin()
+            && ! $model->isSuperAdmin()
+            && $model->belongsToOrganization($currentOrg->model());
     }
 
     /**
      * Determine whether the user can delete the model.
-     * Only admins can delete users, with restrictions.
+     * Super admins can always delete (except self/last SA).
+     * Org admins can delete users who belong to only one organization.
      */
     public function delete(User $user, User $model): bool
     {
-        // Cannot delete yourself
         if ($user->id === $model->id) {
             return false;
         }
 
-        // Only admins can delete
-        if (! $user->isAdmin()) {
+        if ($user->isSuperAdmin()) {
+            if ($model->isSuperAdmin() && User::where('super_admin', true)->count() === 1) {
+                return false;
+            }
+
+            return true;
+        }
+
+        $currentOrg = app(CurrentOrganization::class);
+
+        return $currentOrg->isOrgAdmin()
+            && ! $model->isSuperAdmin()
+            && $model->belongsToOrganization($currentOrg->model())
+            && $model->organizations()->count() === 1;
+    }
+
+    /**
+     * Determine whether the user can remove the model from the current organization.
+     * Only available when the target belongs to more than one organization.
+     */
+    public function removeFromOrganization(User $user, User $model): bool
+    {
+        if ($user->id === $model->id) {
             return false;
         }
 
-        // Cannot delete the last admin
-        if ($model->isAdmin() && User::where('role', User::ROLE_ADMIN)->count() === 1) {
+        if ($model->organizations()->count() <= 1) {
             return false;
         }
 
-        return true;
+        if (! $user->isSuperAdmin() && $model->isSuperAdmin()) {
+            return false;
+        }
+
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        return app(CurrentOrganization::class)->isOrgAdmin();
     }
 
     /**
      * Determine whether the user can copy the invitation link.
-     * Only admins can copy invitation links for pending users.
+     * Super admins and org admins can copy invitation links for pending users.
      */
     public function copyInvitationLink(User $user, User $model): bool
     {
-        return $user->isAdmin() && $model->invitation_token !== null;
+        if ($model->invitation_token === null) {
+            return false;
+        }
+
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        $currentOrg = app(CurrentOrganization::class);
+
+        return $currentOrg->isOrgAdmin()
+            && ! $model->isSuperAdmin()
+            && $model->belongsToOrganization($currentOrg->model());
+    }
+
+    /**
+     * Determine whether the user can attach/detach users in the current org.
+     * Super admins and org admins can manage org membership.
+     */
+    public function manageOrgMembership(User $user): bool
+    {
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        $currentOrg = app(CurrentOrganization::class);
+
+        return $currentOrg->isOrgAdmin();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,9 +11,13 @@ use App\Services\Backup\Filesystems\FtpFilesystem;
 use App\Services\Backup\Filesystems\LocalFilesystem;
 use App\Services\Backup\Filesystems\SftpFilesystem;
 use App\Services\Backup\ShellProcessor;
+use App\Services\CurrentOrganization;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
+use Dedoc\Scramble\Support\Generator\Parameter;
+use Dedoc\Scramble\Support\Generator\Schema;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
+use Dedoc\Scramble\Support\Generator\Types\StringType;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
@@ -30,6 +34,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->registerOAuthServicesConfig();
 
+        $this->app->singleton(CurrentOrganization::class);
         $this->app->singleton(AppConfigService::class);
         $this->app->singleton(ShellProcessor::class);
         $this->app->singleton(CompressorFactory::class);
@@ -95,6 +100,16 @@ class AppServiceProvider extends ServiceProvider
                 $openApi->secure(
                     SecurityScheme::http('bearer')
                 );
+
+                $orgParam = Parameter::make('org_id', 'query')
+                    ->description('Organization ID. If omitted, the main organization is used.')
+                    ->setSchema(Schema::fromType(new StringType));
+
+                foreach ($openApi->paths as $path) {
+                    foreach ($path->operations as $operation) {
+                        $operation->addParameters([$orgParam]);
+                    }
+                }
             });
     }
 
@@ -144,7 +159,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function performOAuthValidation(): void
     {
-        $validRoles = ['viewer', 'member', 'admin'];
+        $validRoles = array_map(fn (\App\Enums\UserRole $r) => $r->value, \App\Enums\UserRole::assignable());
         $defaultRole = config('oauth.default_role');
 
         if ($defaultRole && ! in_array($defaultRole, $validRoles)) {
@@ -176,9 +191,13 @@ class AppServiceProvider extends ServiceProvider
         // Validate role mapping: strict mode requires at least one mapping (only when OIDC is enabled)
         if (config('oauth.providers.oidc.enabled', false)) {
             $roleMapping = config('oauth.role_mapping', []);
-            $hasMapping = trim((string) ($roleMapping['admin'] ?? '')) !== ''
-                || trim((string) ($roleMapping['member'] ?? '')) !== ''
-                || trim((string) ($roleMapping['viewer'] ?? '')) !== '';
+            $hasMapping = false;
+            foreach (\App\Enums\UserRole::assignable() as $role) {
+                if (trim((string) ($roleMapping[$role->value] ?? '')) !== '') {
+                    $hasMapping = true;
+                    break;
+                }
+            }
 
             if (! empty($roleMapping['strict']) && ! $hasMapping) {
                 throw new \InvalidArgumentException(

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -47,8 +47,8 @@ class FortifyServiceProvider extends ServiceProvider
                 return null;
             }
 
-            // Check if user is OAuth-only (no password set)
-            if ($user->isOAuthOnly()) {
+            // OAuth users must use the OAuth login button
+            if ($user->isOAuth()) {
                 throw ValidationException::withMessages([
                     Fortify::username() => [__('This account uses OAuth login. Please use the OAuth button below to sign in.')],
                 ]);
@@ -87,7 +87,7 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::twoFactorChallengeView(fn () => view('livewire.auth.two-factor-challenge'));
         Fortify::confirmPasswordView(function () {
             // OAuth-only users have no password to confirm
-            if (auth()->user()?->isOAuthOnly()) {
+            if (auth()->user()?->isOAuth()) {
                 abort(403, __('Password confirmation is not available for OAuth users.'));
             }
 

--- a/app/Queries/BackupJobQuery.php
+++ b/app/Queries/BackupJobQuery.php
@@ -24,7 +24,7 @@ class BackupJobQuery
      */
     public static function make(): QueryBuilder
     {
-        return QueryBuilder::for(BackupJob::class)
+        return QueryBuilder::for(BackupJob::query()->forCurrentOrg())
             ->with(self::RELATIONSHIPS)
             ->allowedFilters(
                 AllowedFilter::exact('status'),
@@ -65,7 +65,11 @@ class BackupJobQuery
     ): Builder {
         $query = BackupJob::query()
             ->with(self::RELATIONSHIPS)
-            ->addSelect('backup_jobs.*')
+            ->addSelect('backup_jobs.*');
+
+        $query->forCurrentOrg();
+
+        $query
             ->addSelect([
                 'snapshot_size' => Snapshot::select('file_size')
                     ->whereColumn('backup_job_id', 'backup_jobs.id')

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -57,8 +57,12 @@ class SnapshotQuery
         string $sortColumn = 'started_at',
         string $sortDirection = 'desc'
     ): Builder {
-        return Snapshot::query()
-            ->with(self::RELATIONSHIPS)
+        $query = Snapshot::query()
+            ->with(self::RELATIONSHIPS);
+
+        $query->forCurrentOrg();
+
+        return $query
             ->when($search, function (Builder $query) use ($search) {
                 self::applySearch($query, $search);
             })

--- a/app/Services/Backup/SnapshotVerificationService.php
+++ b/app/Services/Backup/SnapshotVerificationService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Backup;
 
+use App\Models\Scopes\OrganizationScope;
 use App\Models\Snapshot;
 use App\Services\Backup\Filesystems\FilesystemProvider;
 use App\Services\NotificationService;
@@ -19,20 +20,28 @@ class SnapshotVerificationService
     ) {}
 
     /**
-     * Verify all completed snapshots still exist on their storage volumes.
+     * Verify completed snapshots still exist on their storage volumes.
      *
      * @return array{verified: int, missing: int}
      */
-    public function run(): array
+    public function run(?string $organizationId = null): array
     {
         $this->newlyMissing = collect();
         $verified = 0;
 
-        $snapshotIds = Snapshot::query()
+        $query = Snapshot::query()
             ->whereNotNull('filename')
             ->where('filename', '!=', '')
-            ->whereRelation('job', 'status', 'completed')
-            ->pluck('id');
+            ->whereRelation('job', 'status', 'completed');
+
+        if ($organizationId) {
+            $query->whereHas('databaseServer', function ($sq) use ($organizationId) {
+                $sq->withoutGlobalScope(OrganizationScope::class)
+                    ->whereRaw('organization_id = ?', [$organizationId]);
+            });
+        }
+
+        $snapshotIds = $query->pluck('id');
 
         foreach ($snapshotIds as $id) {
             $this->verifySnapshot($id);

--- a/app/Services/CurrentOrganization.php
+++ b/app/Services/CurrentOrganization.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\UserRole;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Support\Facades\Cookie;
+
+class CurrentOrganization
+{
+    public const COOKIE_NAME = 'current_organization_id';
+
+    private ?Organization $organization = null;
+
+    private bool $resolved = false;
+
+    /**
+     * Reset the resolved state so the middleware can re-resolve.
+     */
+    public function reset(): void
+    {
+        $this->organization = null;
+        $this->resolved = false;
+    }
+
+    /**
+     * Whether an organization context is active.
+     */
+    public function isResolved(): bool
+    {
+        return $this->resolved;
+    }
+
+    /**
+     * Get the current organization's ID.
+     */
+    public function id(): string
+    {
+        return $this->organization->id;
+    }
+
+    /**
+     * Get the current organization model.
+     */
+    public function model(): Organization
+    {
+        return $this->organization;
+    }
+
+    /**
+     * Get the current user's role in the current org (null for super_admin without membership).
+     */
+    public function userRole(): ?UserRole
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return null;
+        }
+
+        return $user->roleIn($this->organization);
+    }
+
+    /**
+     * Check if user is an admin of the current org (or super_admin).
+     */
+    public function isOrgAdmin(): bool
+    {
+        $user = auth()->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        return $this->userRole() === UserRole::Admin;
+    }
+
+    /**
+     * Switch to a different organization (sets cookie).
+     */
+    public function switchTo(Organization $org): void
+    {
+        $this->organization = $org;
+        $this->resolved = true;
+
+        Cookie::queue(self::COOKIE_NAME, $org->id, 60 * 24 * 365);
+    }
+
+    /**
+     * Resolve the organization from the given user context.
+     * Called by middleware during request lifecycle.
+     */
+    public function resolveForUser(User $user, ?string $cookieOrgId = null): void
+    {
+        // 1. Try cookie org
+        if ($cookieOrgId) {
+            $org = Organization::find($cookieOrgId);
+            if ($org && $this->userCanAccess($user, $org)) {
+                $this->set($org);
+
+                return;
+            }
+        }
+
+        // 2. Fall back to user's first org
+        $firstOrg = $user->organizations()->first();
+        if ($firstOrg) {
+            $this->switchTo($firstOrg);
+
+            return;
+        }
+
+        // 3. Super admins with no membership fall back to main org
+        if ($user->isSuperAdmin()) {
+            $this->switchTo(Organization::main());
+
+            return;
+        }
+    }
+
+    /**
+     * Set the organization directly (without cookie).
+     * Used in middleware when cookie already matches.
+     */
+    public function set(Organization $org): void
+    {
+        $this->organization = $org;
+        $this->resolved = true;
+    }
+
+    /**
+     * Check if a user can access a given organization.
+     */
+    private function userCanAccess(User $user, Organization $org): bool
+    {
+        if ($user->isSuperAdmin()) {
+            return true;
+        }
+
+        return $user->organizations()->wherePivot('organization_id', $org->id)->exists();
+    }
+}

--- a/app/Services/DemoBackupService.php
+++ b/app/Services/DemoBackupService.php
@@ -11,6 +11,8 @@ use RuntimeException;
 
 class DemoBackupService
 {
+    public function __construct(private readonly CurrentOrganization $currentOrganization) {}
+
     /**
      * Create a demo backup configuration for the application's own database.
      *
@@ -37,6 +39,7 @@ class DemoBackupService
             'config' => [
                 'path' => '/data/backups',
             ],
+            'organization_id' => $this->currentOrganization->id(),
         ]);
 
         // Create database server entry based on type
@@ -45,6 +48,7 @@ class DemoBackupService
                 'name' => 'Databasement Database',
                 'database_type' => 'sqlite',
                 'description' => 'Demo database',
+                'organization_id' => $this->currentOrganization->id(),
             ]);
             $backupDatabaseNames = [$dbConfig['database']];
         } else {
@@ -56,6 +60,7 @@ class DemoBackupService
                 'username' => $dbConfig['username'] ?? '',
                 'password' => $dbConfig['password'] ?? '',
                 'description' => 'Demo database',
+                'organization_id' => $this->currentOrganization->id(),
             ]);
             $backupDatabaseNames = [$dbConfig['database'] ?? 'databasement'];
         }

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -2,7 +2,9 @@
 
 namespace App\Services;
 
+use App\Enums\UserRole;
 use App\Models\OAuthIdentity;
+use App\Models\Organization;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Laravel\Socialite\Contracts\User as SocialiteUser;
@@ -42,7 +44,7 @@ class OAuthService
      *
      * @throws \RuntimeException when no user can be found or created
      */
-    private function findOrCreateLocalUser(SocialiteUser $socialiteUser, string $provider, ?string $resolvedRole): User
+    private function findOrCreateLocalUser(SocialiteUser $socialiteUser, string $provider, ?UserRole $resolvedRole): User
     {
         $existingUser = $socialiteUser->getEmail()
             ? User::where('email', $socialiteUser->getEmail())->first()
@@ -78,7 +80,7 @@ class OAuthService
      * Returns the mapped role if a match is found, null if mapping is
      * inactive or no match, or throws if strict mode denies access.
      */
-    private function resolveOidcRole(SocialiteUser $socialiteUser, string $provider): ?string
+    private function resolveOidcRole(SocialiteUser $socialiteUser, string $provider): ?UserRole
     {
         if ($provider !== 'oidc') {
             return null;
@@ -100,8 +102,8 @@ class OAuthService
         $userGroups = array_map('mb_strtolower', (array) $claimValue);
 
         // Check roles in priority order: admin > member > viewer
-        foreach (['admin', 'member', 'viewer'] as $role) {
-            $configuredGroups = $this->parseGroupList(config("oauth.role_mapping.{$role}", ''));
+        foreach ([UserRole::Admin, UserRole::Member, UserRole::Viewer] as $role) {
+            $configuredGroups = $this->parseGroupList(config("oauth.role_mapping.{$role->value}", ''));
 
             if ($configuredGroups !== [] && array_intersect($userGroups, $configuredGroups) !== []) {
                 return $role;
@@ -129,14 +131,17 @@ class OAuthService
 
     /**
      * Sync user role from OIDC claims.
+     * Updates role in the user's default org (main org or configured OIDC org).
      */
-    private function syncUserRole(User $user, SocialiteUser $socialiteUser, string $provider, ?string $resolvedRole = null): void
+    private function syncUserRole(User $user, SocialiteUser $socialiteUser, string $provider, ?UserRole $resolvedRole = null): void
     {
         $role = $resolvedRole ?? $this->resolveOidcRole($socialiteUser, $provider);
 
         if ($role !== null) {
-            $user->role = $role;
-            $user->save();
+            $org = $this->resolveDefaultOrganization();
+            if ($user->belongsToOrganization($org)) {
+                $user->organizations()->updateExistingPivot($org->id, ['role' => $role->value]);
+            }
         }
     }
 
@@ -145,9 +150,13 @@ class OAuthService
      */
     private function isRoleMappingConfigured(): bool
     {
-        return trim((string) config('oauth.role_mapping.admin', '')) !== ''
-            || trim((string) config('oauth.role_mapping.member', '')) !== ''
-            || trim((string) config('oauth.role_mapping.viewer', '')) !== '';
+        foreach (UserRole::assignable() as $role) {
+            if (trim((string) config("oauth.role_mapping.{$role->value}", '')) !== '') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -169,20 +178,18 @@ class OAuthService
 
     /**
      * Create a new user from OAuth data.
+     * Auto-attaches to the default org (main or OIDC-configured org).
      */
-    private function createUser(SocialiteUser $socialiteUser, ?string $resolvedRole = null): User
+    private function createUser(SocialiteUser $socialiteUser, ?UserRole $resolvedRole = null): User
     {
-        $role = $resolvedRole ?? config('oauth.default_role', User::ROLE_MEMBER);
-
-        if (! in_array($role, User::ROLES)) {
-            $role = User::ROLE_MEMBER;
-        }
+        $role = $resolvedRole
+            ?? UserRole::tryFrom(config('oauth.default_role', 'member'))
+            ?? UserRole::Member;
 
         $user = new User([
             'name' => $socialiteUser->getName() ?? $socialiteUser->getNickname() ?? 'OAuth User',
             'email' => $socialiteUser->getEmail(),
             'password' => null,
-            'role' => $role,
             'invitation_accepted_at' => now(),
         ]);
 
@@ -190,7 +197,29 @@ class OAuthService
         $user->email_verified_at = now();
         $user->save();
 
+        // Attach to default org
+        $org = $this->resolveDefaultOrganization();
+        $user->organizations()->attach($org->id, ['role' => $role->value]);
+
         return $user;
+    }
+
+    /**
+     * Resolve the default organization for OAuth users.
+     * Uses OAUTH_DEFAULT_ORGANIZATION_ID if set, otherwise main org.
+     */
+    private function resolveDefaultOrganization(): Organization
+    {
+        $configOrgId = config('oauth.default_organization_id');
+        if (is_string($configOrgId) && $configOrgId !== '') {
+            /** @var Organization|null $org */
+            $org = Organization::find($configOrgId);
+            if ($org) {
+                return $org;
+            }
+        }
+
+        return Organization::main();
     }
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -44,10 +44,14 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
         $middleware->web(append: [
             \App\Http\Middleware\EnsureUserIsActive::class,
+            \App\Http\Middleware\SetCurrentOrganization::class,
             \App\Http\Middleware\SetLocale::class,
         ]);
         $middleware->api(prepend: [
             \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+        ]);
+        $middleware->api(append: [
+            \App\Http\Middleware\SetCurrentOrganization::class,
         ]);
         $middleware->alias([
             'agent' => \App\Http\Middleware\EnsureAgentToken::class,

--- a/config/oauth.php
+++ b/config/oauth.php
@@ -14,6 +14,17 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default Organization ID
+    |--------------------------------------------------------------------------
+    |
+    | When set, auto-created OAuth/OIDC users will join this organization
+    | instead of the main organization. Must be a valid organization ULID.
+    |
+    */
+    'default_organization_id' => env('OAUTH_DEFAULT_ORGANIZATION_ID'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Auto-link by Email
     |--------------------------------------------------------------------------
     |

--- a/database/factories/AgentFactory.php
+++ b/database/factories/AgentFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -18,6 +19,7 @@ class AgentFactory extends Factory
     {
         return [
             'name' => fake()->company().' Agent',
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
         ];
     }
 

--- a/database/factories/DatabaseServerFactory.php
+++ b/database/factories/DatabaseServerFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Enums\DatabaseSelectionMode;
 use App\Models\Backup;
 use App\Models\DatabaseServerSshConfig;
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -32,6 +33,7 @@ class DatabaseServerFactory extends Factory
             'description' => fake()->optional()->sentence(),
             'notification_trigger' => 'failure',
             'notification_channel_selection' => 'all',
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
         ];
     }
 

--- a/database/factories/DatabaseServerSshConfigFactory.php
+++ b/database/factories/DatabaseServerSshConfigFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -24,6 +25,7 @@ class DatabaseServerSshConfigFactory extends Factory
             'password' => 'ssh_password',
             'private_key' => null,
             'key_passphrase' => null,
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
         ];
     }
 

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Organization>
+ */
+class OrganizationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->unique()->company(),
+            'is_main' => false,
+        ];
+    }
+
+    /**
+     * Configure the organization as the main organization.
+     */
+    public function main(): static
+    {
+        return $this->state(fn () => [
+            'name' => 'Main',
+            'is_main' => true,
+        ]);
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,9 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserRole;
+use App\Models\Organization;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -27,13 +30,85 @@ class UserFactory extends Factory
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= 'password',
-            'role' => 'member',
+            'super_admin' => false,
+            'role' => UserRole::Member, // Virtual — not a DB column; intercepted by newModel()
             'invitation_accepted_at' => now(),
             'remember_token' => Str::random(10),
             'two_factor_secret' => Str::random(10),
             'two_factor_recovery_codes' => Str::random(10),
             'two_factor_confirmed_at' => now(),
         ];
+    }
+
+    /**
+     * Intercept the virtual 'role' attribute before forceFill() tries to
+     * write it to the model. The value is stashed on {@see User::$pendingPivotRole}
+     * so that {@see configure()}'s afterCreating hook can attach the user to the
+     * org with the correct role.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function newModel(array $attributes = [])
+    {
+        $role = $attributes['role'] ?? UserRole::Member;
+        unset($attributes['role']);
+
+        if (is_string($role)) {
+            $role = UserRole::from($role);
+        }
+
+        $model = parent::newModel($attributes);
+        $model->pendingPivotRole = $role;
+
+        return $model;
+    }
+
+    /**
+     * After creating, attach the user to the main org with the configured role.
+     */
+    public function configure(): static
+    {
+        return $this->afterCreating(function (User $user) {
+            $org = rescue(fn () => Organization::main(), fn () => Organization::factory()->main()->create());
+            $role = $user->pendingPivotRole ?? UserRole::Member;
+            $user->pendingPivotRole = null;
+
+            if (! $user->organizations()->where('organization_id', $org->id)->exists()) {
+                $user->organizations()->attach($org->id, ['role' => $role->value]);
+            }
+        });
+    }
+
+    /**
+     * Set the user as a super admin (with admin role in org).
+     */
+    public function superAdmin(): static
+    {
+        return $this->state(['super_admin' => true, 'role' => UserRole::Admin]);
+    }
+
+    /**
+     * Set the user's role in the default org to admin.
+     */
+    public function admin(): static
+    {
+        return $this->state(['role' => UserRole::Admin]);
+    }
+
+    /**
+     * Set the user's role in the default org to viewer.
+     */
+    public function viewer(): static
+    {
+        return $this->state(['role' => UserRole::Viewer]);
+    }
+
+    /**
+     * Set the user's role in the default org to demo.
+     */
+    public function demo(): static
+    {
+        return $this->state(['role' => UserRole::Demo]);
     }
 
     /**

--- a/database/factories/VolumeFactory.php
+++ b/database/factories/VolumeFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Models\Organization;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
@@ -22,6 +23,7 @@ class VolumeFactory extends Factory
             'config' => [
                 'path' => $this->createTempDirectory(),
             ],
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
         ];
     }
 

--- a/database/migrations/2026_05_05_000001_create_organizations_tables.php
+++ b/database/migrations/2026_05_05_000001_create_organizations_tables.php
@@ -1,0 +1,80 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 1. Create organizations table
+        Schema::create('organizations', function (Blueprint $table) {
+            $table->char('id', 26)->primary();
+            $table->string('name')->unique();
+            $table->boolean('is_main')->default(false);
+            $table->timestamps();
+        });
+
+        // 2. Create organization_user pivot table
+        Schema::create('organization_user', function (Blueprint $table) {
+            $table->id();
+            $table->char('organization_id', 26);
+            $table->unsignedBigInteger('user_id');
+            $table->string('role');
+            $table->timestamps();
+
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->unique(['organization_id', 'user_id']);
+        });
+
+        // 3. Add super_admin to users
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('super_admin')->default(false)->after('role');
+        });
+
+        // 4. Add nullable organization_id to scoped models
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable()->after('id');
+        });
+
+        Schema::table('volumes', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable()->after('id');
+        });
+
+        Schema::table('agents', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable()->after('id');
+        });
+
+        Schema::table('database_server_ssh_configs', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable()->after('id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('database_server_ssh_configs', function (Blueprint $table) {
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('agents', function (Blueprint $table) {
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('volumes', function (Blueprint $table) {
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->dropColumn('organization_id');
+        });
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('super_admin');
+        });
+
+        Schema::dropIfExists('organization_user');
+        Schema::dropIfExists('organizations');
+    }
+};

--- a/database/migrations/2026_05_05_000002_backfill_organizations_data.php
+++ b/database/migrations/2026_05_05_000002_backfill_organizations_data.php
@@ -1,0 +1,77 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $mainOrgId = Str::ulid()->toBase32();
+
+        DB::transaction(function () use ($mainOrgId) {
+            // 1. Create "Main" organization
+            DB::table('organizations')->insert([
+                'id' => $mainOrgId,
+                'name' => 'Main',
+                'is_main' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            // 2. Backfill organization_id on scoped models
+            DB::table('database_servers')->whereNull('organization_id')->update(['organization_id' => $mainOrgId]);
+            DB::table('volumes')->whereNull('organization_id')->update(['organization_id' => $mainOrgId]);
+            DB::table('agents')->whereNull('organization_id')->update(['organization_id' => $mainOrgId]);
+            DB::table('database_server_ssh_configs')->whereNull('organization_id')->update(['organization_id' => $mainOrgId]);
+
+            // 3. Map existing users to organization with their current roles
+            $users = DB::table('users')->get(['id', 'role']);
+
+            foreach ($users as $user) {
+                // admin users become super_admin
+                if ($user->role === 'admin') {
+                    DB::table('users')->where('id', $user->id)->update(['super_admin' => true]);
+                }
+
+                // All users get attached to main org with their current role
+                DB::table('organization_user')->insert([
+                    'organization_id' => $mainOrgId,
+                    'user_id' => $user->id,
+                    'role' => $user->role,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // Restore role column from pivot data (best effort)
+        $pivotEntries = DB::table('organization_user')
+            ->join('organizations', 'organizations.id', '=', 'organization_user.organization_id')
+            ->where('organizations.is_main', true)
+            ->get(['organization_user.user_id', 'organization_user.role']);
+
+        foreach ($pivotEntries as $entry) {
+            DB::table('users')->where('id', $entry->user_id)->update(['role' => $entry->role]);
+        }
+
+        // Reset super_admin
+        DB::table('users')->update(['super_admin' => false]);
+
+        // Clear pivot table
+        DB::table('organization_user')->delete();
+
+        // Clear organization_id
+        DB::table('database_servers')->update(['organization_id' => null]);
+        DB::table('volumes')->update(['organization_id' => null]);
+        DB::table('agents')->update(['organization_id' => null]);
+        DB::table('database_server_ssh_configs')->update(['organization_id' => null]);
+
+        // Remove main org
+        DB::table('organizations')->where('is_main', true)->delete();
+    }
+};

--- a/database/migrations/2026_05_05_000003_finalize_organizations_schema.php
+++ b/database/migrations/2026_05_05_000003_finalize_organizations_schema.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // 1. Make organization_id NOT NULL and add foreign keys
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable(false)->change();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+        });
+
+        Schema::table('volumes', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable(false)->change();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+        });
+
+        Schema::table('agents', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable(false)->change();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+        });
+
+        Schema::table('database_server_ssh_configs', function (Blueprint $table) {
+            $table->char('organization_id', 26)->nullable(false)->change();
+            $table->foreign('organization_id')->references('id')->on('organizations')->cascadeOnDelete();
+        });
+
+        // 2. Drop role column from users
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+
+    public function down(): void
+    {
+        // Re-add role column
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('member')->after('super_admin');
+        });
+
+        // Drop foreign keys and make nullable again
+        Schema::table('database_server_ssh_configs', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->char('organization_id', 26)->nullable()->change();
+        });
+
+        Schema::table('agents', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->char('organization_id', 26)->nullable()->change();
+        });
+
+        Schema::table('volumes', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->char('organization_id', 26)->nullable()->change();
+        });
+
+        Schema::table('database_servers', function (Blueprint $table) {
+            $table->dropForeign(['organization_id']);
+            $table->char('organization_id', 26)->nullable()->change();
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Backup;
 use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
+use App\Models\Organization;
 use App\Models\User;
 use App\Models\Volume;
 use Illuminate\Database\Seeder;
@@ -16,23 +17,26 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        // Main organization
+        $mainOrg = Organization::firstOrCreate(
+            ['is_main' => true],
+            ['name' => 'Main'],
+        );
+
         // Users (all with password "password", no 2FA)
-        User::factory()->withoutTwoFactor()->create([
+        User::factory()->withoutTwoFactor()->superAdmin()->create([
             'name' => 'Admin User',
             'email' => 'admin@example.com',
-            'role' => User::ROLE_ADMIN,
         ]);
 
         User::factory()->withoutTwoFactor()->create([
             'name' => 'Member User',
             'email' => 'member@example.com',
-            'role' => User::ROLE_MEMBER,
         ]);
 
-        User::factory()->withoutTwoFactor()->create([
+        User::factory()->withoutTwoFactor()->viewer()->create([
             'name' => 'Viewer User',
             'email' => 'viewer@example.com',
-            'role' => User::ROLE_VIEWER,
         ]);
 
         // Shared volume and schedule
@@ -40,6 +44,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Local',
             'type' => 'local',
             'config' => ['path' => '/data/backups'],
+            'organization_id' => $mainOrg->id,
         ]);
 
         $dailySchedule = BackupSchedule::firstOrCreate(
@@ -55,6 +60,7 @@ class DatabaseSeeder extends Seeder
             'database_type' => 'mysql',
             'username' => 'root',
             'password' => 'root',
+            'organization_id' => $mainOrg->id,
         ]);
 
         // PostgreSQL server (from docker-compose)
@@ -65,6 +71,7 @@ class DatabaseSeeder extends Seeder
             'database_type' => 'postgres',
             'username' => 'root',
             'password' => 'root',
+            'organization_id' => $mainOrg->id,
         ]);
 
         // SQLite server
@@ -78,6 +85,7 @@ class DatabaseSeeder extends Seeder
             'port' => 0,
             'username' => '',
             'password' => '',
+            'organization_id' => $mainOrg->id,
         ]);
 
         // Redis server (from docker-compose)
@@ -88,6 +96,7 @@ class DatabaseSeeder extends Seeder
             'database_type' => 'redis',
             'username' => '',
             'password' => '',
+            'organization_id' => $mainOrg->id,
         ]);
 
         // MongoDB server (from docker-compose)
@@ -99,6 +108,7 @@ class DatabaseSeeder extends Seeder
             'username' => 'root',
             'password' => 'root',
             'extra_config' => ['auth_source' => 'admin'],
+            'organization_id' => $mainOrg->id,
         ]);
 
         // Backup configurations (database_selection_mode lives on Backup now)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,27 +167,26 @@ services:
 #      - ftp-data:/home/vsftpd/ftpuser
 
 # Dex OIDC provider for local OAuth testing
-# To enable: 1) Add "127.0.0.1 dex-local" to /etc/hosts
-#            2) Uncomment this service
-#            3) Set OAUTH_OIDC_ENABLED=true in .env.local
+# Prerequisites: 1) Add "127.0.0.1 dex-local" to /etc/hosts
+#                2) Set OAUTH_OIDC_ENABLED=true in .env.local
 # Test users (password: databasement):
 #   admin@databasement.com   (groups: databasement-admins, team-a)
 #   user@databasement.com    (groups: databasement-members, team-b)
 #   viewer@databasement.com  (groups: databasement-viewers)
 #   outsider@databasement.com (no groups)
-#  dex:
-#    image: ghcr.io/dexidp/dex:v2.45.0
-#    container_name: databasement-dex
-#    volumes:
-#      - ./docker/dex/config.yaml:/etc/dex/config.yaml:ro
-#    ports:
-#      - "5556:5556"
-#    command: ["dex", "serve", "/etc/dex/config.yaml"]
-#    healthcheck:
-#      test: ["CMD", "wget", "--spider", "-q", "http://localhost:5556/dex/.well-known/openid-configuration"]
-#      interval: 10s
-#      timeout: 5s
-#      retries: 5
+  dex:
+    image: ghcr.io/dexidp/dex:v2.45.0
+    container_name: databasement-dex
+    volumes:
+      - ./docker/dex/config.yaml:/etc/dex/config.yaml:ro
+    ports:
+      - "5556:5556"
+    command: ["dex", "serve", "/etc/dex/config.yaml"]
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:5556/dex/.well-known/openid-configuration"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   app-data:

--- a/docs/docs/self-hosting/configuration/sso.md
+++ b/docs/docs/self-hosting/configuration/sso.md
@@ -138,6 +138,16 @@ New users created via OAuth are assigned this role:
 OAUTH_DEFAULT_ROLE=member  # Options: viewer, member, admin
 ```
 
+### Default Organization
+
+By default, auto-created OAuth users join the main organization. To assign them to a different organization instead, set:
+
+```env
+OAUTH_DEFAULT_ORGANIZATION_ID=01JA2B3C4D5E6F7G8H9J0KMNPQ  # Organization ULID
+```
+
+You can find the organization ID in **Configuration > Organizations**. See the [Organizations guide](/user-guide/organizations) for more details on multi-org setups.
+
 ### Auto-Link by Email
 
 When enabled (default), OAuth logins are automatically linked to existing users with matching email addresses:

--- a/docs/docs/user-guide/organizations.md
+++ b/docs/docs/user-guide/organizations.md
@@ -1,0 +1,112 @@
+---
+sidebar_position: 5
+---
+
+# Organizations
+
+Databasement supports multi-organization setups, allowing you to isolate resources (database servers, volumes, agents, snapshots) between teams or projects.
+
+## Concepts
+
+- Every resource belongs to exactly one organization
+- Users can belong to multiple organizations with different roles in each
+- A **main organization** is created automatically on first install
+- Super admins can create and manage additional organizations
+
+## User Roles
+
+Roles are **per-organization**. A user can be an admin in one org and a viewer in another.
+
+| Role       | Scope                                                        |
+|------------|--------------------------------------------------------------|
+| **Super Admin** | Global. Full access to all organizations and settings.  |
+| **Admin**  | Per-org. Can manage users and all resources within the org.  |
+| **Member** | Per-org. Can manage resources but not users.                 |
+| **Viewer** | Per-org. Read-only access.                                   |
+
+Super admin is a flag on the user account, not an org role. It grants access everywhere regardless of membership.
+
+## Switching Organizations
+
+Use the organization switcher in the sidebar to change your active context. All pages (dashboard, servers, volumes, snapshots) reflect the selected organization. The switcher is visible when you belong to more than one organization or are a super admin.
+
+On switch, you are redirected to the dashboard to avoid stale resource URLs. Your selection is persisted in a cookie and restored on next login.
+
+## Managing Organizations
+
+Super admins can manage organizations from **Configuration > Organizations**:
+
+- Create new organizations
+- Rename existing organizations
+- Delete empty organizations (all servers, volumes, and agents must be removed first)
+
+The main organization cannot be deleted or renamed. Organization names must be unique.
+
+## User Management
+
+The **Users** page shows members of the currently selected organization.
+
+Admins (org or super) can add users from the **Users > Add User** page:
+
+- **Invite new user** — Creates a new account with an invitation link. The user joins the current organization with the selected role.
+- **Add existing user** — Adds a user who already has an account (in another org) to the current organization. Select the user and assign a role.
+
+**Delete** permanently removes the user account. **Remove from org** detaches the user from the current organization but keeps their account for other orgs.
+
+| Scenario | Org Admin | Super Admin |
+|---|---|---|
+| User in **one** org | Delete | Delete |
+| User in **multiple** orgs | Remove from org | Delete or Remove from org |
+
+- Admins cannot delete or remove themselves
+- Org admins cannot act on super admin users
+- The last super admin cannot be deleted
+
+## API Usage
+
+API requests target an organization using the `?org_id=` query parameter (by organization ID):
+
+```
+GET /api/v1/database-servers?org_id=01JA2B3C4D5E6F7G8H9J0KMNPQ
+```
+
+Alternatively, pass the `X-Organization-Id` header with the same value. If neither is provided, the main organization is used.
+
+You can find the organization ID in **Configuration > Organizations**.
+
+## Data Isolation
+
+Each organization has its own:
+
+- Database servers and SSH configs
+- Storage volumes
+- Snapshots and backup jobs
+- Agents
+
+Shared across all organizations:
+
+- User accounts and API tokens
+- Global configuration (application, authentication, backup, notification settings)
+- Backup schedules
+
+A backup's database server and volume must belong to the same organization. Cross-org restore is not allowed — the source snapshot and target server must be in the same org.
+
+## Agents
+
+Agents belong to a single organization. They only execute jobs for servers within their assigned organization.
+
+## OAuth / OIDC
+
+Auto-created OAuth users join the main organization by default. Set the `OAUTH_DEFAULT_ORGANIZATION_ID` environment variable to assign them to a different org instead.
+
+## CLI Commands
+
+Artisan commands (`backup:run`, `cleanup:snapshots`, `verify:files`) operate globally across all organizations. They bypass org scoping by design.
+
+## Fresh Install
+
+On first install:
+
+1. A **Main** organization is created automatically
+2. The first registered user becomes a super admin, attached to the main org as admin
+3. Additional organizations can be created from Configuration

--- a/docs/docs/user-guide/permissions.md
+++ b/docs/docs/user-guide/permissions.md
@@ -4,15 +4,16 @@ sidebar_position: 6
 
 # Permissions
 
-Databasement uses a role-based access control system with three user roles. Each role has different permissions for managing resources.
+Databasement uses a role-based access control system. Roles are assigned **per organization** — a user can have different roles in different organizations. See [Organizations](./organizations.md) for details on multi-org setup.
 
 ## User Roles
 
-| Role       | Description                                                                |
-|------------|----------------------------------------------------------------------------|
-| **Admin**  | Full access to all features including user management                      |
-| **Member** | Can manage database servers, volumes, and backups, but cannot manage users |
-| **Viewer** | Read-only access to view resources and monitor backup status               |
+| Role            | Scope  | Description                                                                |
+|-----------------|--------|----------------------------------------------------------------------------|
+| **Super Admin** | Global | Full access to all organizations, user deletion, and global configuration  |
+| **Admin**       | Org    | Full access within the org, including user management                      |
+| **Member**      | Org    | Can manage database servers, volumes, and backups, but cannot manage users |
+| **Viewer**      | Org    | Read-only access to view resources and monitor backup status               |
 
 ## Permissions by Resource
 
@@ -47,19 +48,30 @@ Databasement uses a role-based access control system with three user roles. Each
 
 ### Users
 
-| Action               | Viewer | Member | Admin |
-|----------------------|:------:|:------:|:-----:|
-| View list            |   ✅    |   ✅    |   ✅   |
-| Invite new user      |   ❌    |   ❌    |   ✅   |
-| Edit user role       |   ❌    |   ❌    |   ✅   |
-| Delete user          |   ❌    |   ❌    |   ✅   |
-| Copy invitation link |   ❌    |   ❌    |   ✅   |
+| Action                       | Viewer | Member | Admin |
+|------------------------------|:------:|:------:|:-----:|
+| View list                    |   ✅    |   ✅    |   ✅   |
+| Invite new user              |   ❌    |   ❌    |   ✅   |
+| Edit user role               |   ❌    |   ❌    |   ✅   |
+| Delete user                  |   ❌    |   ❌    |   ✅*  |
+| Remove from organization     |   ❌    |   ❌    |   ✅   |
+| Copy invitation link         |   ❌    |   ❌    |   ✅   |
+
+\* Org admins can only delete users who belong to their organization and no other. See restrictions below.
 
 ## Special Rules
 
-### User Deletion Restrictions
+### User Deletion
 
-Even admins have some restrictions when deleting users:
+**Super admins** can delete any user, with these restrictions:
 
-- **Cannot delete yourself**: An admin cannot delete their own account
-- **Cannot delete the last admin**: The system must always have at least one admin user
+- Cannot delete yourself
+- Cannot delete the last super admin
+
+**Org admins** can delete a user only when all of the following are true:
+
+- The target user is not a super admin
+- The target user belongs to the admin's current organization
+- The target user belongs to **only one organization** (the admin's org)
+
+If the target user belongs to multiple organizations, admins can **remove them from the organization** instead of deleting them entirely.

--- a/lang/es.json
+++ b/lang/es.json
@@ -666,5 +666,11 @@
   "{1} :count monthly|[2,*] :count monthly": "{1} :count mensual|[2,*] :count mensuales",
   "{1} :count weekly|[2,*] :count weekly": "{1} :count semanal|[2,*] :count semanales",
   "{1} Snapshots older than :count day will be deleted automatically during the next cleanup run.|[2,*] Snapshots older than :count days will be deleted automatically during the next cleanup run.": "{1} Los snapshots con más de :count día se eliminarán automáticamente en la próxima limpieza.|[2,*] Los snapshots con más de :count días se eliminarán automáticamente en la próxima limpieza.",
-  "{1} the last :count day|[2,*] the last :count days": "{1} el último :count día|[2,*] los últimos :count días"
+  "{1} the last :count day|[2,*] the last :count days": "{1} el último :count día|[2,*] los últimos :count días",
+  "Go to page :page": "Ir a la página :page",
+  "of": "de",
+  "Pagination Navigation": "Navegación de paginación",
+  "results": "resultados",
+  "Showing": "Mostrando",
+  "to": "a"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -666,5 +666,11 @@
   "{1} :count monthly|[2,*] :count monthly": "{1} :count mensuel|[2,*] :count mensuels",
   "{1} :count weekly|[2,*] :count weekly": "{1} :count hebdomadaire|[2,*] :count hebdomadaires",
   "{1} Snapshots older than :count day will be deleted automatically during the next cleanup run.|[2,*] Snapshots older than :count days will be deleted automatically during the next cleanup run.": "{1} Les snapshots plus anciens que :count jour seront automatiquement supprimés lors du prochain nettoyage.|[2,*] Les snapshots plus anciens que :count jours seront automatiquement supprimés lors du prochain nettoyage.",
-  "{1} the last :count day|[2,*] the last :count days": "{1} le dernier :count jour|[2,*] les :count derniers jours"
+  "{1} the last :count day|[2,*] the last :count days": "{1} le dernier :count jour|[2,*] les :count derniers jours",
+  "Go to page :page": "Aller à la page :page",
+  "of": "sur",
+  "Pagination Navigation": "Navigation de pagination",
+  "results": "résultats",
+  "Showing": "Affichage de",
+  "to": "à"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
         "@tailwindcss/vite": "4.2.2",
         "autoprefixer": "^10.4.20",
-        "axios": "^1.15.0",
+        "axios": "^1.16.0",
         "chart.js": "^4.5.1",
         "concurrently": "^9.0.1",
         "copy-to-clipboard": "^4.0.2",
@@ -19,7 +20,7 @@
         "husky": "^9.1.7"
       },
       "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
         "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
         "lightningcss-linux-x64-gnu": "^1.29.1"
       }
@@ -382,14 +383,11 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -522,9 +520,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -540,9 +535,6 @@
       "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -575,9 +567,6 @@
       "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -655,9 +644,6 @@
       "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -759,12 +745,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@tailwindcss/vite": "4.2.2",
     "autoprefixer": "^10.4.20",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "chart.js": "^4.5.1",
     "concurrently": "^9.0.1",
     "copy-to-clipboard": "^4.0.2",
@@ -17,7 +17,7 @@
     "vite": "^8.0.10"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "4.60.2",
+    "@rollup/rollup-linux-x64-gnu": "4.60.3",
     "@tailwindcss/oxide-linux-x64-gnu": "^4.0.1",
     "lightningcss-linux-x64-gnu": "^1.29.1"
   },

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -18,3 +18,9 @@
         padding: 0.75rem;
     }
 }
+
+/* Mary UI's pagination wrapper uses overflow-y-auto, which causes a brief
+   scrollbar flash during Livewire's DOM morph on page changes. */
+.mary-table-pagination > div:last-child {
+    overflow-y: visible;
+}

--- a/resources/views/layouts/_theme-init.blade.php
+++ b/resources/views/layouts/_theme-init.blade.php
@@ -1,14 +1,33 @@
 <meta name="theme-legacy" content="{{ request()->cookie('theme', '') }}">
 <script>
-    function applyTheme() {
-        var legacy = document.querySelector('meta[name="theme-legacy"]');
-        if (legacy && legacy.content && !localStorage.getItem('theme')) {
-            localStorage.setItem('theme', legacy.content);
-        }
-        var theme = localStorage.getItem('theme') ||
-            (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-        document.documentElement.setAttribute('data-theme', theme);
+    function safeGetItem(key) {
+        try { return localStorage.getItem(key); } catch (e) { return null; }
     }
+    function safeSetItem(key, value) {
+        try { localStorage.setItem(key, value); } catch (e) {}
+    }
+
+    function getTheme() {
+        var legacy = document.querySelector('meta[name="theme-legacy"]');
+        if (legacy && legacy.content && !safeGetItem('theme')) {
+            safeSetItem('theme', legacy.content);
+        }
+        return safeGetItem('theme') ||
+            (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    }
+
+    function applyTheme() {
+        document.documentElement.setAttribute('data-theme', getTheme());
+    }
+
     applyTheme();
+
+    // Re-apply theme instantly when Livewire's DOM morph removes/changes data-theme
+    new MutationObserver(function () {
+        if (document.documentElement.getAttribute('data-theme') !== getTheme()) {
+            applyTheme();
+        }
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
     document.addEventListener('livewire:navigated', applyTheme);
 </script>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -32,6 +32,18 @@
             {{-- BRAND --}}
             <x-app-brand class="px-5 pt-4" />
 
+            {{-- ORG SWITCHER --}}
+            @if($user = auth()->user())
+                @php
+                    $showSwitcher = $user->isSuperAdmin() || $user->organizations()->count() > 1;
+                @endphp
+                @if($showSwitcher)
+                    <div class="px-4 pt-3">
+                        <livewire:organization-switcher />
+                    </div>
+                @endif
+            @endif
+
             {{-- MAIN MENU --}}
             <x-menu activate-by-route class="flex-1">
                 <x-menu-separator />
@@ -39,7 +51,9 @@
                 <x-menu-item title="{{ __('Database Servers') }}" icon="o-server-stack" link="{{ route('database-servers.index') }}" wire:navigate />
                 <livewire:menu.jobs-menu-item />
                 <x-menu-item title="{{ __('Volumes') }}" icon="o-circle-stack" link="{{ route('volumes.index') }}" wire:navigate />
-                <x-menu-item title="{{ __('Users') }}" icon="o-users" link="{{ route('users.index') }}" wire:navigate />
+                @can('viewAny', \App\Models\User::class)
+                    <x-menu-item title="{{ __('Users') }}" icon="o-users" link="{{ route('users.index') }}" wire:navigate />
+                @endcan
                 <x-menu-item title="{{ __('Agents') }}" icon="o-cpu-chip" link="{{ route('agents.index') }}" wire:navigate :badge="__('Beta')" badge-classes="badge-warning badge-soft badge-xs" />
                 <x-menu-separator />
                 <x-menu-item :title="__('Configuration')" icon="o-cog-6-tooth" :link="route('configuration.application')" wire:navigate />
@@ -54,7 +68,7 @@
                         <x-menu-item title="{{ __('Preferences') }}" icon="o-paint-brush" link="{{ route('preferences.edit') }}" wire:navigate />
                         @unless($user->isDemo())
                             <x-menu-item title="{{ __('Profile') }}" icon="o-user" link="{{ route('profile.edit') }}" wire:navigate />
-                            @unless($user->isOAuthOnly())
+                            @unless($user->isOAuth())
                                 <x-menu-item title="{{ __('Password') }}" icon="o-key" link="{{ route('user-password.edit') }}" wire:navigate />
                                 @if (Laravel\Fortify\Features::canManageTwoFactorAuthentication())
                                     <x-menu-item title="{{ __('Two-Factor Auth') }}" icon="o-shield-check" link="{{ route('two-factor.show') }}" wire:navigate />

--- a/resources/views/livewire/api-token/index.blade.php
+++ b/resources/views/livewire/api-token/index.blade.php
@@ -26,7 +26,8 @@
                             <div class="text-sm text-base-content/70">
                                 @if($token->tokenable)
                                     <span class="font-medium">{{ $token->tokenable->name }}</span>
-                                    <span class="badge badge-sm badge-ghost ml-1">{{ ucfirst($token->tokenable->role) }}</span>
+                                    @php $tokenRole = $token->tokenable->roleIn(app(\App\Services\CurrentOrganization::class)->model()); @endphp
+                                    <span class="badge badge-sm badge-ghost ml-1">{{ ($tokenRole ?? \App\Enums\UserRole::Member)->label() }}</span>
                                     &mdash;
                                 @endif
                                 {{ __('Created') }} {{ \App\Support\Formatters::humanDate($token->created_at) }}

--- a/resources/views/livewire/configuration/_tabs.blade.php
+++ b/resources/views/livewire/configuration/_tabs.blade.php
@@ -15,4 +15,10 @@
        role="tab" @class(['tab', 'tab-active' => $active === 'authentication'])>
         {{ __('Authentication') }}
     </a>
+    @if(auth()->user()->isSuperAdmin())
+        <a href="{{ route('configuration.organizations') }}" wire:navigate
+           role="tab" @class(['tab', 'tab-active' => $active === 'organizations'])>
+            {{ __('Organizations') }}
+        </a>
+    @endif
 </div>

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -1,0 +1,80 @@
+<div>
+    <x-header :title="__('Configuration')" separator>
+        <x-slot:subtitle>
+            {{ __('Manage organizations and their resources.') }}
+        </x-slot:subtitle>
+    </x-header>
+
+    @include('livewire.configuration._tabs', ['active' => 'organizations'])
+
+    <x-alert icon="o-information-circle" class="alert-info mb-4">
+        {{ __('Organizations let you group users, servers, and volumes into isolated workspaces.') }}
+        <a href="https://david-crty.github.io/databasement/docs/user-guide/organizations" target="_blank" rel="noopener noreferrer" class="link link-primary">{{ __('Learn more') }}</a>
+    </x-alert>
+
+    <div class="flex justify-end mb-4">
+        <x-button :label="__('New Organization')" icon="o-plus" class="btn-primary" wire:click="openCreateModal" />
+    </div>
+
+    <x-card shadow>
+        <x-table :headers="$headers" :rows="$organizations">
+            @scope('cell_name', $org)
+                <div class="flex items-center gap-2">
+                    {{ $org->name }}
+                    @if($org->is_main)
+                        <x-popover>
+                            <x-slot:trigger>
+                                <x-icon name="o-lock-closed" class="w-4 h-4 text-base-content/50 cursor-pointer" />
+                            </x-slot:trigger>
+                            <x-slot:content>
+                                {{ __('The main organization cannot be edited or deleted.') }}
+                            </x-slot:content>
+                        </x-popover>
+                    @endif
+                </div>
+            @endscope
+
+            @scope('cell_id', $org)
+                <code class="text-xs">{{ $org->id }}</code>
+            @endscope
+
+            @scope('cell_actions', $org)
+                @unless($org->is_main)
+                    <div class="text-right">
+                        <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditModal('{{ $org->id }}')" :tooltip="__('Edit')" />
+                        @if(!$org->hasResources())
+                            <x-button icon="o-trash" class="btn-ghost btn-xs text-error" wire:click="confirmDelete('{{ $org->id }}')" :tooltip="__('Delete')" />
+                        @endif
+                    </div>
+                @endunless
+            @endscope
+        </x-table>
+    </x-card>
+
+    {{-- Create Modal --}}
+    <x-modal wire:model="showCreateModal" :title="__('Create Organization')">
+        <x-input :label="__('Name')" wire:model="newOrgName" />
+        <x-slot:actions>
+            <x-button :label="__('Cancel')" @click="$wire.showCreateModal = false" />
+            <x-button :label="__('Create')" class="btn-primary" wire:click="createOrganization" />
+        </x-slot:actions>
+    </x-modal>
+
+    {{-- Edit Modal --}}
+    <x-modal wire:model="showEditModal" :title="__('Edit Organization')">
+        <x-input :label="__('Name')" wire:model="editOrgName" />
+        <x-slot:actions>
+            <x-button :label="__('Cancel')" @click="$wire.showEditModal = false" />
+            <x-button :label="__('Save')" class="btn-primary" wire:click="updateOrganization" />
+        </x-slot:actions>
+    </x-modal>
+
+    {{-- Delete Confirmation --}}
+    <x-modal wire:model="showDeleteModal" :title="__('Delete Organization')">
+        <p>{{ __('Are you sure you want to delete this organization? This action cannot be undone.') }}</p>
+        <x-slot:actions>
+            <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
+            <x-button :label="__('Delete')" class="btn-error" wire:click="deleteOrganization" />
+        </x-slot:actions>
+    </x-modal>
+</div>

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -42,9 +42,7 @@
                 @unless($org->is_main)
                     <div class="text-right">
                         <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditModal('{{ $org->id }}')" :tooltip="__('Edit')" />
-                        @if(!$org->hasResources())
-                            <x-button icon="o-trash" class="btn-ghost btn-xs text-error" wire:click="confirmDelete('{{ $org->id }}')" :tooltip="__('Delete')" />
-                        @endif
+                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error" wire:click="confirmDelete('{{ $org->id }}')" :tooltip="__('Delete')" />
                     </div>
                 @endunless
             @endscope
@@ -71,10 +69,18 @@
 
     {{-- Delete Confirmation --}}
     <x-modal wire:model="showDeleteModal" :title="__('Delete Organization')">
-        <p>{{ __('Are you sure you want to delete this organization? This action cannot be undone.') }}</p>
+        @if($deleteOrgHasResources)
+            <x-alert icon="o-exclamation-triangle" class="alert-warning">
+                {{ __('This organization still has servers, volumes, or agents. Remove all resources before deleting it.') }}
+            </x-alert>
+        @else
+            <p>{{ __('Are you sure you want to delete this organization? This action cannot be undone.') }}</p>
+        @endif
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
-            <x-button :label="__('Delete')" class="btn-error" wire:click="deleteOrganization" />
+            @unless($deleteOrgHasResources)
+                <x-button :label="__('Delete')" class="btn-error" wire:click="deleteOrganization" />
+            @endunless
         </x-slot:actions>
     </x-modal>
 </div>

--- a/resources/views/livewire/organization-switcher.blade.php
+++ b/resources/views/livewire/organization-switcher.blade.php
@@ -1,0 +1,11 @@
+<div>
+    <x-select
+        :options="$organizations"
+        option-value="id"
+        option-label="name"
+        wire:model="currentOrgId"
+        wire:change="switchOrg($event.target.value)"
+        icon="o-building-office"
+        class="select-sm"
+    />
+</div>

--- a/resources/views/livewire/settings/delete-user-form.blade.php
+++ b/resources/views/livewire/settings/delete-user-form.blade.php
@@ -11,17 +11,26 @@
     />
 
     <x-modal wire:model="showDeleteModal" title="{{ __('Are you sure you want to delete your account?') }}" class="backdrop-blur">
-        <p class="mb-4">
-            {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}
-        </p>
-
         <form wire:submit="deleteUser" class="space-y-6">
-            <x-password wire:model="password" label="{{ __('Password') }}" />
+            <p>
+                {{ __('Once your account is deleted, all of its resources and data will be permanently deleted.') }}
+                @unless($isOAuthUser)
+                    {{ __('Please enter your password to confirm you would like to permanently delete your account.') }}
+                @endunless
+            </p>
 
-            <x-slot:actions>
+            <x-alert icon="o-information-circle" class="alert-info">
+                {!! __('Database servers, backups, snapshots, and other resources you created <strong>WILL NOT</strong> be deleted and will remain accessible to other users.') !!}
+            </x-alert>
+
+            @unless($isOAuthUser)
+                <x-password wire:model="password" label="{{ __('Password') }}" />
+            @endunless
+
+            <div class="flex justify-end gap-2">
                 <x-button label="{{ __('Cancel') }}" @click="$wire.showDeleteModal = false" />
                 <x-button label="{{ __('Delete account') }}" class="btn-error" type="submit" data-test="confirm-delete-user-button" />
-            </x-slot:actions>
+            </div>
         </form>
     </x-modal>
 </section>

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -6,7 +6,15 @@
         <form wire:submit="updateProfileInformation" class="space-y-6">
             <x-input wire:model="name" label="{{ __('Name') }}" type="text" required autofocus autocomplete="name" />
 
-            <x-input wire:model="email" label="{{ __('Email') }}" type="email" required autocomplete="email" />
+            <x-input
+                wire:model="email"
+                label="{{ __('Email') }}"
+                type="email"
+                required
+                autocomplete="email"
+                :disabled="$isOAuthUser"
+                :hint="$isOAuthUser ? __('Email cannot be changed for SSO/OAuth users.') : null"
+            />
 
             <div class="flex items-center justify-end">
                 <x-button type="submit" class="btn-primary" label="{{ __('Save') }}" data-test="update-profile-button" />

--- a/resources/views/livewire/user/create.blade.php
+++ b/resources/views/livewire/user/create.blade.php
@@ -1,51 +1,115 @@
 <div>
-    <x-header title="{{ __('Create User') }}" subtitle="{{ __('Invite a new user to the application') }}" size="text-2xl" separator class="mb-6">
+    <x-header :title="__('Add User')" :subtitle="__('Invite a new user or add an existing one to this organization')" size="text-2xl" separator class="mb-6">
         <x-slot:actions>
-            <x-button label="{{ __('Cancel') }}" link="{{ route('users.index') }}" wire:navigate icon="o-arrow-left" class="btn-ghost" />
+            <x-button :label="__('Cancel')" link="{{ route('users.index') }}" wire:navigate icon="o-arrow-left" class="btn-ghost" />
         </x-slot:actions>
     </x-header>
 
     <x-card class="space-y-6">
-        <form wire:submit="save" class="space-y-6">
-            <x-input
-                wire:model="form.name"
-                label="{{ __('Name') }}"
-                placeholder="{{ __('Full name') }}"
-                icon="o-user"
-                required
-            />
+        @if($this->hasMultipleOrganizations)
+            <x-radio-card-group class="grid-cols-1 sm:grid-cols-2">
+                <x-radio-card
+                    :active="$mode === 'invite'"
+                    icon="o-envelope"
+                    :label="__('Invite new user')"
+                    :hint="__('Create a new account and send an invitation link')"
+                    value="invite"
+                    horizontal
+                    wire:model.live="mode"
+                />
+                <x-radio-card
+                    :active="$mode === 'existing'"
+                    icon="o-user-plus"
+                    :label="__('Add existing user')"
+                    :hint="__('Add a user who already has an account to this organization')"
+                    value="existing"
+                    horizontal
+                    wire:model.live="mode"
+                />
+            </x-radio-card-group>
+        @endif
 
-            <x-input
-                wire:model="form.email"
-                label="{{ __('Email') }}"
-                type="email"
-                placeholder="{{ __('email@example.com') }}"
-                icon="o-envelope"
-                required
-            />
+        @if($mode === 'invite')
+            <form wire:submit="save" class="space-y-6">
+                <x-input
+                    wire:model="form.name"
+                    :label="__('Name')"
+                    :placeholder="__('Full name')"
+                    icon="o-user"
+                    required
+                />
 
-            <div>
-                <label class="label label-text font-semibold mb-2">{{ __('Role') }}</label>
-                <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Role')">
-                    @foreach($roleOptions as $option)
-                        <x-radio-card
-                            :active="$form->role === $option['id']"
-                            :icon="$option['icon']"
-                            :label="$option['name']"
-                            :hint="$option['description']"
-                            :value="$option['id']"
-                            horizontal
-                            wire:model.live="form.role"
-                        />
-                    @endforeach
-                </x-radio-card-group>
-            </div>
+                <x-input
+                    wire:model="form.email"
+                    :label="__('Email')"
+                    type="email"
+                    placeholder="email@example.com"
+                    icon="o-envelope"
+                    required
+                />
 
-            <div class="flex justify-end gap-3">
-                <x-button label="{{ __('Cancel') }}" link="{{ route('users.index') }}" wire:navigate />
-                <x-button type="submit" label="{{ __('Create User') }}" class="btn-primary" spinner="save" />
-            </div>
-        </form>
+                @if(auth()->user()->isSuperAdmin())
+                    <x-checkbox
+                        wire:model="form.superAdmin"
+                        :label="__('Super Admin')"
+                        :hint="__('Super admins can access all organizations and manage global settings.')"
+                    />
+                @endif
+
+                <div>
+                    <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Role in current organization')">
+                        @foreach($roleOptions as $option)
+                            <x-radio-card
+                                :active="$form->role === $option['id']"
+                                :icon="$option['icon']"
+                                :label="$option['name']"
+                                :hint="$option['description']"
+                                :value="$option['id']"
+                                horizontal
+                                wire:model.live="form.role"
+                            />
+                        @endforeach
+                    </x-radio-card-group>
+                </div>
+
+                <div class="flex justify-end gap-3">
+                    <x-button :label="__('Cancel')" link="{{ route('users.index') }}" wire:navigate />
+                    <x-button type="submit" :label="__('Invite User')" class="btn-primary" spinner="save" />
+                </div>
+            </form>
+        @else
+            <form wire:submit="addExisting" class="space-y-6">
+                <x-select
+                    wire:model="existingUserId"
+                    :label="__('User')"
+                    :options="$availableUsers"
+                    :placeholder="__('Select a user')"
+                    icon="o-user"
+                    required
+                />
+
+                <div>
+                    <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Role in current organization')">
+                        @foreach($roleOptions as $option)
+                            <x-radio-card
+                                :active="$existingUserRole === $option['id']"
+                                :icon="$option['icon']"
+                                :label="$option['name']"
+                                :hint="$option['description']"
+                                :value="$option['id']"
+                                horizontal
+                                wire:model.live="existingUserRole"
+                            />
+                        @endforeach
+                    </x-radio-card-group>
+                </div>
+
+                <div class="flex justify-end gap-3">
+                    <x-button :label="__('Cancel')" link="{{ route('users.index') }}" wire:navigate />
+                    <x-button type="submit" :label="__('Add to Organization')" class="btn-primary" spinner="addExisting" />
+                </div>
+            </form>
+        @endif
     </x-card>
 
     <!-- INVITATION LINK MODAL -->

--- a/resources/views/livewire/user/edit.blade.php
+++ b/resources/views/livewire/user/edit.blade.php
@@ -22,15 +22,21 @@
                 type="email"
                 placeholder="{{ __('email@example.com') }}"
                 icon="o-envelope"
+                :disabled="$isOAuthUser"
+                :hint="$isOAuthUser ? __('Email cannot be changed for SSO/OAuth users.') : null"
                 required
             />
 
-            @php
-                $isOnlyAdmin = $form->user->isAdmin() && \App\Models\User::where('role', 'admin')->count() === 1;
-            @endphp
+            @if($isSuperAdmin)
+                <x-checkbox
+                    wire:model="form.superAdmin"
+                    :label="__('Super Admin')"
+                    :hint="__('Super admins can access all organizations and manage global settings.')"
+                />
+            @endif
 
             <div>
-                <label class="label label-text font-semibold mb-2">{{ __('Role') }}</label>
+                <label class="label label-text font-semibold mb-2">{{ __('Role in current organization') }}</label>
                 <x-radio-card-group class="grid-cols-1 sm:grid-cols-3" :label="__('Role')">
                     @foreach($roleOptions as $option)
                         <x-radio-card
@@ -39,19 +45,12 @@
                             :label="$option['name']"
                             :hint="$option['description']"
                             :value="$option['id']"
-                            :disabled="$isOnlyAdmin && $option['id'] !== \App\Models\User::ROLE_ADMIN"
                             horizontal
                             wire:model.live="form.role"
                         />
                     @endforeach
                 </x-radio-card-group>
             </div>
-
-            @if($isOnlyAdmin)
-                <x-alert class="alert-warning" icon="o-exclamation-triangle">
-                    {{ __('This is the only administrator. The role cannot be changed.') }}
-                </x-alert>
-            @endif
 
             <div class="bg-base-200 p-4 rounded-lg">
                 <h4 class="font-medium mb-2">{{ __('User Status') }}</h4>

--- a/resources/views/livewire/user/index.blade.php
+++ b/resources/views/livewire/user/index.blade.php
@@ -35,7 +35,7 @@
                     @if($user->id === auth()->id())
                         <span class="text-xs text-base-content/50">{{ __('(You)') }}</span>
                     @endif
-                    @if($user->isOAuthOnly())
+                    @if($user->isOAuth())
                         <x-badge value="OAuth" class="badge-ghost badge-sm" />
                     @endif
                 </div>
@@ -47,14 +47,18 @@
 
             @scope('cell_role', $user)
                 @php
-                    $roleClass = match($user->role) {
-                        'admin' => 'badge-primary',
-                        'member' => 'badge-info',
-                        'viewer' => 'badge-neutral',
-                        default => 'badge-ghost',
-                    };
+                    $currentOrg = app(\App\Services\CurrentOrganization::class);
+                    $orgRole = $user->roleIn($currentOrg->model());
+                    $displayRole = $orgRole ?? \App\Enums\UserRole::Member;
                 @endphp
-                <x-badge :value="ucfirst($user->role)" :icon="\App\Models\User::roleIcon($user->role)" class="{{ $roleClass }}" />
+                <div class="flex flex-wrap items-center gap-1">
+                    @if($user->isSuperAdmin())
+                        <x-badge value="Super Admin" icon="o-star" class="badge-warning whitespace-nowrap" />
+                    @endif
+                    @if($orgRole)
+                        <x-badge :value="$displayRole->label()" :icon="$displayRole->icon()" class="{{ $displayRole->badgeClass() }}" />
+                    @endif
+                </div>
             @endscope
 
             @scope('cell_status', $user)
@@ -89,6 +93,14 @@
                             class="btn-ghost btn-sm"
                         />
                     @endcan
+                    @can('removeFromOrganization', $user)
+                        <x-button
+                            icon="o-user-minus"
+                            wire:click="confirmRemoveFromOrg({{ $user->id }})"
+                            tooltip="{{ __('Remove from organization') }}"
+                            class="btn-ghost btn-sm text-warning"
+                        />
+                    @endcan
                     @can('delete', $user)
                         <x-button
                             icon="o-trash"
@@ -107,7 +119,21 @@
         :title="__('Delete User')"
         :message="__('Are you sure you want to delete this user? This action cannot be undone.')"
         onConfirm="delete"
-    />
+    >
+        <x-alert icon="o-information-circle" class="alert-info mt-4">
+            {!! __('Database servers, backups, snapshots, and other resources created by this user <strong>WILL NOT</strong> be deleted and will remain accessible.') !!}
+        </x-alert>
+    </x-delete-confirmation-modal>
+
+    <!-- REMOVE FROM ORG CONFIRMATION MODAL -->
+    <x-modal wire:model="showRemoveModal" :title="__('Remove User from Organization')" class="backdrop-blur">
+        <p>{{ __('Are you sure you want to remove this user from the current organization? The user will retain access to other organizations they belong to.') }}</p>
+
+        <x-slot:actions>
+            <x-button :label="__('Cancel')" @click="$wire.showRemoveModal = false" />
+            <x-button :label="__('Remove')" class="btn-warning" wire:click="removeFromOrg" spinner="removeFromOrg" />
+        </x-slot:actions>
+    </x-modal>
 
     <!-- COPY INVITATION LINK MODAL -->
     <x-invitation-link-modal

--- a/resources/views/livewire/user/index.blade.php
+++ b/resources/views/livewire/user/index.blade.php
@@ -115,23 +115,39 @@
     </x-card>
 
     <!-- DELETE CONFIRMATION MODAL -->
-    <x-delete-confirmation-modal
-        :title="__('Delete User')"
-        :message="__('Are you sure you want to delete this user? This action cannot be undone.')"
-        onConfirm="delete"
-    >
-        <x-alert icon="o-information-circle" class="alert-info mt-4">
-            {!! __('Database servers, backups, snapshots, and other resources created by this user <strong>WILL NOT</strong> be deleted and will remain accessible.') !!}
-        </x-alert>
-    </x-delete-confirmation-modal>
+    <x-modal wire:model="showDeleteModal" :title="__('Delete User')" class="backdrop-blur">
+        @if($deleteBlockReason)
+            <x-alert icon="o-exclamation-triangle" class="alert-warning">
+                {{ $deleteBlockReason }}
+            </x-alert>
+        @else
+            <p>{{ __('Are you sure you want to delete this user? This action cannot be undone.') }}</p>
+            <x-alert icon="o-information-circle" class="alert-info mt-4">
+                {!! __('Database servers, backups, snapshots, and other resources created by this user <strong>WILL NOT</strong> be deleted and will remain accessible.') !!}
+            </x-alert>
+        @endif
+        <x-slot:actions>
+            <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
+            @unless($deleteBlockReason)
+                <x-button :label="__('Delete')" class="btn-error" wire:click="delete" spinner="delete" />
+            @endunless
+        </x-slot:actions>
+    </x-modal>
 
     <!-- REMOVE FROM ORG CONFIRMATION MODAL -->
     <x-modal wire:model="showRemoveModal" :title="__('Remove User from Organization')" class="backdrop-blur">
-        <p>{{ __('Are you sure you want to remove this user from the current organization? The user will retain access to other organizations they belong to.') }}</p>
-
+        @if($removeBlockReason)
+            <x-alert icon="o-exclamation-triangle" class="alert-warning">
+                {{ $removeBlockReason }}
+            </x-alert>
+        @else
+            <p>{{ __('Are you sure you want to remove this user from the current organization? The user will retain access to other organizations they belong to.') }}</p>
+        @endif
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showRemoveModal = false" />
-            <x-button :label="__('Remove')" class="btn-warning" wire:click="removeFromOrg" spinner="removeFromOrg" />
+            @unless($removeBlockReason)
+                <x-button :label="__('Remove')" class="btn-warning" wire:click="removeFromOrg" spinner="removeFromOrg" />
+            @endunless
         </x-slot:actions>
     </x-modal>
 

--- a/resources/views/vendor/livewire/tailwind.blade.php
+++ b/resources/views/vendor/livewire/tailwind.blade.php
@@ -1,0 +1,106 @@
+@php
+if (! isset($scrollTo)) {
+    $scrollTo = 'body';
+}
+
+$scrollIntoViewJsSnippet = ($scrollTo !== false)
+    ? <<<JS
+       (\$el.closest('{$scrollTo}') || document.querySelector('{$scrollTo}')).scrollIntoView()
+    JS
+    : '';
+@endphp
+
+<div>
+    @if ($paginator->hasPages())
+        <nav role="navigation" aria-label="{{ __('Pagination Navigation') }}" class="flex items-center justify-between">
+            <div class="flex justify-between flex-1 sm:hidden">
+                @if ($paginator->onFirstPage())
+                    <span class="btn btn-sm btn-disabled">{!! __('pagination.previous') !!}</span>
+                @else
+                    <button type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="btn btn-sm">
+                        {!! __('pagination.previous') !!}
+                    </button>
+                @endif
+
+                @if ($paginator->hasMorePages())
+                    <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" wire:loading.attr="disabled" class="btn btn-sm">
+                        {!! __('pagination.next') !!}
+                    </button>
+                @else
+                    <span class="btn btn-sm btn-disabled">{!! __('pagination.next') !!}</span>
+                @endif
+            </div>
+
+            <div class="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+                <div>
+                    <p class="text-sm text-base-content/70">
+                        <span>{!! __('Showing') !!}</span>
+                        <span class="font-medium">{{ $paginator->firstItem() }}</span>
+                        <span>{!! __('to') !!}</span>
+                        <span class="font-medium">{{ $paginator->lastItem() }}</span>
+                        <span>{!! __('of') !!}</span>
+                        <span class="font-medium">{{ $paginator->total() }}</span>
+                        <span>{!! __('results') !!}</span>
+                    </p>
+                </div>
+
+                <div>
+                    <div class="join">
+                        {{-- Previous Page Link --}}
+                        @if ($paginator->onFirstPage())
+                            <span class="join-item btn btn-sm btn-disabled" aria-label="{{ __('pagination.previous') }}">
+                                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        @else
+                            <button type="button" wire:click="previousPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" dusk="previousPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.after" class="join-item btn btn-sm" aria-label="{{ __('pagination.previous') }}">
+                                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </button>
+                        @endif
+
+                        {{-- Pagination Elements --}}
+                        @foreach ($elements as $element)
+                            {{-- "Three Dots" Separator --}}
+                            @if (is_string($element))
+                                <span class="join-item btn btn-sm btn-disabled">{{ $element }}</span>
+                            @endif
+
+                            {{-- Array Of Links --}}
+                            @if (is_array($element))
+                                @foreach ($element as $page => $url)
+                                    <span wire:key="paginator-{{ $paginator->getPageName() }}-page{{ $page }}">
+                                        @if ($page == $paginator->currentPage())
+                                            <span class="join-item btn btn-sm btn-active" aria-current="page">{{ $page }}</span>
+                                        @else
+                                            <button type="button" wire:click="gotoPage({{ $page }}, '{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" class="join-item btn btn-sm" aria-label="{{ __('Go to page :page', ['page' => $page]) }}">
+                                                {{ $page }}
+                                            </button>
+                                        @endif
+                                    </span>
+                                @endforeach
+                            @endif
+                        @endforeach
+
+                        {{-- Next Page Link --}}
+                        @if ($paginator->hasMorePages())
+                            <button type="button" wire:click="nextPage('{{ $paginator->getPageName() }}')" x-on:click="{{ $scrollIntoViewJsSnippet }}" dusk="nextPage{{ $paginator->getPageName() == 'page' ? '' : '.' . $paginator->getPageName() }}.after" class="join-item btn btn-sm" aria-label="{{ __('pagination.next') }}">
+                                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </button>
+                        @else
+                            <span class="join-item btn btn-sm btn-disabled" aria-label="{{ __('pagination.next') }}">
+                                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd" />
+                                </svg>
+                            </span>
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </nav>
+    @endif
+</div>

--- a/routes/ai.php
+++ b/routes/ai.php
@@ -1,9 +1,10 @@
 <?php
 
+use App\Http\Middleware\SetCurrentOrganization;
 use App\Mcp\Servers\DatabasementServer;
 use Laravel\Mcp\Facades\Mcp;
 
 Mcp::local('databasement', DatabasementServer::class);
 
 Mcp::web('/mcp', DatabasementServer::class)
-    ->middleware('auth:sanctum');
+    ->middleware(['auth:sanctum', SetCurrentOrganization::class]);

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Api\V1\BackupJobController;
 use App\Http\Controllers\Api\V1\BackupScheduleController;
 use App\Http\Controllers\Api\V1\DatabaseServerController;
 use App\Http\Controllers\Api\V1\SnapshotController;
+use App\Http\Controllers\Api\V1\UserOrganizationController;
 use App\Http\Controllers\Api\V1\VolumeController;
 use Illuminate\Support\Facades\Route;
 
@@ -39,6 +40,9 @@ Route::middleware(['auth:sanctum'])->name('api.')->prefix('v1')->group(function 
         ->only(['index', 'show', 'store', 'destroy']);
     Route::put('backup-schedules/{backup_schedule}', [BackupScheduleController::class, 'update'])
         ->name('backup-schedules.update');
+
+    Route::get('user/organizations', [UserOrganizationController::class, 'index'])
+        ->name('user.organizations');
 });
 
 // Agent API routes — authenticated via Sanctum with agent-specific token check

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,8 @@ Route::middleware(['auth'])->group(function () {
         ->name('configuration.notification');
     Route::livewire('configuration/authentication', \App\Livewire\Configuration\Authentication::class)
         ->name('configuration.authentication');
+    Route::livewire('configuration/organizations', \App\Livewire\Configuration\Organization::class)
+        ->name('configuration.organizations');
 
     // Agents
     Route::livewire('agents', \App\Livewire\Agent\Index::class)

--- a/tests/Feature/Agent/AgentCrudTest.php
+++ b/tests/Feature/Agent/AgentCrudTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\Agent\Create;
 use App\Livewire\Agent\Edit;
 use App\Livewire\Agent\Index;
@@ -49,7 +50,7 @@ describe('agent index', function () {
     });
 
     test('viewers cannot delete agents', function () {
-        $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
         $agent = Agent::factory()->create();
 
         Livewire::actingAs($user)
@@ -78,7 +79,7 @@ describe('agent creation', function () {
     });
 
     test('demo users cannot create agents', function () {
-        $user = User::factory()->create(['role' => User::ROLE_DEMO]);
+        $user = User::factory()->create(['role' => UserRole::Demo]);
 
         Livewire::actingAs($user)
             ->test(Create::class)
@@ -86,7 +87,7 @@ describe('agent creation', function () {
     });
 
     test('viewers cannot create agents', function () {
-        $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
 
         Livewire::actingAs($user)
             ->test(Create::class)
@@ -126,7 +127,7 @@ describe('agent editing', function () {
     });
 
     test('viewers cannot edit agents', function () {
-        $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+        $user = User::factory()->create(['role' => UserRole::Viewer]);
         $agent = Agent::factory()->create();
 
         Livewire::actingAs($user)

--- a/tests/Feature/Api/BackupApiTest.php
+++ b/tests/Feature/Api/BackupApiTest.php
@@ -14,7 +14,7 @@ test('unauthenticated users cannot trigger a backup', function () {
 });
 
 test('viewer users cannot trigger a backup', function () {
-    $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+    $user = User::factory()->viewer()->create();
     $server = DatabaseServer::factory()->create();
 
     $response = $this->actingAs($user, 'sanctum')

--- a/tests/Feature/Api/BackupScheduleCrudApiTest.php
+++ b/tests/Feature/Api/BackupScheduleCrudApiTest.php
@@ -54,7 +54,7 @@ test('unauthenticated users cannot create backup schedules', function () {
 });
 
 test('viewers cannot create backup schedules', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
 
     $this->actingAs($user, 'sanctum')
         ->postJson('/api/v1/backup-schedules', [
@@ -124,7 +124,7 @@ test('unauthenticated users cannot update backup schedules', function () {
 });
 
 test('viewers cannot update backup schedules', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
     $schedule = BackupSchedule::factory()->create();
 
     $this->actingAs($user, 'sanctum')
@@ -183,7 +183,7 @@ test('unauthenticated users cannot delete backup schedules', function () {
 });
 
 test('viewers cannot delete backup schedules', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
     $schedule = BackupSchedule::factory()->create();
 
     $this->actingAs($user, 'sanctum')

--- a/tests/Feature/Api/DatabaseServerCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerCrudApiTest.php
@@ -14,7 +14,7 @@ test('unauthenticated users cannot create database servers', function () {
 });
 
 test('viewers cannot create database servers', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
     $volume = Volume::factory()->local()->create();
     $schedule = BackupSchedule::firstOrCreate(['name' => 'Daily'], ['expression' => '0 2 * * *']);
 
@@ -239,7 +239,7 @@ test('unauthenticated users cannot update database servers', function () {
 });
 
 test('viewers cannot update database servers', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
     $server = DatabaseServer::factory()->create(['database_type' => 'mysql']);
     $volume = Volume::factory()->local()->create();
     $schedule = BackupSchedule::firstOrCreate(['name' => 'Daily'], ['expression' => '0 2 * * *']);
@@ -367,7 +367,7 @@ test('unauthenticated users cannot delete database servers', function () {
 });
 
 test('viewers cannot delete database servers', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
     $server = DatabaseServer::factory()->create();
 
     $this->actingAs($user, 'sanctum')

--- a/tests/Feature/Api/OrganizationContextApiTest.php
+++ b/tests/Feature/Api/OrganizationContextApiTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Models\DatabaseServer;
+use App\Models\Organization;
+use App\Models\User;
+
+beforeEach(function () {
+    $this->mainOrg = Organization::main();
+    $this->otherOrg = Organization::factory()->create(['name' => 'Other Org']);
+});
+
+describe('org_id query parameter', function () {
+    test('defaults to main org when no org_id is provided', function () {
+        $user = User::factory()->create();
+
+        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/database-servers');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Main Server');
+    });
+
+    test('org_id scopes resources to the specified organization', function () {
+        $user = User::factory()->superAdmin()->create();
+
+        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson("/api/v1/database-servers?org_id={$this->otherOrg->id}");
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Other Server');
+    });
+
+    test('returns 403 when org_id points to an inaccessible organization', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'sanctum')
+            ->getJson("/api/v1/database-servers?org_id={$this->otherOrg->id}")
+            ->assertForbidden();
+    });
+
+    test('returns 403 when org_id is a nonexistent id', function () {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/database-servers?org_id=nonexistent-ulid')
+            ->assertForbidden();
+    });
+
+    test('X-Organization-Id header works like org_id parameter', function () {
+        $user = User::factory()->superAdmin()->create();
+
+        DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/database-servers', ['X-Organization-Id' => $this->otherOrg->id]);
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Other Server');
+    });
+});
+
+describe('cross-org resource isolation', function () {
+    test('user cannot see database servers from another organization', function () {
+        $user = User::factory()->create();
+
+        DatabaseServer::factory()->create(['name' => 'My Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'Their Server', 'organization_id' => $this->otherOrg->id]);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/database-servers');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'My Server');
+    });
+
+    test('user cannot access a specific resource from another organization', function () {
+        $user = User::factory()->create();
+
+        $otherServer = DatabaseServer::factory()->create(['organization_id' => $this->otherOrg->id]);
+
+        $this->actingAs($user, 'sanctum')
+            ->getJson("/api/v1/database-servers/{$otherServer->id}")
+            ->assertNotFound();
+    });
+
+    test('super admin can access any organization via org_id', function () {
+        $superAdmin = User::factory()->superAdmin()->create();
+
+        DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
+
+        $response = $this->actingAs($superAdmin, 'sanctum')
+            ->getJson("/api/v1/database-servers?org_id={$this->otherOrg->id}");
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Other Server');
+    });
+
+    test('member of multiple orgs can switch between them', function () {
+        $user = User::factory()->create();
+        $user->organizations()->attach($this->otherOrg->id, ['role' => UserRole::Member]);
+
+        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
+
+        // Default: main org
+        $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/database-servers')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Main Server');
+
+        // Explicit: other org
+        $this->actingAs($user, 'sanctum')
+            ->getJson("/api/v1/database-servers?org_id={$this->otherOrg->id}")
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.name', 'Other Server');
+    });
+});

--- a/tests/Feature/Api/RestoreApiTest.php
+++ b/tests/Feature/Api/RestoreApiTest.php
@@ -15,7 +15,7 @@ test('unauthenticated users cannot trigger a restore', function () {
 });
 
 test('viewer users cannot trigger a restore', function () {
-    $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+    $user = User::factory()->viewer()->create();
     $server = DatabaseServer::factory()->create();
     $snapshot = Snapshot::factory()->forServer($server)->create();
 

--- a/tests/Feature/Api/UserOrganizationApiTest.php
+++ b/tests/Feature/Api/UserOrganizationApiTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Models\Organization;
+use App\Models\User;
+
+test('returns the authenticated user organizations with roles', function () {
+    $user = User::factory()->create();
+    $otherOrg = Organization::factory()->create(['name' => 'Second Org']);
+    $user->organizations()->attach($otherOrg->id, ['role' => UserRole::Admin]);
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->getJson('/api/v1/user/organizations');
+
+    $response->assertOk()
+        ->assertJsonCount(2, 'data')
+        ->assertJsonPath('data.0.role', UserRole::Member->value)
+        ->assertJsonPath('data.1.name', 'Second Org')
+        ->assertJsonPath('data.1.role', UserRole::Admin->value);
+});
+
+test('requires authentication', function () {
+    $this->getJson('/api/v1/user/organizations')->assertUnauthorized();
+});

--- a/tests/Feature/Api/VolumeCrudApiTest.php
+++ b/tests/Feature/Api/VolumeCrudApiTest.php
@@ -72,7 +72,7 @@ test('unauthenticated users cannot create volumes', function () {
 });
 
 test('viewers cannot create volumes', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
 
     $this->actingAs($user, 'sanctum')
         ->postJson('/api/v1/volumes/local', [
@@ -133,7 +133,7 @@ test('unauthenticated users cannot delete volumes', function () {
 });
 
 test('viewers cannot delete volumes', function () {
-    $user = User::factory()->create(['role' => 'viewer']);
+    $user = User::factory()->viewer()->create();
     $volume = Volume::factory()->create();
 
     $this->actingAs($user, 'sanctum')

--- a/tests/Feature/ApiToken/IndexTest.php
+++ b/tests/Feature/ApiToken/IndexTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\ApiToken\Index;
 use App\Models\User;
 use Livewire\Livewire;
@@ -36,8 +37,8 @@ test('can revoke an existing token', function () {
 });
 
 test('regular user cannot revoke another users token', function () {
-    $owner = User::factory()->create(['role' => User::ROLE_MEMBER]);
-    $otherUser = User::factory()->create(['role' => User::ROLE_MEMBER]);
+    $owner = User::factory()->create(['role' => UserRole::Member]);
+    $otherUser = User::factory()->create(['role' => UserRole::Member]);
     $token = $owner->createToken('Owner Token');
     $tokenId = $token->accessToken->id;
 
@@ -52,8 +53,8 @@ test('regular user cannot revoke another users token', function () {
 });
 
 test('admin can revoke any users token', function () {
-    $owner = User::factory()->create(['role' => User::ROLE_MEMBER]);
-    $admin = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $owner = User::factory()->create(['role' => UserRole::Member]);
+    $admin = User::factory()->create(['role' => UserRole::Admin]);
     $token = $owner->createToken('Owner Token');
     $tokenId = $token->accessToken->id;
 
@@ -66,8 +67,8 @@ test('admin can revoke any users token', function () {
 });
 
 test('admin sees all tokens with user info', function () {
-    $admin = User::factory()->create(['name' => 'Alice', 'role' => User::ROLE_ADMIN]);
-    $member = User::factory()->create(['name' => 'Bob', 'role' => User::ROLE_MEMBER]);
+    $admin = User::factory()->create(['name' => 'Alice', 'role' => UserRole::Admin]);
+    $member = User::factory()->create(['name' => 'Bob', 'role' => UserRole::Member]);
     $admin->createToken('Alice Token');
     $member->createToken('Bob Token');
 
@@ -82,8 +83,8 @@ test('admin sees all tokens with user info', function () {
 });
 
 test('non-admin only sees own tokens', function () {
-    $admin = User::factory()->create(['name' => 'Alice', 'role' => User::ROLE_ADMIN]);
-    $member = User::factory()->create(['name' => 'Bob', 'role' => User::ROLE_MEMBER]);
+    $admin = User::factory()->create(['name' => 'Alice', 'role' => UserRole::Admin]);
+    $member = User::factory()->create(['name' => 'Bob', 'role' => UserRole::Member]);
     $admin->createToken('Alice Token');
     $member->createToken('Bob Token');
 

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -46,12 +46,8 @@ test('users can not authenticate with invalid password', function () {
     $this->assertGuest();
 });
 
-test('oauth only users see helpful error when trying to login with password', function () {
-    $user = User::factory()->create([
-        'password' => null, // OAuth-only user
-    ]);
-
-    // Create an OAuth identity for this user
+test('oauth users see helpful error when trying to login with password', function () {
+    $user = User::factory()->create(['password' => null]);
     OAuthIdentity::create([
         'user_id' => $user->id,
         'provider' => 'github',
@@ -142,6 +138,16 @@ test('login screen renders oauth provider button when enabled', function (string
     'gitlab' => ['gitlab', 'GitLab'],
     'oidc' => ['oidc', 'SSO'],
 ]);
+
+test('user without organization is logged out with error', function () {
+    $user = User::factory()->create();
+    $user->organizations()->detach();
+
+    $response = $this->actingAs($user)->get(route('dashboard'));
+
+    $response->assertRedirect(route('login'));
+    $this->assertGuest();
+});
 
 test('users can logout', function () {
     $user = User::factory()->create();

--- a/tests/Feature/Auth/OAuthTest.php
+++ b/tests/Feature/Auth/OAuthTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Models\OAuthIdentity;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -78,7 +79,7 @@ test('oauth callback creates new user when email not found', function () {
     $user = User::where('email', 'newuser@example.com')->first();
     expect($user)->not->toBeNull()
         ->and($user->name)->toBe('New User')
-        ->and($user->role)->toBe(User::ROLE_MEMBER)
+        ->and($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Member)
         ->and($user->password)->toBeNull()
         ->and($user->email_verified_at)->not->toBeNull()
         ->and($user->invitation_accepted_at)->not->toBeNull();
@@ -94,7 +95,7 @@ test('oauth callback creates new user when email not found', function () {
 test('oauth callback links to existing user by email and clears password', function () {
     $existingUser = User::factory()->create([
         'email' => 'existing@example.com',
-        'role' => User::ROLE_ADMIN,
+        'role' => UserRole::Admin,
         'password' => 'original-password',
     ]);
 
@@ -116,7 +117,7 @@ test('oauth callback links to existing user by email and clears password', funct
 
     $existingUser->refresh();
     expect($existingUser->oauthIdentities)->toHaveCount(1)
-        ->and($existingUser->role)->toBe(User::ROLE_ADMIN) // unchanged
+        ->and($existingUser->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin) // unchanged
         ->and($existingUser->password)->toBeNull(); // cleared to enforce OAuth-only login
 });
 
@@ -158,7 +159,7 @@ test('oauth uses configured default role for new users', function () {
     $this->get(route('oauth.callback', 'github'));
 
     $user = User::where('email', 'viewer@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_VIEWER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
 });
 
 test('oauth callback fails when auto-create is disabled and no matching user', function () {
@@ -268,7 +269,7 @@ test('oidc role mapping assigns admin role from matching group', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'admin@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_ADMIN);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping assigns member role from matching group', function () {
@@ -280,7 +281,7 @@ test('oidc role mapping assigns member role from matching group', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'member@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_MEMBER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Member);
 });
 
 test('oidc role mapping assigns viewer role from matching group', function () {
@@ -292,7 +293,7 @@ test('oidc role mapping assigns viewer role from matching group', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'viewer@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_VIEWER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping uses highest priority role when multiple groups match', function () {
@@ -305,7 +306,7 @@ test('oidc role mapping uses highest priority role when multiple groups match', 
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'multi@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_ADMIN);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping falls back to default role when no group matches and strict is off', function () {
@@ -318,7 +319,7 @@ test('oidc role mapping falls back to default role when no group matches and str
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'fallback@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_VIEWER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping denies access when no group matches and strict is on', function () {
@@ -339,7 +340,7 @@ test('oidc role mapping syncs role for returning user', function () {
     enableOidcProvider();
     Config::set('oauth.role_mapping.admin', 'databasement-admins');
 
-    $user = User::factory()->create(['role' => User::ROLE_MEMBER]);
+    $user = User::factory()->create(['role' => UserRole::Member]);
     OAuthIdentity::create([
         'user_id' => $user->id,
         'provider' => 'oidc',
@@ -352,7 +353,7 @@ test('oidc role mapping syncs role for returning user', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user->refresh();
-    expect($user->role)->toBe(User::ROLE_ADMIN);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping updates role when groups change for returning user', function () {
@@ -360,7 +361,7 @@ test('oidc role mapping updates role when groups change for returning user', fun
     Config::set('oauth.role_mapping.admin', 'databasement-admins');
     Config::set('oauth.role_mapping.viewer', 'databasement-viewers');
 
-    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
     OAuthIdentity::create([
         'user_id' => $user->id,
         'provider' => 'oidc',
@@ -374,7 +375,7 @@ test('oidc role mapping updates role when groups change for returning user', fun
     $this->get(route('oauth.callback', 'oidc'));
 
     $user->refresh();
-    expect($user->role)->toBe(User::ROLE_VIEWER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping uses default role when no mapping is configured', function () {
@@ -387,7 +388,7 @@ test('oidc role mapping uses default role when no mapping is configured', functi
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'default@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_VIEWER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping falls back to default role when groups claim is missing', function () {
@@ -400,7 +401,7 @@ test('oidc role mapping falls back to default role when groups claim is missing'
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'noclaimuser@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_VIEWER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping strict mode denies access when groups claim is missing', function () {
@@ -435,7 +436,7 @@ test('oidc role mapping reads from custom claim name', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'custom@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_ADMIN);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping does not apply to non-oidc providers', function () {
@@ -455,7 +456,7 @@ test('oidc role mapping does not apply to non-oidc providers', function () {
     $this->get(route('oauth.callback', 'github'));
 
     $user = User::where('email', 'ghuser@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_MEMBER);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Member);
 });
 
 test('oidc role mapping supports comma-separated groups in env var', function () {
@@ -467,7 +468,7 @@ test('oidc role mapping supports comma-separated groups in env var', function ()
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'comma@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_ADMIN);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping matches groups case-insensitively', function () {
@@ -479,7 +480,58 @@ test('oidc role mapping matches groups case-insensitively', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'case@example.com')->first();
-    expect($user->role)->toBe(User::ROLE_ADMIN);
+    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+});
+
+test('new oauth user joins configured default organization', function () {
+    enableOidcProvider();
+    $customOrg = \App\Models\Organization::factory()->create(['name' => 'Custom Org']);
+    Config::set('oauth.default_organization_id', $customOrg->id);
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-org-1', 'orguser@example.com', 'Org User'));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'orguser@example.com')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->belongsToOrganization($customOrg))->toBeTrue()
+        ->and($user->roleIn($customOrg))->toBe(UserRole::Member);
+});
+
+test('new oauth user falls back to main org when configured org does not exist', function () {
+    enableOidcProvider();
+    Config::set('oauth.default_organization_id', 'nonexistent-ulid');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-org-2', 'fallbackorg@example.com', 'Fallback Org'));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'fallbackorg@example.com')->first();
+    expect($user)->not->toBeNull()
+        ->and($user->belongsToOrganization(\App\Models\Organization::main()))->toBeTrue();
+});
+
+test('oidc role mapping syncs role in configured default organization', function () {
+    enableOidcProvider();
+    $customOrg = \App\Models\Organization::factory()->create(['name' => 'Custom Org']);
+    Config::set('oauth.default_organization_id', $customOrg->id);
+    Config::set('oauth.role_mapping.admin', 'databasement-admins');
+
+    $user = User::factory()->create(['role' => UserRole::Member]);
+    $user->organizations()->attach($customOrg->id, ['role' => UserRole::Member]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'oidc',
+        'provider_user_id' => 'oidc-org-3',
+        'email' => $user->email,
+    ]);
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-org-3', $user->email, $user->name, ['databasement-admins']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user->refresh();
+    expect($user->roleIn($customOrg))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping strict mode denies returning user with revoked groups', function () {
@@ -487,7 +539,7 @@ test('oidc role mapping strict mode denies returning user with revoked groups', 
     Config::set('oauth.role_mapping.admin', 'databasement-admins');
     Config::set('oauth.role_mapping.strict', true);
 
-    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
     OAuthIdentity::create([
         'user_id' => $user->id,
         'provider' => 'oidc',

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Models\DatabaseServer;
 use App\Models\User;
 use App\Services\DemoBackupService;
@@ -24,8 +25,10 @@ test('first user can register as admin', function () {
 
     $this->assertAuthenticated();
 
-    // First user should be admin
-    expect(auth()->user()->role)->toBe(User::ROLE_ADMIN);
+    // First user should be super admin
+    $user = auth()->user();
+    expect($user->super_admin)->toBeTrue()
+        ->and($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
 });
 
 test('first user can create demo backup during registration', function () {
@@ -82,14 +85,14 @@ test('registration POST returns 403 when users exist', function () {
 // Invitation flow (allowed for non-first users)
 test('users can join via invitation link even when registration is closed', function () {
     // Create first admin
-    User::factory()->create(['role' => User::ROLE_ADMIN]);
+    User::factory()->create(['role' => UserRole::Admin]);
 
     // Create invited user (pending invitation)
     $invitedUser = User::factory()->create([
         'password' => null,
         'invitation_token' => 'test-token-123',
         'invitation_accepted_at' => null,
-        'role' => User::ROLE_MEMBER,
+        'role' => UserRole::Member,
     ]);
 
     // Accept invitation page should be accessible even though registration is closed

--- a/tests/Feature/Configuration/ApplicationTest.php
+++ b/tests/Feature/Configuration/ApplicationTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\Configuration\Application;
 use App\Models\User;
 use Livewire\Livewire;
 
 test('configuration route redirects to application tab', function () {
-    $user = User::factory()->create(['role' => 'admin']);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
 
     $this->actingAs($user)
         ->get('/configuration')
@@ -13,7 +14,7 @@ test('configuration route redirects to application tab', function () {
 });
 
 test('application page displays environment variables', function () {
-    $user = User::factory()->create(['role' => 'admin']);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
 
     Livewire::actingAs($user)
         ->test(Application::class)

--- a/tests/Feature/Configuration/AuthenticationTest.php
+++ b/tests/Feature/Configuration/AuthenticationTest.php
@@ -1,11 +1,12 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\Configuration\Authentication;
 use App\Models\User;
 use Livewire\Livewire;
 
 test('authentication page displays SSO environment variables', function () {
-    $user = User::factory()->create(['role' => 'admin']);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
 
     Livewire::actingAs($user)
         ->test(Authentication::class)
@@ -13,5 +14,6 @@ test('authentication page displays SSO environment variables', function () {
         ->assertSee('OAUTH_GOOGLE_ENABLED')
         ->assertSee('OAUTH_GITHUB_ENABLED')
         ->assertSee('OAUTH_GITLAB_ENABLED')
-        ->assertSee('OAUTH_OIDC_ENABLED');
+        ->assertSee('OAUTH_OIDC_ENABLED')
+        ->assertSee('OAUTH_DEFAULT_ORGANIZATION_ID');
 });

--- a/tests/Feature/Configuration/BackupTest.php
+++ b/tests/Feature/Configuration/BackupTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Facades\AppConfig;
 use App\Jobs\CleanupExpiredSnapshotsJob;
 use App\Jobs\ProcessBackupJob;
@@ -19,7 +20,7 @@ beforeEach(function () {
 });
 
 test('backup page displays current values', function () {
-    $user = User::factory()->create(['role' => 'admin']);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
 
     Livewire::actingAs($user)
         ->test(Backup::class)
@@ -31,7 +32,7 @@ test('backup page displays current values', function () {
 });
 
 test('non-admin users see read-only backup page', function () {
-    $user = User::factory()->create(['role' => 'member']);
+    $user = User::factory()->create(['role' => UserRole::Member]);
 
     Livewire::actingAs($user)
         ->test(Backup::class)
@@ -40,14 +41,14 @@ test('non-admin users see read-only backup page', function () {
 });
 
 test('non-admin users cannot save backup config', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Backup::class)
         ->call('saveBackupConfig')
         ->assertForbidden();
 });
 
 test('saving backup config persists values', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->set('form.compression', 'zstd')
         ->set('form.compression_level', 10)
@@ -65,7 +66,7 @@ test('shows warning toast when scheduler restart fails', function () {
 
     Process::fake(fn () => Process::result(errorOutput: 'connection refused', exitCode: 1));
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('saveBackupConfig');
 
@@ -75,7 +76,7 @@ test('shows warning toast when scheduler restart fails', function () {
 });
 
 test('validation rejects invalid backup values', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->set('form.compression', 'invalid')
         ->set('form.compression_level', 0)
@@ -88,7 +89,7 @@ test('validation rejects invalid backup values', function () {
 // Backup Schedule CRUD tests
 
 test('admin can create a backup schedule', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('openScheduleModal')
         ->assertSet('showScheduleModal', true)
@@ -110,7 +111,7 @@ test('admin can edit a backup schedule', function () {
         'expression' => '0 1 * * *',
     ]);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('openScheduleModal', $schedule->id)
         ->assertSet('form.schedule_name', 'Old Name')
@@ -127,7 +128,7 @@ test('admin can edit a backup schedule', function () {
 test('admin can delete an unused backup schedule', function () {
     $schedule = BackupSchedule::factory()->create(['name' => 'To Delete']);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('confirmDeleteSchedule', $schedule->id)
         ->assertSet('showDeleteScheduleModal', true)
@@ -141,7 +142,7 @@ test('cannot delete a backup schedule that is in use', function () {
     $server = DatabaseServer::factory()->create();
     $schedule = $server->backups->first()->backupSchedule;
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('confirmDeleteSchedule', $schedule->id)
         ->call('deleteSchedule');
@@ -150,7 +151,7 @@ test('cannot delete a backup schedule that is in use', function () {
 });
 
 test('schedule name must be unique', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('openScheduleModal')
         ->set('form.schedule_name', 'Daily')
@@ -160,7 +161,7 @@ test('schedule name must be unique', function () {
 });
 
 test('schedule requires valid cron expression', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('openScheduleModal')
         ->set('form.schedule_name', 'Bad Cron')
@@ -170,14 +171,14 @@ test('schedule requires valid cron expression', function () {
 });
 
 test('non-admin cannot create schedule', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Backup::class)
         ->call('saveSchedule')
         ->assertForbidden();
 });
 
 test('non-admin cannot delete schedule', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Backup::class)
         ->call('deleteSchedule')
         ->assertForbidden();
@@ -190,7 +191,7 @@ test('admin can run a schedule to trigger backups for all its servers', function
     $server = DatabaseServer::factory()->create(['database_names' => ['app']]);
     $server->backups->first()->update(['backup_schedule_id' => $schedule->id]);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('runSchedule', $schedule->id);
 
@@ -206,7 +207,7 @@ test('running a schedule skips servers with backups disabled', function () {
     $enabledServer->backups->first()->update(['backup_schedule_id' => $schedule->id]);
     $disabledServer->backups->first()->update(['backup_schedule_id' => $schedule->id]);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('runSchedule', $schedule->id);
 
@@ -220,7 +221,7 @@ test('running a schedule skips servers with backups disabled', function () {
 });
 
 test('non-admin cannot run a schedule', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Backup::class)
         ->call('runSchedule', 'fake-id')
         ->assertForbidden();
@@ -229,7 +230,7 @@ test('non-admin cannot run a schedule', function () {
 test('admin can run cleanup manually', function () {
     Queue::fake();
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('runCleanup');
 
@@ -237,7 +238,7 @@ test('admin can run cleanup manually', function () {
 });
 
 test('non-admin cannot run cleanup', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Backup::class)
         ->call('runCleanup')
         ->assertForbidden();
@@ -246,7 +247,7 @@ test('non-admin cannot run cleanup', function () {
 test('admin can run verify files manually', function () {
     Queue::fake();
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Backup::class)
         ->call('runVerifyFiles');
 
@@ -254,7 +255,7 @@ test('admin can run verify files manually', function () {
 });
 
 test('non-admin cannot run verify files', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Backup::class)
         ->call('runVerifyFiles')
         ->assertForbidden();

--- a/tests/Feature/Configuration/NotificationTest.php
+++ b/tests/Feature/Configuration/NotificationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\Configuration\Notification;
 use App\Models\NotificationChannel;
 use App\Models\User;
@@ -9,7 +10,7 @@ use Illuminate\Support\Facades\Notification as NotificationFacade;
 use Livewire\Livewire;
 
 test('admin can create a notification channel', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Notification::class)
         ->call('openChannelModal')
         ->assertSet('showChannelModal', true)
@@ -32,7 +33,7 @@ test('admin can edit a notification channel', function () {
         'config' => ['to' => 'old@example.com'],
     ]);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Notification::class)
         ->call('openChannelModal', $channel->id)
         ->assertSet('channelForm.name', 'Old Name')
@@ -48,7 +49,7 @@ test('admin can edit a notification channel', function () {
 test('admin can delete a notification channel', function () {
     $channel = NotificationChannel::factory()->email()->create(['name' => 'To Delete']);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Notification::class)
         ->call('confirmDeleteChannel', $channel->id)
         ->assertSet('showDeleteChannelModal', true)
@@ -59,21 +60,21 @@ test('admin can delete a notification channel', function () {
 });
 
 test('non-admin cannot save notification channel', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Notification::class)
         ->call('saveChannel')
         ->assertForbidden();
 });
 
 test('non-admin cannot delete notification channel', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Notification::class)
         ->call('deleteChannel')
         ->assertForbidden();
 });
 
 test('non-admin cannot send test notification', function () {
-    Livewire::actingAs(User::factory()->create(['role' => 'member']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Member]))
         ->test(Notification::class)
         ->call('sendTestNotification', 'fake-id')
         ->assertForbidden();
@@ -85,7 +86,7 @@ test('sendTestNotification sends notification for a channel', function () {
         'config' => ['to' => 'admin@example.com'],
     ]);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Notification::class)
         ->call('sendTestNotification', $channel->id);
 
@@ -102,14 +103,14 @@ test('sendTestNotification handles notification failure gracefully', function ()
     $mock->shouldReceive('sendTestNotification')->andThrow(new RuntimeException('SMTP connection failed'));
     app()->instance(NotificationService::class, $mock);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Notification::class)
         ->call('sendTestNotification', $channel->id)
         ->assertSuccessful();
 });
 
 test('admin can create notification channels of various types', function (string $type, array $formFields, array $expectedOnEdit) {
-    $component = Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    $component = Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Notification::class)
         ->call('openChannelModal')
         ->set('channelForm.name', 'Test Channel')
@@ -149,7 +150,7 @@ test('editing a channel preserves sensitive fields when left blank', function ()
         'config' => ['webhook_url' => \Illuminate\Support\Facades\Crypt::encryptString('https://hooks.slack.com/original')],
     ]);
 
-    Livewire::actingAs(User::factory()->create(['role' => 'admin']))
+    Livewire::actingAs(User::factory()->create(['role' => UserRole::Admin]))
         ->test(Notification::class)
         ->call('openChannelModal', $channel->id)
         ->assertSet('channelForm.has_config_webhook_url', true)

--- a/tests/Feature/Configuration/OrganizationTest.php
+++ b/tests/Feature/Configuration/OrganizationTest.php
@@ -90,7 +90,7 @@ test('super admin cannot delete main organization', function () {
         ->assertForbidden();
 });
 
-test('super admin cannot delete organization with resources', function () {
+test('super admin sees warning when deleting organization with resources', function () {
     $admin = User::factory()->superAdmin()->create();
     $org = OrganizationModel::factory()->create();
     DatabaseServer::factory()->create(['organization_id' => $org->id]);
@@ -98,5 +98,19 @@ test('super admin cannot delete organization with resources', function () {
     Livewire::actingAs($admin)
         ->test(Organization::class)
         ->call('confirmDelete', $org->id)
-        ->assertForbidden();
+        ->assertSet('deleteOrgHasResources', true)
+        ->assertSee('still has servers, volumes, or agents. Remove all resources before deleting it.');
+});
+
+test('super admin cannot force delete organization with resources', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $org = OrganizationModel::factory()->create();
+    DatabaseServer::factory()->create(['organization_id' => $org->id]);
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->set('deleteOrgId', $org->id)
+        ->call('deleteOrganization');
+
+    expect(OrganizationModel::find($org->id))->not->toBeNull();
 });

--- a/tests/Feature/Configuration/OrganizationTest.php
+++ b/tests/Feature/Configuration/OrganizationTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use App\Livewire\Configuration\Organization;
+use App\Models\DatabaseServer;
+use App\Models\Organization as OrganizationModel;
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+test('non-super-admin cannot access organizations page', function () {
+    $user = User::factory()->admin()->create();
+    actingAs($user);
+
+    get(route('configuration.organizations'))
+        ->assertForbidden();
+});
+
+test('super admin can access organizations page', function () {
+    $admin = User::factory()->superAdmin()->create();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->assertOk()
+        ->assertSee('Main');
+});
+
+test('super admin can create an organization', function () {
+    $admin = User::factory()->superAdmin()->create();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('createOrganization')
+        ->assertHasErrors('newOrgName');
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->set('newOrgName', 'Engineering')
+        ->call('createOrganization')
+        ->assertRedirect(route('configuration.organizations'));
+
+    expect(OrganizationModel::where('name', 'Engineering')->exists())->toBeTrue();
+});
+
+test('super admin can rename a non-main organization', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $org = OrganizationModel::factory()->create(['name' => 'Old Name']);
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('openEditModal', $org->id)
+        ->set('editOrgName', 'New Name')
+        ->call('updateOrganization')
+        ->assertRedirect(route('configuration.organizations'));
+
+    expect($org->fresh()->name)->toBe('New Name');
+});
+
+test('super admin cannot rename the main organization', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $mainOrg = OrganizationModel::main();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('openEditModal', $mainOrg->id)
+        ->assertForbidden();
+});
+
+test('super admin can delete an empty non-main organization', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $org = OrganizationModel::factory()->create();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('confirmDelete', $org->id)
+        ->call('deleteOrganization')
+        ->assertRedirect(route('configuration.organizations'));
+
+    expect(OrganizationModel::find($org->id))->toBeNull();
+});
+
+test('super admin cannot delete main organization', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $mainOrg = OrganizationModel::main();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('confirmDelete', $mainOrg->id)
+        ->assertForbidden();
+});
+
+test('super admin cannot delete organization with resources', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $org = OrganizationModel::factory()->create();
+    DatabaseServer::factory()->create(['organization_id' => $org->id]);
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('confirmDelete', $org->id)
+        ->assertForbidden();
+});

--- a/tests/Feature/Dashboard/SnapshotsCardTest.php
+++ b/tests/Feature/Dashboard/SnapshotsCardTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Jobs\VerifySnapshotFileJob;
 use App\Livewire\Dashboard\SnapshotsCard;
 use App\Models\DatabaseServer;
@@ -79,7 +80,7 @@ test('snapshots card shows all verified when no snapshots are missing', function
 test('verify files button dispatches verification job', function () {
     Queue::fake();
 
-    $admin = User::factory()->create(['role' => 'admin']);
+    $admin = User::factory()->create(['role' => UserRole::Admin]);
 
     Livewire::withoutLazyLoading()
         ->actingAs($admin)
@@ -92,9 +93,10 @@ test('verify files button dispatches verification job', function () {
 test('verify files button prevents rapid re-dispatch via cache lock', function () {
     Queue::fake();
 
-    $admin = User::factory()->create(['role' => 'admin']);
+    $admin = User::factory()->create(['role' => UserRole::Admin]);
 
-    Cache::lock('verify-snapshot-files', 300)->get();
+    $org = \App\Models\Organization::main();
+    Cache::lock('verify-snapshot-files:'.$org->id, 300)->get();
 
     Livewire::withoutLazyLoading()
         ->actingAs($admin)

--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -14,6 +14,7 @@ test('can create database server', function (array $config) {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $component = Livewire::actingAs($user)
@@ -106,6 +107,7 @@ test('can create database server with retention policy', function (array $config
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $component = Livewire::actingAs($user)
@@ -144,6 +146,7 @@ test('cannot create database server with GFS retention when all tiers are empty'
         'name' => 'GFS Validation Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     Livewire::actingAs($user)
@@ -262,6 +265,7 @@ test('can create database server with dump flags', function () {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     Livewire::actingAs($user)
@@ -289,7 +293,7 @@ test('can create database server with dump flags', function () {
 
 test('local volume options reflect use_agent state', function (bool $useAgent, bool $expectedDisabled) {
     $user = User::factory()->create();
-    $localVolume = Volume::create(['name' => 'Local Vol', 'type' => 'local', 'config' => ['path' => '/backups']]);
+    $localVolume = Volume::create(['name' => 'Local Vol', 'type' => 'local', 'config' => ['path' => '/backups'], 'organization_id' => \App\Models\Organization::first()->id]);
 
     $component = Livewire::actingAs($user)
         ->test(Create::class)
@@ -306,7 +310,7 @@ test('local volume options reflect use_agent state', function (bool $useAgent, b
 
 test('toggling use_agent clears local volume but keeps remote volume', function (string $volumeType, array $volumeConfig, string $expectedVolumeId) {
     $user = User::factory()->create();
-    $volume = Volume::create(['name' => 'Test Vol', 'type' => $volumeType, 'config' => $volumeConfig]);
+    $volume = Volume::create(['name' => 'Test Vol', 'type' => $volumeType, 'config' => $volumeConfig, 'organization_id' => \App\Models\Organization::first()->id]);
 
     $expected = $expectedVolumeId === 'keep' ? $volume->id : '';
 
@@ -323,7 +327,7 @@ test('toggling use_agent clears local volume but keeps remote volume', function 
 test('cannot create agent-backed server with local volume', function () {
     $user = User::factory()->create();
     $agent = Agent::factory()->create();
-    $localVolume = Volume::create(['name' => 'Local Vol', 'type' => 'local', 'config' => ['path' => '/backups']]);
+    $localVolume = Volume::create(['name' => 'Local Vol', 'type' => 'local', 'config' => ['path' => '/backups'], 'organization_id' => \App\Models\Organization::first()->id]);
 
     Livewire::actingAs($user)
         ->test(Create::class)
@@ -349,6 +353,7 @@ test('backup summary is incomplete until volume and schedule are set, then rende
         'name' => 'Prod Backups',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $component = Livewire::actingAs($user)
@@ -425,6 +430,7 @@ test('backup summary reports incomplete when retention settings are blank', func
         'name' => 'Prod Backups',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $component = Livewire::actingAs($user)
@@ -465,11 +471,13 @@ test('can create a server with multiple backup configurations', function () {
         'name' => 'Primary Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups/primary'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
     $volume2 = Volume::create([
         'name' => 'Secondary Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups/secondary'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
     $daily = dailySchedule();
     $weekly = weeklySchedule();

--- a/tests/Feature/DatabaseServer/EditTest.php
+++ b/tests/Feature/DatabaseServer/EditTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\DatabaseServer\Edit;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
@@ -15,12 +16,14 @@ test('can edit database server', function (array $config) {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
     $schedule = dailySchedule();
 
     $serverData = [
         'name' => $config['name'],
         'database_type' => $config['type'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ];
 
     $backupDatabaseNames = null;
@@ -100,6 +103,7 @@ test('can change retention policy', function (array $config) {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
     $schedule = dailySchedule();
 
@@ -110,6 +114,7 @@ test('can change retention policy', function (array $config) {
         'port' => 3306,
         'username' => 'dbuser',
         'password' => 'secret',
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     // Start with forever retention (no specific retention days)
@@ -249,7 +254,7 @@ test('pattern mode filters available databases and auto-loads on switch', functi
 });
 
 test('admin can select notification channels for a database server', function () {
-    $admin = User::factory()->create(['role' => 'admin']);
+    $admin = User::factory()->create(['role' => UserRole::Admin]);
 
     $email = NotificationChannel::factory()->email()->create(['name' => 'Zebra Alerts']);
     $slack = NotificationChannel::factory()->slack()->create(['name' => 'Alpha Slack']);
@@ -281,7 +286,7 @@ test('admin can select notification channels for a database server', function ()
 });
 
 test('selected notification channel selection requires at least one channel', function (string $trigger) {
-    $admin = User::factory()->create(['role' => 'admin']);
+    $admin = User::factory()->create(['role' => UserRole::Admin]);
     NotificationChannel::factory()->email()->create();
     $server = DatabaseServer::factory()->create(['database_names' => ['myapp']]);
 
@@ -299,7 +304,7 @@ test('selected notification channel selection requires at least one channel', fu
 ]);
 
 test('notification channel selection is not required when trigger is disabled', function () {
-    $admin = User::factory()->create(['role' => 'admin']);
+    $admin = User::factory()->create(['role' => UserRole::Admin]);
     NotificationChannel::factory()->email()->create();
     $server = DatabaseServer::factory()->create(['database_names' => ['myapp']]);
 

--- a/tests/Feature/DatabaseServer/RestoreModalTest.php
+++ b/tests/Feature/DatabaseServer/RestoreModalTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Jobs\ProcessRestoreJob;
 use App\Livewire\DatabaseServer\Index;
 use App\Livewire\DatabaseServer\RestoreModal;
@@ -13,7 +14,7 @@ use Livewire\Livewire;
 use function Pest\Laravel\actingAs;
 
 beforeEach(function () {
-    $this->user = User::factory()->create(['role' => 'admin']);
+    $this->user = User::factory()->create(['role' => UserRole::Admin]);
     actingAs($this->user);
 
     // Mock DatabaseProvider to prevent real connection attempts in loadExistingDatabases()

--- a/tests/Feature/DatabaseServer/SshTunnelTest.php
+++ b/tests/Feature/DatabaseServer/SshTunnelTest.php
@@ -17,6 +17,7 @@ test('can create database server with SSH tunnel (password auth)', function () {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     Livewire::actingAs($user)
@@ -65,6 +66,7 @@ test('can create database server with SSH tunnel (key auth)', function () {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $privateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest_key_content\n-----END OPENSSH PRIVATE KEY-----";
@@ -108,6 +110,7 @@ test('can create database server using existing SSH config', function () {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     // Create existing SSH config
@@ -189,6 +192,7 @@ test('can create SQLite server with SSH config for remote access', function () {
         'name' => 'Test Volume',
         'type' => 'local',
         'config' => ['path' => '/var/backups'],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     Livewire::actingAs($user)

--- a/tests/Feature/DemoModeTest.php
+++ b/tests/Feature/DemoModeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\BackupJob\Index as BackupJobIndex;
 use App\Livewire\DatabaseServer\Create as DatabaseServerCreate;
 use App\Livewire\DatabaseServer\Edit as DatabaseServerEdit;
@@ -14,7 +15,7 @@ use App\Services\Backup\BackupJobFactory;
 use Livewire\Livewire;
 
 beforeEach(function () {
-    $this->demoUser = User::factory()->create(['role' => User::ROLE_DEMO]);
+    $this->demoUser = User::factory()->create(['role' => UserRole::Demo]);
     config(['app.demo_mode' => true]);
 });
 
@@ -212,7 +213,7 @@ test('first admin can register even when demo mode is enabled', function () {
     // User should be authenticated as the new admin (not demo user)
     $this->assertAuthenticated();
     expect(auth()->user()->email)->toBe('admin@example.com')
-        ->and(auth()->user()->role)->toBe(User::ROLE_ADMIN)
+        ->and(auth()->user()->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin)
         ->and(auth()->user()->isDemo())->toBeFalse();
 
     // Should be able to access dashboard
@@ -224,7 +225,7 @@ test('demo user is created when visiting login page in demo mode', function () {
     User::query()->delete();
 
     // Create an admin so registration is closed
-    User::factory()->create(['role' => User::ROLE_ADMIN]);
+    User::factory()->create(['role' => UserRole::Admin]);
 
     config([
         'app.demo_mode' => true,
@@ -241,6 +242,7 @@ test('demo user is created when visiting login page in demo mode', function () {
     // Demo user should now exist
     $this->assertDatabaseHas('users', [
         'email' => 'auto-demo@example.com',
-        'role' => User::ROLE_DEMO,
     ]);
+    $demoUser = User::where('email', 'auto-demo@example.com')->first();
+    expect($demoUser->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Demo);
 });

--- a/tests/Feature/Livewire/DatabaseServer/IndexTest.php
+++ b/tests/Feature/Livewire/DatabaseServer/IndexTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Jobs\ProcessBackupJob;
 use App\Livewire\DatabaseServer\Index;
 use App\Models\Backup;
@@ -13,7 +14,7 @@ beforeEach(function () {
 });
 
 test('runBackup triggers backup for a specific backup configuration', function () {
-    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
     $server = DatabaseServer::factory()->withoutBackups()->create();
     $backup = Backup::factory()->for($server)->selected(['test_db'])->create();
 
@@ -25,7 +26,7 @@ test('runBackup triggers backup for a specific backup configuration', function (
 });
 
 test('runBackup includes backup display label in success toast', function () {
-    $user = User::factory()->create(['role' => User::ROLE_ADMIN]);
+    $user = User::factory()->create(['role' => UserRole::Admin]);
     $server = DatabaseServer::factory()->withoutBackups()->create();
     $backup = Backup::factory()->for($server)->selected(['test_db'])->create();
 
@@ -38,7 +39,7 @@ test('runBackup includes backup display label in success toast', function () {
 });
 
 test('runBackup fails with authorization error if user is viewer', function () {
-    $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+    $user = User::factory()->create(['role' => UserRole::Viewer]);
     $server = DatabaseServer::factory()->withoutBackups()->create();
     $backup = Backup::factory()->for($server)->selected(['test_db'])->create();
 

--- a/tests/Feature/Mcp/McpServerTest.php
+++ b/tests/Feature/Mcp/McpServerTest.php
@@ -1,14 +1,17 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Jobs\ProcessBackupJob;
 use App\Jobs\ProcessRestoreJob;
 use App\Mcp\Servers\DatabasementServer;
 use App\Mcp\Tools\GetJobStatusTool;
 use App\Mcp\Tools\ListDatabaseServersTool;
+use App\Mcp\Tools\ListOrganizationsTool;
 use App\Mcp\Tools\ListSnapshotsTool;
 use App\Mcp\Tools\TriggerBackupTool;
 use App\Mcp\Tools\TriggerRestoreTool;
 use App\Models\BackupJob;
+use App\Models\Organization;
 use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Models\User;
@@ -94,7 +97,7 @@ test('trigger backup dispatches job', function () {
 });
 
 test('trigger backup rejects viewer users', function () {
-    $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+    $user = User::factory()->create(['role' => UserRole::Viewer]);
     $server = createDatabaseServer();
 
     $response = DatabasementServer::actingAs($user)->tool(TriggerBackupTool::class, [
@@ -140,7 +143,7 @@ test('trigger restore rejects type mismatch', function () {
 });
 
 test('trigger restore rejects viewer users', function () {
-    $user = User::factory()->create(['role' => User::ROLE_VIEWER]);
+    $user = User::factory()->create(['role' => UserRole::Viewer]);
     $server = createDatabaseServer(['database_type' => 'mysql']);
     $snapshot = Snapshot::factory()->forServer($server)->create();
 
@@ -192,6 +195,7 @@ test('list database servers shows unconfigured backup', function () {
         'database_type' => 'mysql',
         'username' => 'root',
         'password' => 'secret',
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $response = DatabasementServer::actingAs($user)->tool(ListDatabaseServersTool::class);
@@ -254,6 +258,7 @@ test('trigger backup rejects server without backup config', function () {
         'password' => 'secret',
         'database_names' => ['testdb'],
         'database_selection_mode' => 'selected',
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $response = DatabasementServer::actingAs($user)->tool(TriggerBackupTool::class, [
@@ -361,4 +366,31 @@ test('get job status shows error message for failed jobs', function () {
 
 test('web mcp route requires authentication', function () {
     $this->postJson('/mcp')->assertUnauthorized();
+});
+
+test('list organizations shows user orgs with active indicator', function () {
+    $user = User::factory()->create();
+    $otherOrg = Organization::factory()->create(['name' => 'Other Org']);
+    $user->organizations()->attach($otherOrg->id, ['role' => UserRole::Member]);
+
+    $response = DatabasementServer::actingAs($user)->tool(ListOrganizationsTool::class);
+
+    $response->assertOk()
+        ->assertSee('Your Organizations (2)')
+        ->assertSee('(active)')
+        ->assertSee('Other Org');
+});
+
+test('list database servers only returns servers from current org', function () {
+    $user = User::factory()->create();
+    $otherOrg = Organization::factory()->create(['name' => 'Other Org']);
+
+    createDatabaseServer(['name' => 'My Server']);
+    \App\Models\DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $otherOrg->id]);
+
+    $response = DatabasementServer::actingAs($user)->tool(ListDatabaseServersTool::class);
+
+    $response->assertOk()
+        ->assertSee('My Server')
+        ->assertDontSee('Other Server');
 });

--- a/tests/Feature/OrganizationSwitcherTest.php
+++ b/tests/Feature/OrganizationSwitcherTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Livewire\OrganizationSwitcher;
+use App\Models\Organization;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('user can switch to an organization they belong to', function () {
+    $user = User::factory()->create();
+    $otherOrg = Organization::factory()->create();
+    $user->organizations()->attach($otherOrg->id, ['role' => UserRole::Member]);
+
+    Livewire::actingAs($user)
+        ->test(OrganizationSwitcher::class)
+        ->call('switchOrg', $otherOrg->id)
+        ->assertRedirect(route('dashboard'));
+});
+
+test('user cannot switch to an organization they do not belong to', function () {
+    $user = User::factory()->create();
+    $foreignOrg = Organization::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(OrganizationSwitcher::class)
+        ->call('switchOrg', $foreignOrg->id)
+        ->assertNoRedirect();
+});
+
+test('super admin can switch to any organization', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $otherOrg = Organization::factory()->create();
+
+    Livewire::actingAs($admin)
+        ->test(OrganizationSwitcher::class)
+        ->call('switchOrg', $otherOrg->id)
+        ->assertRedirect(route('dashboard'));
+});

--- a/tests/Feature/Services/Backup/LocalVolumeStorageTest.php
+++ b/tests/Feature/Services/Backup/LocalVolumeStorageTest.php
@@ -39,6 +39,7 @@ test('getForVolume supports both root and path config keys for local filesystem'
         'name' => 'Volume with root key',
         'type' => 'local',
         'config' => ['root' => $tempDir],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $filesystem = $this->filesystemProvider->getForVolume($volumeWithRoot);
@@ -51,6 +52,7 @@ test('getForVolume supports both root and path config keys for local filesystem'
         'name' => 'Volume with path key',
         'type' => 'local',
         'config' => ['path' => $tempDir],
+        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $filesystem2 = $this->filesystemProvider->getForVolume($volumeWithPath);

--- a/tests/Feature/Services/DemoBackupServiceTest.php
+++ b/tests/Feature/Services/DemoBackupServiceTest.php
@@ -11,7 +11,7 @@ test('creates demo backup for sqlite database', function () {
     // This mirrors the production scenario where the app uses SQLite
     config(['database.connections.sqlite.database' => '/data/database.sqlite']);
 
-    $service = new DemoBackupService;
+    $service = app(DemoBackupService::class);
     $databaseServer = $service->createDemoBackup('sqlite');
 
     expect($databaseServer)->toBeInstanceOf(DatabaseServer::class)
@@ -36,7 +36,7 @@ test('creates demo backup for mysql database', function () {
         'password' => 'secret',
     ]]);
 
-    $service = new DemoBackupService;
+    $service = app(DemoBackupService::class);
     $databaseServer = $service->createDemoBackup('mysql');
 
     expect($databaseServer)->toBeInstanceOf(DatabaseServer::class)
@@ -60,7 +60,7 @@ test('creates demo backup for postgresql database', function () {
         'password' => 'secret',
     ]]);
 
-    $service = new DemoBackupService;
+    $service = app(DemoBackupService::class);
     $databaseServer = $service->createDemoBackup('pgsql');
 
     expect($databaseServer)->toBeInstanceOf(DatabaseServer::class)
@@ -74,6 +74,6 @@ test('creates demo backup for postgresql database', function () {
 });
 
 test('throws exception for unsupported database type', function () {
-    $service = new DemoBackupService;
+    $service = app(DemoBackupService::class);
     $service->createDemoBackup('mongodb');
 })->throws(RuntimeException::class, 'Unsupported database connection: mongodb');

--- a/tests/Feature/Settings/PasswordUpdateTest.php
+++ b/tests/Feature/Settings/PasswordUpdateTest.php
@@ -1,13 +1,18 @@
 <?php
 
 use App\Livewire\Settings\Password;
+use App\Models\OAuthIdentity;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Livewire\Livewire;
 
-test('oauth only users cannot access password settings', function () {
-    $user = User::factory()->create([
-        'password' => null, // OAuth users have no password
+test('oauth user cannot access password settings', function () {
+    $user = User::factory()->create(['password' => null]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'github',
+        'provider_user_id' => 'gh-123',
+        'email' => $user->email,
     ]);
 
     $this->actingAs($user)

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\Settings\DeleteUserForm;
 use App\Livewire\Settings\Profile;
+use App\Models\OAuthIdentity;
 use App\Models\User;
 use Livewire\Livewire;
 
@@ -40,10 +41,50 @@ test('user can delete their account', function () {
 
     $response
         ->assertHasNoErrors()
-        ->assertRedirect('/');
+        ->assertRedirect(route('login'));
 
     expect($user->fresh())->toBeNull();
     expect(auth()->check())->toBeFalse();
+});
+
+test('oauth user sees disabled email field', function () {
+    $user = User::factory()->create();
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'github',
+        'provider_user_id' => 'gh-123',
+        'email' => $user->email,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(Profile::class)
+        ->assertSee(__('Email cannot be changed for SSO/OAuth users.'));
+});
+
+test('oauth user email is not updated on save', function () {
+    $user = User::factory()->create([
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+    ]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'oidc',
+        'provider_user_id' => 'oidc-123',
+        'email' => $user->email,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(Profile::class)
+        ->set('name', 'Updated Name')
+        ->set('email', 'hacked@example.com')
+        ->call('updateProfileInformation')
+        ->assertHasNoErrors();
+
+    $user->refresh();
+    expect($user->name)->toBe('Updated Name')
+        ->and($user->email)->toBe('oauth@example.com');
 });
 
 test('correct password must be provided to delete account', function () {
@@ -58,4 +99,24 @@ test('correct password must be provided to delete account', function () {
     $response->assertHasErrors(['password']);
 
     expect($user->fresh())->not->toBeNull();
+});
+
+test('oauth user can delete account without password', function () {
+    $user = User::factory()->create(['password' => null]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'github',
+        'provider_user_id' => 'gh-123',
+        'email' => $user->email,
+    ]);
+
+    $this->actingAs($user);
+
+    Livewire::test(DeleteUserForm::class)
+        ->call('deleteUser')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('login'));
+
+    expect($user->fresh())->toBeNull();
+    expect(auth()->check())->toBeFalse();
 });

--- a/tests/Feature/Settings/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/Settings/TwoFactorAuthenticationTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Livewire\Settings\TwoFactor;
+use App\Models\OAuthIdentity;
 use App\Models\User;
 use Laravel\Fortify\Features;
 use Livewire\Livewire;
@@ -27,9 +28,13 @@ test('two factor settings page can be rendered', function () {
         ->assertSee('Disabled');
 });
 
-test('oauth only users are redirected to password confirmation which blocks them', function () {
-    $user = User::factory()->create([
-        'password' => null, // OAuth users have no password
+test('oauth user is blocked from two factor settings', function () {
+    $user = User::factory()->create(['password' => null]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'github',
+        'provider_user_id' => 'gh-123',
+        'email' => $user->email,
     ]);
 
     // First, they get redirected to password confirmation

--- a/tests/Feature/User/CreateTest.php
+++ b/tests/Feature/User/CreateTest.php
@@ -1,6 +1,8 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\User\Create;
+use App\Models\Organization;
 use App\Models\User;
 use Livewire\Livewire;
 
@@ -8,47 +10,108 @@ use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 
 beforeEach(function () {
-    $this->admin = User::factory()->create(['role' => 'admin']);
+    $this->admin = User::factory()->superAdmin()->create();
 });
 
-test('non-admin users cannot access create user page', function () {
-    $member = User::factory()->create(['role' => 'member']);
-    actingAs($member);
+describe('access control', function () {
+    test('super admin can access create page', function () {
+        actingAs($this->admin);
 
-    get(route('users.create'))
-        ->assertForbidden();
+        get(route('users.create'))->assertOk();
+    });
+
+    test('org admin can access create page', function () {
+        $orgAdmin = User::factory()->admin()->create();
+        actingAs($orgAdmin);
+
+        get(route('users.create'))->assertOk();
+    });
+
+    test('non-admin cannot access create page', function (string $role) {
+        $user = User::factory()->create(['role' => $role]);
+        actingAs($user);
+
+        get(route('users.create'))->assertForbidden();
+    })->with(['member', 'viewer']);
 });
 
-test('viewer cannot access create user page', function () {
-    $viewer = User::factory()->create(['role' => 'viewer']);
-    actingAs($viewer);
+describe('invite new user', function () {
+    test('creates user with invitation token attached to current org', function () {
+        actingAs($this->admin);
 
-    get(route('users.create'))
-        ->assertForbidden();
+        Livewire::test(Create::class)
+            ->set('form.name', 'New User')
+            ->set('form.email', 'newuser@example.com')
+            ->set('form.role', UserRole::Member->value)
+            ->call('save')
+            ->assertSet('showCopyModal', true)
+            ->assertSet('invitationUrl', fn ($url) => str_contains($url, '/invitation/'));
+
+        $user = User::where('email', 'newuser@example.com')->first();
+        expect($user)->not->toBeNull()
+            ->and($user->name)->toBe('New User')
+            ->and($user->roleIn(Organization::main()))->toBe(UserRole::Member)
+            ->and($user->invitation_token)->not->toBeNull()
+            ->and($user->password)->toBeNull();
+    });
+
+    test('super admin can set super admin flag', function () {
+        actingAs($this->admin);
+
+        Livewire::test(Create::class)
+            ->set('form.name', 'New Super Admin')
+            ->set('form.email', 'superadmin@example.com')
+            ->set('form.role', UserRole::Admin->value)
+            ->set('form.superAdmin', true)
+            ->call('save');
+
+        $user = User::where('email', 'superadmin@example.com')->first();
+        expect($user->super_admin)->toBeTrue();
+    });
+
+    test('non-super-admin cannot set super admin flag', function () {
+        $orgAdmin = User::factory()->admin()->create();
+        actingAs($orgAdmin);
+
+        Livewire::test(Create::class)
+            ->set('form.name', 'Attempted Super')
+            ->set('form.email', 'attempted@example.com')
+            ->set('form.role', UserRole::Admin->value)
+            ->set('form.superAdmin', true)
+            ->call('save');
+
+        $user = User::where('email', 'attempted@example.com')->first();
+        expect($user->super_admin)->toBeFalse();
+    });
 });
 
-test('admin can access create user page', function () {
-    actingAs($this->admin);
+describe('add existing user', function () {
+    test('admin can add existing user to current organization', function () {
+        actingAs($this->admin);
 
-    get(route('users.create'))
-        ->assertOk();
-});
+        $otherOrg = Organization::factory()->create();
+        $existingUser = User::factory()->create();
+        // Move user to other org only (detach from main)
+        $existingUser->organizations()->sync([$otherOrg->id => ['role' => UserRole::Member]]);
 
-test('admin can create user with valid data', function () {
-    actingAs($this->admin);
+        Livewire::test(Create::class)
+            ->set('existingUserId', $existingUser->id)
+            ->set('existingUserRole', UserRole::Viewer->value)
+            ->call('addExisting')
+            ->assertHasNoErrors();
 
-    Livewire::test(Create::class)
-        ->set('form.name', 'New User')
-        ->set('form.email', 'newuser@example.com')
-        ->set('form.role', 'member')
-        ->call('save')
-        ->assertSet('showCopyModal', true)
-        ->assertSet('invitationUrl', fn ($url) => str_contains($url, '/invitation/'));
+        expect($existingUser->roleIn(Organization::main()))->toBe(UserRole::Viewer);
+    });
 
-    $user = User::where('email', 'newuser@example.com')->first();
-    expect($user)->not->toBeNull();
-    expect($user->name)->toBe('New User');
-    expect($user->role)->toBe('member');
-    expect($user->invitation_token)->not->toBeNull();
-    expect($user->password)->toBeNull();
+    test('rejects adding user already in organization', function () {
+        actingAs($this->admin);
+
+        $existingUser = User::factory()->create();
+
+        Livewire::test(Create::class)
+            ->set('existingUserId', $existingUser->id)
+            ->set('existingUserRole', UserRole::Member->value)
+            ->call('addExisting')
+            ->assertHasErrors('existingUserId');
+    });
 });

--- a/tests/Feature/User/EditTest.php
+++ b/tests/Feature/User/EditTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\User\Edit;
+use App\Models\OAuthIdentity;
+use App\Models\Organization;
 use App\Models\User;
 use Livewire\Livewire;
 
@@ -8,92 +11,155 @@ use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
 
 beforeEach(function () {
-    $this->admin = User::factory()->create(['role' => 'admin']);
+    $this->admin = User::factory()->superAdmin()->create();
 });
 
-test('non-admin users cannot access edit user page', function () {
-    $member = User::factory()->create(['role' => 'member']);
-    $userToEdit = User::factory()->create();
-    actingAs($member);
+describe('access control', function () {
+    test('super admin can edit any user', function () {
+        actingAs($this->admin);
 
-    get(route('users.edit', $userToEdit))
-        ->assertForbidden();
+        $user = User::factory()->create();
+
+        get(route('users.edit', $user))->assertOk();
+    });
+
+    test('org admin can edit non-super-admin users in their org', function () {
+        $orgAdmin = User::factory()->admin()->create();
+        actingAs($orgAdmin);
+
+        $user = User::factory()->create();
+
+        get(route('users.edit', $user))->assertOk();
+    });
+
+    test('org admin cannot edit super admin users', function () {
+        $orgAdmin = User::factory()->admin()->create();
+        actingAs($orgAdmin);
+
+        get(route('users.edit', $this->admin))->assertForbidden();
+    });
+
+    test('org admin cannot edit users outside their org', function () {
+        $orgAdmin = User::factory()->admin()->create();
+        actingAs($orgAdmin);
+
+        $otherOrg = Organization::factory()->create();
+        $outsideUser = User::factory()->create();
+        $outsideUser->organizations()->sync([$otherOrg->id => ['role' => UserRole::Member]]);
+
+        get(route('users.edit', $outsideUser))->assertForbidden();
+    });
+
+    test('non-admin cannot edit users', function (string $role) {
+        $user = User::factory()->create(['role' => $role]);
+        $target = User::factory()->create();
+        actingAs($user);
+
+        get(route('users.edit', $target))->assertForbidden();
+    })->with(['member', 'viewer']);
 });
 
-test('viewer cannot access edit user page', function () {
-    $viewer = User::factory()->create(['role' => 'viewer']);
-    $userToEdit = User::factory()->create();
-    actingAs($viewer);
-
-    get(route('users.edit', $userToEdit))
-        ->assertForbidden();
-});
-
-test('admin can edit another user', function () {
+test('can update user name email and role', function () {
     actingAs($this->admin);
 
-    $userToEdit = User::factory()->create([
+    $user = User::factory()->create([
         'name' => 'Original Name',
         'email' => 'original@example.com',
-        'role' => 'member',
+        'role' => UserRole::Member,
     ]);
 
-    Livewire::test(Edit::class, ['user' => $userToEdit])
+    Livewire::test(Edit::class, ['user' => $user])
         ->set('form.name', 'Updated Name')
         ->set('form.email', 'updated@example.com')
-        ->set('form.role', 'viewer')
+        ->set('form.role', UserRole::Viewer->value)
         ->call('save')
         ->assertRedirect(route('users.index'));
 
-    $userToEdit->refresh();
-    expect($userToEdit->name)->toBe('Updated Name');
-    expect($userToEdit->email)->toBe('updated@example.com');
-    expect($userToEdit->role)->toBe('viewer');
+    $user->refresh();
+    expect($user->name)->toBe('Updated Name')
+        ->and($user->email)->toBe('updated@example.com')
+        ->and($user->roleIn(Organization::main()))->toBe(UserRole::Viewer);
 });
 
-test('cannot change last admin to non-admin role', function () {
+test('cannot remove last super admin', function () {
     actingAs($this->admin);
 
-    // Ensure there's only one admin
-    expect(User::where('role', 'admin')->count())->toBe(1);
+    expect(User::where('super_admin', true)->count())->toBe(1);
 
     Livewire::test(Edit::class, ['user' => $this->admin])
-        ->set('form.role', 'member')
+        ->set('form.superAdmin', false)
         ->call('save')
-        ->assertHasNoErrors()
         ->assertNoRedirect();
 
-    // Role should not have changed
     $this->admin->refresh();
-    expect($this->admin->role)->toBe('admin');
+    expect($this->admin->super_admin)->toBeTrue();
 });
 
-test('can change admin to non-admin when multiple admins exist', function () {
+test('can demote super admin when multiple exist', function () {
     actingAs($this->admin);
 
-    $anotherAdmin = User::factory()->create(['role' => 'admin']);
-
-    expect(User::where('role', 'admin')->count())->toBe(2);
+    $anotherAdmin = User::factory()->superAdmin()->create();
+    expect(User::where('super_admin', true)->count())->toBe(2);
 
     Livewire::test(Edit::class, ['user' => $anotherAdmin])
-        ->set('form.role', 'member')
+        ->set('form.role', UserRole::Member->value)
         ->call('save')
         ->assertRedirect(route('users.index'));
 
     $anotherAdmin->refresh();
-    expect($anotherAdmin->role)->toBe('member');
+    expect($anotherAdmin->roleIn(Organization::main()))->toBe(UserRole::Member);
 });
 
 test('can promote user to admin', function () {
     actingAs($this->admin);
 
-    $member = User::factory()->create(['role' => 'member']);
+    $member = User::factory()->create(['role' => UserRole::Member]);
 
     Livewire::test(Edit::class, ['user' => $member])
-        ->set('form.role', 'admin')
+        ->set('form.role', UserRole::Admin->value)
         ->call('save')
         ->assertRedirect(route('users.index'));
 
     $member->refresh();
-    expect($member->role)->toBe('admin');
+    expect($member->roleIn(Organization::main()))->toBe(UserRole::Admin);
+});
+
+test('oauth user email field is disabled', function () {
+    actingAs($this->admin);
+
+    $user = User::factory()->create();
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'google',
+        'provider_user_id' => 'oauth-123',
+        'email' => $user->email,
+    ]);
+
+    Livewire::test(Edit::class, ['user' => $user])
+        ->assertSee(__('Email cannot be changed for SSO/OAuth users.'));
+});
+
+test('oauth user email is not updated on save', function () {
+    actingAs($this->admin);
+
+    $user = User::factory()->create([
+        'name' => 'OAuth User',
+        'email' => 'oauth@example.com',
+    ]);
+    OAuthIdentity::create([
+        'user_id' => $user->id,
+        'provider' => 'oidc',
+        'provider_user_id' => 'oauth-456',
+        'email' => $user->email,
+    ]);
+
+    Livewire::test(Edit::class, ['user' => $user])
+        ->set('form.name', 'Updated Name')
+        ->set('form.email', 'hacked@example.com')
+        ->call('save')
+        ->assertRedirect(route('users.index'));
+
+    $user->refresh();
+    expect($user->name)->toBe('Updated Name')
+        ->and($user->email)->toBe('oauth@example.com');
 });

--- a/tests/Feature/User/IndexTest.php
+++ b/tests/Feature/User/IndexTest.php
@@ -1,17 +1,43 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Livewire\User\Index;
+use App\Models\Organization;
 use App\Models\User;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
-use function Pest\Laravel\get;
 
 beforeEach(function () {
-    $this->admin = User::factory()->create(['role' => 'admin']);
+    $this->admin = User::factory()->superAdmin()->create();
 });
 
-test('displays users in table', function () {
+describe('access control', function () {
+    test('super admin can access user index', function () {
+        actingAs($this->admin);
+
+        Livewire::test(Index::class)
+            ->assertOk();
+    });
+
+    test('org admin can access user index', function () {
+        $orgAdmin = User::factory()->admin()->create();
+        actingAs($orgAdmin);
+
+        Livewire::test(Index::class)
+            ->assertOk();
+    });
+
+    test('non-admin cannot access user index', function (string $role) {
+        $user = User::factory()->create(['role' => $role]);
+        actingAs($user);
+
+        Livewire::test(Index::class)
+            ->assertForbidden();
+    })->with(['member', 'viewer']);
+});
+
+test('displays users in current organization', function () {
     actingAs($this->admin);
 
     User::factory()->create(['name' => 'John Doe']);
@@ -34,88 +60,128 @@ test('can search users by name', function () {
         ->assertDontSee('Jane Smith');
 });
 
-test('admin can delete another user', function () {
-    actingAs($this->admin);
+describe('delete', function () {
+    test('delete authorization', function (string $actorType, bool $targetSuperAdmin, int $targetOrgCount, bool $allowed) {
+        $actor = $actorType === 'super_admin'
+            ? $this->admin
+            : User::factory()->admin()->create();
 
-    $userToDelete = User::factory()->create(['name' => 'Delete Me']);
+        $target = $targetSuperAdmin
+            ? User::factory()->superAdmin()->create()
+            : User::factory()->create();
 
-    Livewire::test(Index::class)
-        ->call('confirmDelete', $userToDelete->id)
-        ->assertSet('showDeleteModal', true)
-        ->call('delete')
-        ->assertSet('showDeleteModal', false);
+        if ($targetOrgCount > 1) {
+            $secondOrg = Organization::factory()->create();
+            $target->organizations()->attach($secondOrg->id, ['role' => UserRole::Member]);
+        }
 
-    expect(User::find($userToDelete->id))->toBeNull();
-});
+        actingAs($actor);
 
-test('admin cannot delete themselves', function () {
-    actingAs($this->admin);
+        $component = Livewire::test(Index::class)
+            ->call('confirmDelete', $target->id);
 
-    Livewire::test(Index::class)
-        ->call('confirmDelete', $this->admin->id)
-        ->assertForbidden();
-});
-
-test('admin cannot delete the last admin', function () {
-    actingAs($this->admin);
-
-    // Ensure this is the only admin
-    expect(User::where('role', 'admin')->count())->toBe(1);
-
-    // Create another admin to delete, then delete them to get back to 1 admin
-    $anotherAdmin = User::factory()->create(['role' => 'admin', 'name' => 'Another Admin']);
-
-    // Delete the other admin (should work)
-    Livewire::test(Index::class)
-        ->call('confirmDelete', $anotherAdmin->id)
-        ->call('delete');
-
-    expect(User::find($anotherAdmin->id))->toBeNull();
-
-    // Now try to delete the last admin - should fail on authorize
-    // We need to create another user to try from (but they need to be admin)
-    // Actually, the test should verify you can't delete when count = 1
-});
-
-test('admin can copy invitation link for pending user', function () {
-    actingAs($this->admin);
-
-    $pendingUser = User::factory()->create([
-        'name' => 'Pending User',
-        'invitation_token' => 'test-token-123',
-        'invitation_accepted_at' => null,
+        if ($allowed) {
+            $component->assertSet('showDeleteModal', true)
+                ->call('delete')
+                ->assertSet('showDeleteModal', false);
+            expect(User::find($target->id))->toBeNull();
+        } else {
+            $component->assertForbidden();
+        }
+    })->with([
+        'super admin deletes regular user (1 org)' => ['super_admin', false, 1, true],
+        'super admin deletes regular user (2 orgs)' => ['super_admin', false, 2, true],
+        'super admin deletes super admin (not last)' => ['super_admin', true, 1, true],
+        'org admin deletes regular user (1 org)' => ['admin', false, 1, true],
+        'org admin cannot delete user in multiple orgs' => ['admin', false, 2, false],
+        'org admin cannot delete super admin' => ['admin', true, 1, false],
     ]);
 
-    Livewire::test(Index::class)
-        ->call('copyInvitationLink', $pendingUser->id)
-        ->assertSet('showCopyModal', true)
-        ->assertSet('invitationUrl', route('invitation.accept', 'test-token-123'));
+    test('cannot delete yourself', function () {
+        actingAs($this->admin);
+
+        Livewire::test(Index::class)
+            ->call('confirmDelete', $this->admin->id)
+            ->assertForbidden();
+    });
 });
 
-test('non-admin cannot delete users', function () {
-    $member = User::factory()->create(['role' => 'member']);
-    actingAs($member);
+describe('remove from organization', function () {
+    test('remove from org authorization', function (string $actorType, bool $targetSuperAdmin, int $targetOrgCount, bool $allowed) {
+        $actor = $actorType === 'super_admin'
+            ? $this->admin
+            : User::factory()->admin()->create();
 
-    $userToDelete = User::factory()->create();
+        $target = $targetSuperAdmin
+            ? User::factory()->superAdmin()->create()
+            : User::factory()->create();
 
-    Livewire::test(Index::class)
-        ->call('confirmDelete', $userToDelete->id)
-        ->assertForbidden();
+        if ($targetOrgCount > 1) {
+            $secondOrg = Organization::factory()->create();
+            $target->organizations()->attach($secondOrg->id, ['role' => UserRole::Member]);
+        }
+
+        actingAs($actor);
+
+        $component = Livewire::test(Index::class)
+            ->call('confirmRemoveFromOrg', $target->id);
+
+        if ($allowed) {
+            $component->assertSet('showRemoveModal', true)
+                ->call('removeFromOrg')
+                ->assertSet('showRemoveModal', false);
+
+            // User still exists but is no longer in the current org
+            expect(User::find($target->id))->not->toBeNull();
+            $currentOrgId = app(\App\Services\CurrentOrganization::class)->id();
+            expect($target->fresh()->organizations()->where('organization_id', $currentOrgId)->exists())->toBeFalse();
+        } else {
+            $component->assertForbidden();
+        }
+    })->with([
+        'super admin removes user (2 orgs)' => ['super_admin', false, 2, true],
+        'org admin removes user (2 orgs)' => ['admin', false, 2, true],
+        'cannot remove user in single org (super admin)' => ['super_admin', false, 1, false],
+        'cannot remove user in single org (org admin)' => ['admin', false, 1, false],
+        'org admin cannot remove super admin' => ['admin', true, 2, false],
+    ]);
+
+    test('cannot remove yourself from org', function () {
+        actingAs($this->admin);
+
+        Livewire::test(Index::class)
+            ->call('confirmRemoveFromOrg', $this->admin->id)
+            ->assertForbidden();
+    });
 });
 
-test('viewer can access user index but cannot perform actions', function () {
-    $viewer = User::factory()->create(['role' => 'viewer']);
-    actingAs($viewer);
+describe('invitation link', function () {
+    test('super admin can copy invitation link for pending user', function () {
+        actingAs($this->admin);
 
-    $someUser = User::factory()->create();
+        $pendingUser = User::factory()->create([
+            'invitation_token' => 'test-token-123',
+            'invitation_accepted_at' => null,
+        ]);
 
-    // Can view index
-    Livewire::test(Index::class)
-        ->assertOk()
-        ->assertSee($someUser->name);
+        Livewire::test(Index::class)
+            ->call('copyInvitationLink', $pendingUser->id)
+            ->assertSet('showCopyModal', true)
+            ->assertSet('invitationUrl', route('invitation.accept', 'test-token-123'));
+    });
 
-    // Cannot delete
-    Livewire::test(Index::class)
-        ->call('confirmDelete', $someUser->id)
-        ->assertForbidden();
+    test('org admin can copy invitation link for pending user in their org', function () {
+        $orgAdmin = User::factory()->admin()->create();
+        actingAs($orgAdmin);
+
+        $pendingUser = User::factory()->create([
+            'invitation_token' => 'test-token-456',
+            'invitation_accepted_at' => null,
+        ]);
+
+        Livewire::test(Index::class)
+            ->call('copyInvitationLink', $pendingUser->id)
+            ->assertSet('showCopyModal', true)
+            ->assertSet('invitationUrl', route('invitation.accept', 'test-token-456'));
+    });
 });

--- a/tests/Feature/User/IndexTest.php
+++ b/tests/Feature/User/IndexTest.php
@@ -61,7 +61,7 @@ test('can search users by name', function () {
 });
 
 describe('delete', function () {
-    test('delete authorization', function (string $actorType, bool $targetSuperAdmin, int $targetOrgCount, bool $allowed) {
+    test('delete authorization', function (string $actorType, bool $targetSuperAdmin, int $targetOrgCount, string $expected) {
         $actor = $actorType === 'super_admin'
             ? $this->admin
             : User::factory()->admin()->create();
@@ -80,21 +80,29 @@ describe('delete', function () {
         $component = Livewire::test(Index::class)
             ->call('confirmDelete', $target->id);
 
-        if ($allowed) {
-            $component->assertSet('showDeleteModal', true)
-                ->call('delete')
-                ->assertSet('showDeleteModal', false);
-            expect(User::find($target->id))->toBeNull();
-        } else {
-            $component->assertForbidden();
-        }
+        match ($expected) {
+            'allowed' => tap($component, function ($c) use ($target) {
+                $c->assertSet('showDeleteModal', true)
+                    ->assertSet('deleteBlockReason', '')
+                    ->call('delete')
+                    ->assertSet('showDeleteModal', false);
+                expect(User::find($target->id))->toBeNull();
+            }),
+            'forbidden' => $component->assertForbidden(),
+            'blocked' => tap($component, function ($c) use ($target) {
+                $c->assertSet('showDeleteModal', true)
+                    ->assertNotSet('deleteBlockReason', '');
+                $c->call('delete');
+                expect(User::find($target->id))->not->toBeNull();
+            }),
+        };
     })->with([
-        'super admin deletes regular user (1 org)' => ['super_admin', false, 1, true],
-        'super admin deletes regular user (2 orgs)' => ['super_admin', false, 2, true],
-        'super admin deletes super admin (not last)' => ['super_admin', true, 1, true],
-        'org admin deletes regular user (1 org)' => ['admin', false, 1, true],
-        'org admin cannot delete user in multiple orgs' => ['admin', false, 2, false],
-        'org admin cannot delete super admin' => ['admin', true, 1, false],
+        'super admin deletes regular user (1 org)' => ['super_admin', false, 1, 'allowed'],
+        'super admin deletes regular user (2 orgs)' => ['super_admin', false, 2, 'allowed'],
+        'super admin deletes super admin (not last)' => ['super_admin', true, 1, 'allowed'],
+        'org admin deletes regular user (1 org)' => ['admin', false, 1, 'allowed'],
+        'org admin blocked from deleting user in multiple orgs' => ['admin', false, 2, 'blocked'],
+        'org admin cannot delete super admin' => ['admin', true, 1, 'forbidden'],
     ]);
 
     test('cannot delete yourself', function () {
@@ -107,7 +115,7 @@ describe('delete', function () {
 });
 
 describe('remove from organization', function () {
-    test('remove from org authorization', function (string $actorType, bool $targetSuperAdmin, int $targetOrgCount, bool $allowed) {
+    test('remove from org authorization', function (string $actorType, bool $targetSuperAdmin, int $targetOrgCount, string $expected) {
         $actor = $actorType === 'super_admin'
             ? $this->admin
             : User::factory()->admin()->create();
@@ -126,24 +134,31 @@ describe('remove from organization', function () {
         $component = Livewire::test(Index::class)
             ->call('confirmRemoveFromOrg', $target->id);
 
-        if ($allowed) {
-            $component->assertSet('showRemoveModal', true)
-                ->call('removeFromOrg')
-                ->assertSet('showRemoveModal', false);
+        $currentOrgId = app(\App\Services\CurrentOrganization::class)->id();
 
-            // User still exists but is no longer in the current org
-            expect(User::find($target->id))->not->toBeNull();
-            $currentOrgId = app(\App\Services\CurrentOrganization::class)->id();
-            expect($target->fresh()->organizations()->where('organization_id', $currentOrgId)->exists())->toBeFalse();
-        } else {
-            $component->assertForbidden();
-        }
+        match ($expected) {
+            'allowed' => tap($component, function ($c) use ($target, $currentOrgId) {
+                $c->assertSet('showRemoveModal', true)
+                    ->assertSet('removeBlockReason', '')
+                    ->call('removeFromOrg')
+                    ->assertSet('showRemoveModal', false);
+                expect(User::find($target->id))->not->toBeNull();
+                expect($target->fresh()->organizations()->where('organization_id', $currentOrgId)->exists())->toBeFalse();
+            }),
+            'forbidden' => $component->assertForbidden(),
+            'blocked' => tap($component, function ($c) use ($target, $currentOrgId) {
+                $c->assertSet('showRemoveModal', true)
+                    ->assertNotSet('removeBlockReason', '');
+                $c->call('removeFromOrg');
+                expect($target->fresh()->organizations()->where('organization_id', $currentOrgId)->exists())->toBeTrue();
+            }),
+        };
     })->with([
-        'super admin removes user (2 orgs)' => ['super_admin', false, 2, true],
-        'org admin removes user (2 orgs)' => ['admin', false, 2, true],
-        'cannot remove user in single org (super admin)' => ['super_admin', false, 1, false],
-        'cannot remove user in single org (org admin)' => ['admin', false, 1, false],
-        'org admin cannot remove super admin' => ['admin', true, 2, false],
+        'super admin removes user (2 orgs)' => ['super_admin', false, 2, 'allowed'],
+        'org admin removes user (2 orgs)' => ['admin', false, 2, 'allowed'],
+        'super admin blocked from removing user in single org' => ['super_admin', false, 1, 'blocked'],
+        'org admin blocked from removing user in single org' => ['admin', false, 1, 'blocked'],
+        'org admin cannot remove super admin' => ['admin', true, 2, 'forbidden'],
     ]);
 
     test('cannot remove yourself from org', function () {

--- a/tests/Feature/Volume/VolumeTest.php
+++ b/tests/Feature/Volume/VolumeTest.php
@@ -204,11 +204,13 @@ describe('volume listing', function () {
             'name' => 'Local Volume',
             'type' => 'local',
             'config' => ['path' => '/var/backups'],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
         Volume::create([
             'name' => 'S3 Volume',
             'type' => 's3',
             'config' => ['bucket' => 'my-bucket', 'prefix' => ''],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         Livewire::actingAs($user)
@@ -225,11 +227,13 @@ describe('volume listing', function () {
             'name' => 'Production Volume',
             'type' => 'local',
             'config' => ['path' => '/var/backups'],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
         Volume::create([
             'name' => 'Development Volume',
             'type' => 's3',
             'config' => ['bucket' => 'dev-bucket', 'prefix' => ''],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         Livewire::actingAs($user)
@@ -247,6 +251,7 @@ describe('volume deletion', function () {
             'name' => 'Volume to Delete',
             'type' => 'local',
             'config' => ['path' => '/var/backups'],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         Livewire::actingAs($user)
@@ -400,6 +405,7 @@ describe('volume immutability', function () {
             'name' => 'Empty Volume',
             'type' => 'local',
             'config' => ['path' => '/var/backups'],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         // Verify volume has no snapshots
@@ -443,6 +449,7 @@ describe('connection testing', function () {
                 'password' => Crypt::encryptString('secret-password'),
                 'root' => '/uploads',
             ],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         // Mock the FilesystemProvider to verify the volume receives merged password

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,12 +16,18 @@ use App\Support\FilesystemSupport;
 
 pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->beforeEach(fn () => dailySchedule())
+    ->beforeEach(function () {
+        dailySchedule();
+        setupOrgContext();
+    })
     ->in('Feature');
 
 pest()->extend(Tests\TestCase::class)
     ->use(Illuminate\Foundation\Testing\RefreshDatabase::class)
-    ->beforeEach(fn () => dailySchedule())
+    ->beforeEach(function () {
+        dailySchedule();
+        setupOrgContext();
+    })
     ->group('integration')
     ->in('Integration');
 
@@ -86,6 +92,23 @@ expect()->extend('toBeOne', function () {
 | global functions to help you to reduce the number of lines of code in your test files.
 |
 */
+
+/**
+ * Create the main organization and set it as the current org context.
+ * This ensures OrganizationScope and CurrentOrganization work in tests.
+ */
+function setupOrgContext(): \App\Models\Organization
+{
+    $org = \App\Models\Organization::firstOrCreate(
+        ['is_main' => true],
+        ['name' => 'Main'],
+    );
+
+    $currentOrg = app(\App\Services\CurrentOrganization::class);
+    $currentOrg->set($org);
+
+    return $org;
+}
 
 function dailySchedule(): \App\Models\BackupSchedule
 {

--- a/tests/Support/IntegrationTestHelpers.php
+++ b/tests/Support/IntegrationTestHelpers.php
@@ -98,6 +98,7 @@ class IntegrationTestHelpers
             'name' => "Integration Test Volume ({$type})",
             'type' => 'local',
             'config' => ['root' => $storageDir],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
     }
 
@@ -119,6 +120,7 @@ class IntegrationTestHelpers
                 'root' => '/config/backups',
                 'timeout' => 10,
             ],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
     }
 
@@ -145,6 +147,7 @@ class IntegrationTestHelpers
             $serverData['extra_config'] = ['auth_source' => $config['auth_source']];
         }
 
+        $serverData['organization_id'] = \App\Models\Organization::first()->id;
         $server = DatabaseServer::create($serverData);
         $server->pendingBackupState['database_names'] = [$config['database']];
 
@@ -278,6 +281,7 @@ class IntegrationTestHelpers
             'username' => $config['username'],
             'password' => $config['password'],
             'description' => 'Integration test Redis server',
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
     }
 
@@ -307,6 +311,7 @@ class IntegrationTestHelpers
             'name' => 'Integration Test SQLite Server',
             'database_type' => 'sqlite',
             'description' => 'Integration test SQLite database',
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         $server->pendingBackupState['database_names'] = [$sqlitePath];
@@ -369,6 +374,7 @@ class IntegrationTestHelpers
             'username' => $ssh['username'],
             'auth_type' => 'password',
             'password' => $ssh['password'],
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
     }
 
@@ -401,6 +407,7 @@ class IntegrationTestHelpers
             'password' => $dbConfig['password'],
             'description' => "Integration test {$type} database server via SSH tunnel",
             'ssh_config_id' => $sshConfig->id,
+            'organization_id' => \App\Models\Organization::first()->id,
         ]);
         $server->pendingBackupState['database_names'] = [$dbConfig['database']];
 


### PR DESCRIPTION
## Summary

Adds multi-organization (multi-tenant) support to Databasement. Each organization has its own isolated set of resources (database servers, volumes, agents, backup jobs, snapshots), with role-based access control at the organization level.

### Key changes

- **Database schema**: 3-step migration (create tables → backfill existing data into default org → finalize with non-nullable FKs and drop legacy role column)
- **Multi-tenancy runtime**: `CurrentOrganization` service + `SetCurrentOrganization` middleware automatically scope all queries to the active org via Eloquent global scopes
- **Organization management UI**: Configuration page for CRUD operations on orgs, invitation links, and an org switcher in the sidebar
- **User management rework**: Org-scoped user listing, org admin role (can manage users within their org), user removal vs deletion distinction
- **OAuth/SSO integration**: New OAuth users are assigned to an org (via invitation link or default), profile settings adapted for OAuth users
- **Org scope on all features**: Dashboard, queries, forms, API controllers, jobs, and services all respect the current org context
- **API & MCP**: New endpoints to list user organizations, switch org context via header, and MCP tool for org listing
- **Roles**: `UserRole` enum (`super_admin`, `admin`, `member`) replaces the old boolean `is_admin` — org admins manage their org, super admins manage everything

### Commit breakdown

1. `feat: add organization database schema, model, and core enums` — migrations, Organization model, OrganizationScope, factory, UserRole enum, seeder
2. `feat: add multi-tenancy runtime infrastructure and model scoping` — CurrentOrganization service, middleware, providers, User model, all model scopes, factories, test helpers
3. `feat: add organization management UI and context switching` — config page, switcher, policy, layout, routes, tests
4. `feat: update user management for multi-organization support` — UserPolicy, UserForm, CRUD components, views, tests
5. `feat: update OAuth, auth flows, and user settings for organizations` — OAuthService, settings components, auth/settings tests
6. `feat: apply organization scope to existing features and update tests` — dashboards, queries, forms, controllers, jobs, services, all affected tests
7. `feat: add organization API endpoints and MCP tools` — API controller, resource, MCP tool, routes, API/MCP tests
8. `chore: update docs, translations, and infrastructure for multi-org` — docs, i18n, docker, npm deps, pagination view

## Test plan

- [ ] All existing tests pass with organization context (parallel test suite)
- [ ] New org CRUD tests (create, edit, delete, invitation links)
- [ ] Org switcher test (switching context updates session)
- [ ] User management tests (org-scoped listing, role assignment, removal vs deletion)
- [ ] OAuth tests (org assignment on first login, invitation link flow)
- [ ] API tests (org context isolation, cross-org access denied, org listing endpoint)
- [ ] MCP tests (list organizations tool)
- [ ] Migration is safe: backfill runs in a transaction, existing data is preserved