### PR TITLE
Fix theme flash during Livewire SPA navigation

### DIFF
--- a/resources/views/layouts/_theme-init.blade.php
+++ b/resources/views/layouts/_theme-init.blade.php
@@ -1,11 +1,18 @@
 <meta name="theme-legacy" content="{{ request()->cookie('theme', '') }}">
 <script>
+    function safeGetItem(key) {
+        try { return localStorage.getItem(key); } catch (e) { return null; }
+    }
+    function safeSetItem(key, value) {
+        try { localStorage.setItem(key, value); } catch (e) {}
+    }
+
     function getTheme() {
         var legacy = document.querySelector('meta[name="theme-legacy"]');
-        if (legacy && legacy.content && !localStorage.getItem('theme')) {
-            localStorage.setItem('theme', legacy.content);
+        if (legacy && legacy.content && !safeGetItem('theme')) {
+            safeSetItem('theme', legacy.content);
         }
-        return localStorage.getItem('theme') ||
+        return safeGetItem('theme') ||
             (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
     }
 

--- a/resources/views/layouts/_theme-init.blade.php
+++ b/resources/views/layouts/_theme-init.blade.php
@@ -1,14 +1,26 @@
 <meta name="theme-legacy" content="{{ request()->cookie('theme', '') }}">
 <script>
-    function applyTheme() {
+    function getTheme() {
         var legacy = document.querySelector('meta[name="theme-legacy"]');
         if (legacy && legacy.content && !localStorage.getItem('theme')) {
             localStorage.setItem('theme', legacy.content);
         }
-        var theme = localStorage.getItem('theme') ||
+        return localStorage.getItem('theme') ||
             (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-        document.documentElement.setAttribute('data-theme', theme);
     }
+
+    function applyTheme() {
+        document.documentElement.setAttribute('data-theme', getTheme());
+    }
+
     applyTheme();
+
+    // Re-apply theme instantly when Livewire's DOM morph removes/changes data-theme
+    new MutationObserver(function () {
+        if (document.documentElement.getAttribute('data-theme') !== getTheme()) {
+            applyTheme();
+        }
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+
     document.addEventListener('livewire:navigated', applyTheme);
 </script>


### PR DESCRIPTION
## Summary
- Fixes a brief flash of the wrong theme (dark→light) when navigating between pages using Livewire's SPA mode
- Adds a `MutationObserver` on `<html>` that instantly re-applies the correct `data-theme` whenever Livewire's DOM morph resets it
- Extracts theme resolution into a `getTheme()` function used by both the observer and `livewire:navigated` handler

## Test plan
- [ ] Set theme to "light" in a browser that defaults to dark
- [ ] Navigate between pages using sidebar/links — verify no flash of dark theme
- [ ] Switch to dark theme and repeat — verify no flash of light theme
- [ ] Verify system preference fallback still works (clear localStorage theme)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme persistence and reliable re-application during dynamic DOM updates by observing theme attribute changes.
  * Safer handling of stored theme values to avoid errors when accessing browser storage.

* **Refactor**
  * Simplified and centralized theme initialization and application logic for greater reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->