### PR TITLE
Rename primary organization from "Main" to "Default"

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -48,10 +48,10 @@ class CreateNewUser implements CreatesNewUsers
 
         $createDemoBackup = ! empty($input['create_demo_backup']);
 
-        // Ensure main org exists (migration creates it, but handle fresh install)
-        $mainOrg = Organization::firstOrCreate(
-            ['is_main' => true],
-            ['name' => 'Main']
+        // Ensure default org exists (migration creates it, but handle fresh install)
+        $defaultOrg = Organization::firstOrCreate(
+            ['is_default' => true],
+            ['name' => 'Default']
         );
 
         // First user is always super_admin
@@ -64,7 +64,7 @@ class CreateNewUser implements CreatesNewUsers
         ]);
 
         // Attach to main org as admin
-        $user->organizations()->attach($mainOrg->id, ['role' => UserRole::Admin->value]);
+        $user->organizations()->attach($defaultOrg->id, ['role' => UserRole::Admin->value]);
 
         if ($createDemoBackup) {
             try {

--- a/app/Http/Middleware/DemoModeMiddleware.php
+++ b/app/Http/Middleware/DemoModeMiddleware.php
@@ -64,7 +64,7 @@ class DemoModeMiddleware
         );
 
         $user->organizations()->syncWithoutDetaching([
-            Organization::main()->id => ['role' => UserRole::Demo->value],
+            Organization::default()->id => ['role' => UserRole::Demo->value],
         ]);
     }
 }

--- a/app/Http/Resources/OrganizationResource.php
+++ b/app/Http/Resources/OrganizationResource.php
@@ -21,7 +21,7 @@ class OrganizationResource extends JsonResource
         return [
             'id' => $this->id,
             'name' => $this->name,
-            'is_main' => $this->is_main,
+            'is_default' => $this->is_default,
             'role' => $this->whenPivotLoaded('organization_user', fn () => $this->pivot->role), // @phpstan-ignore property.notFound
         ];
     }

--- a/app/Livewire/Configuration/Organization.php
+++ b/app/Livewire/Configuration/Organization.php
@@ -51,7 +51,7 @@ class Organization extends Component
             'volumes' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
             'agents' => fn ($q) => $q->withoutGlobalScope(OrganizationScope::class),
         ])
-            ->orderByDesc('is_main')
+            ->orderByDesc('is_default')
             ->orderBy('name')
             ->get();
     }

--- a/app/Livewire/OrganizationSwitcher.php
+++ b/app/Livewire/OrganizationSwitcher.php
@@ -39,10 +39,10 @@ class OrganizationSwitcher extends Component
         $user = auth()->user();
 
         if ($user->isSuperAdmin()) {
-            return Organization::orderByDesc('is_main')->orderBy('name')->get(['id', 'name'])->toArray();
+            return Organization::orderByDesc('is_default')->orderBy('name')->get(['id', 'name'])->toArray();
         }
 
-        return $user->organizations()->orderByDesc('organizations.is_main')->orderBy('organizations.name')->get(['organizations.id', 'organizations.name'])->toArray();
+        return $user->organizations()->orderByDesc('organizations.is_default')->orderBy('organizations.name')->get(['organizations.id', 'organizations.name'])->toArray();
     }
 
     public function render(): View

--- a/app/Mcp/Tools/ListOrganizationsTool.php
+++ b/app/Mcp/Tools/ListOrganizationsTool.php
@@ -31,7 +31,7 @@ class ListOrganizationsTool extends Tool
             $active = $org->id === $currentOrgId ? ' **(active)**' : '';
             $role = $org->pivot->role ?? 'unknown';
 
-            return "- **{$org->name}** (ID: {$org->id}){$active}\n  Role: {$role}".($org->is_main ? ' | Main organization' : '');
+            return "- **{$org->name}** (ID: {$org->id}){$active}\n  Role: {$role}".($org->is_default ? ' | Default organization' : '');
         });
 
         return Response::text("Your Organizations ({$orgs->count()}):\n\n".implode("\n\n", $lines->all()));

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Carbon;
 /**
  * @property string $id
  * @property string $name
- * @property bool $is_main
+ * @property bool $is_default
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Collection<int, User> $users
@@ -44,13 +44,13 @@ class Organization extends Model
 
     protected $fillable = [
         'name',
-        'is_main',
+        'is_default',
     ];
 
     protected function casts(): array
     {
         return [
-            'is_main' => 'boolean',
+            'is_default' => 'boolean',
         ];
     }
 
@@ -95,11 +95,11 @@ class Organization extends Model
     }
 
     /**
-     * Get the main organization.
+     * Get the default organization.
      */
-    public static function main(): self
+    public static function default(): self
     {
-        return static::where('is_main', true)->firstOrFail();
+        return static::where('is_default', true)->firstOrFail();
     }
 
     /**

--- a/app/Policies/OrganizationPolicy.php
+++ b/app/Policies/OrganizationPolicy.php
@@ -34,13 +34,13 @@ class OrganizationPolicy
             return false;
         }
 
-        // Main org name cannot be changed
-        return ! $organization->is_main;
+        // Default org name cannot be changed
+        return ! $organization->is_default;
     }
 
     /**
      * Determine whether the user can delete the organization.
-     * Only super admins can delete non-main orgs.
+     * Only super admins can delete non-default orgs.
      */
     public function delete(User $user, Organization $organization): bool
     {
@@ -48,6 +48,6 @@ class OrganizationPolicy
             return false;
         }
 
-        return ! $organization->is_main;
+        return ! $organization->is_default;
     }
 }

--- a/app/Services/CurrentOrganization.php
+++ b/app/Services/CurrentOrganization.php
@@ -115,9 +115,9 @@ class CurrentOrganization
             return;
         }
 
-        // 3. Super admins with no membership fall back to main org
+        // 3. Super admins with no membership fall back to default org
         if ($user->isSuperAdmin()) {
-            $this->switchTo(Organization::main());
+            $this->switchTo(Organization::default());
 
             return;
         }

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -219,7 +219,7 @@ class OAuthService
             }
         }
 
-        return Organization::main();
+        return Organization::default();
     }
 
     /**

--- a/database/factories/AgentFactory.php
+++ b/database/factories/AgentFactory.php
@@ -19,7 +19,7 @@ class AgentFactory extends Factory
     {
         return [
             'name' => fake()->company().' Agent',
-            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->default(),
         ];
     }
 

--- a/database/factories/DatabaseServerFactory.php
+++ b/database/factories/DatabaseServerFactory.php
@@ -33,7 +33,7 @@ class DatabaseServerFactory extends Factory
             'description' => fake()->optional()->sentence(),
             'notification_trigger' => 'failure',
             'notification_channel_selection' => 'all',
-            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->default(),
         ];
     }
 

--- a/database/factories/DatabaseServerSshConfigFactory.php
+++ b/database/factories/DatabaseServerSshConfigFactory.php
@@ -25,7 +25,7 @@ class DatabaseServerSshConfigFactory extends Factory
             'password' => 'ssh_password',
             'private_key' => null,
             'key_passphrase' => null,
-            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->default(),
         ];
     }
 

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -18,18 +18,18 @@ class OrganizationFactory extends Factory
     {
         return [
             'name' => fake()->unique()->company(),
-            'is_main' => false,
+            'is_default' => false,
         ];
     }
 
     /**
-     * Configure the organization as the main organization.
+     * Configure the organization as the default organization.
      */
-    public function main(): static
+    public function default(): static
     {
         return $this->state(fn () => [
-            'name' => 'Main',
-            'is_main' => true,
+            'name' => 'Default',
+            'is_default' => true,
         ]);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -69,7 +69,7 @@ class UserFactory extends Factory
     public function configure(): static
     {
         return $this->afterCreating(function (User $user) {
-            $org = rescue(fn () => Organization::main(), fn () => Organization::factory()->main()->create());
+            $org = rescue(fn () => Organization::default(), fn () => Organization::factory()->default()->create());
             $role = $user->pendingPivotRole ?? UserRole::Member;
             $user->pendingPivotRole = null;
 

--- a/database/factories/VolumeFactory.php
+++ b/database/factories/VolumeFactory.php
@@ -23,7 +23,7 @@ class VolumeFactory extends Factory
             'config' => [
                 'path' => $this->createTempDirectory(),
             ],
-            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->main(),
+            'organization_id' => fn () => Organization::first()?->id ?? Organization::factory()->default(),
         ];
     }
 

--- a/database/migrations/2026_05_07_000001_rename_main_to_default_organization.php
+++ b/database/migrations/2026_05_07_000001_rename_main_to_default_organization.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->renameColumn('is_main', 'is_default');
+        });
+
+        DB::table('organizations')->where('is_default', true)->update(['name' => 'Default']);
+    }
+
+    public function down(): void
+    {
+        DB::table('organizations')->where('is_default', true)->update(['name' => 'Main']);
+
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->renameColumn('is_default', 'is_main');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,10 +17,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // Main organization
-        $mainOrg = Organization::firstOrCreate(
-            ['is_main' => true],
-            ['name' => 'Main'],
+        // Default organization
+        $defaultOrg = Organization::firstOrCreate(
+            ['is_default' => true],
+            ['name' => 'Default'],
         );
 
         // Users (all with password "password", no 2FA)
@@ -44,7 +44,7 @@ class DatabaseSeeder extends Seeder
             'name' => 'Local',
             'type' => 'local',
             'config' => ['path' => '/data/backups'],
-            'organization_id' => $mainOrg->id,
+            'organization_id' => $defaultOrg->id,
         ]);
 
         $dailySchedule = BackupSchedule::firstOrCreate(
@@ -60,7 +60,7 @@ class DatabaseSeeder extends Seeder
             'database_type' => 'mysql',
             'username' => 'root',
             'password' => 'root',
-            'organization_id' => $mainOrg->id,
+            'organization_id' => $defaultOrg->id,
         ]);
 
         // PostgreSQL server (from docker-compose)
@@ -71,7 +71,7 @@ class DatabaseSeeder extends Seeder
             'database_type' => 'postgres',
             'username' => 'root',
             'password' => 'root',
-            'organization_id' => $mainOrg->id,
+            'organization_id' => $defaultOrg->id,
         ]);
 
         // SQLite server
@@ -85,7 +85,7 @@ class DatabaseSeeder extends Seeder
             'port' => 0,
             'username' => '',
             'password' => '',
-            'organization_id' => $mainOrg->id,
+            'organization_id' => $defaultOrg->id,
         ]);
 
         // Redis server (from docker-compose)
@@ -96,7 +96,7 @@ class DatabaseSeeder extends Seeder
             'database_type' => 'redis',
             'username' => '',
             'password' => '',
-            'organization_id' => $mainOrg->id,
+            'organization_id' => $defaultOrg->id,
         ]);
 
         // MongoDB server (from docker-compose)
@@ -108,7 +108,7 @@ class DatabaseSeeder extends Seeder
             'username' => 'root',
             'password' => 'root',
             'extra_config' => ['auth_source' => 'admin'],
-            'organization_id' => $mainOrg->id,
+            'organization_id' => $defaultOrg->id,
         ]);
 
         // Backup configurations (database_selection_mode lives on Backup now)

--- a/docs/docs/self-hosting/configuration/sso.md
+++ b/docs/docs/self-hosting/configuration/sso.md
@@ -140,7 +140,7 @@ OAUTH_DEFAULT_ROLE=member  # Options: viewer, member, admin
 
 ### Default Organization
 
-By default, auto-created OAuth users join the main organization. To assign them to a different organization instead, set:
+By default, auto-created OAuth users join the default organization. To assign them to a different organization instead, set:
 
 ```env
 OAUTH_DEFAULT_ORGANIZATION_ID=01JA2B3C4D5E6F7G8H9J0KMNPQ  # Organization ULID

--- a/docs/docs/user-guide/organizations.md
+++ b/docs/docs/user-guide/organizations.md
@@ -10,7 +10,7 @@ Databasement supports multi-organization setups, allowing you to isolate resourc
 
 - Every resource belongs to exactly one organization
 - Users can belong to multiple organizations with different roles in each
-- A **main organization** is created automatically on first install
+- A **default organization** is created automatically on first install
 - Super admins can create and manage additional organizations
 
 ## User Roles
@@ -40,7 +40,7 @@ Super admins can manage organizations from **Configuration > Organizations**:
 - Rename existing organizations
 - Delete empty organizations (all servers, volumes, and agents must be removed first)
 
-The main organization cannot be deleted or renamed. Organization names must be unique.
+The default organization cannot be renamed or deleted. Organization names must be unique.
 
 ## User Management
 
@@ -70,7 +70,7 @@ API requests target an organization using the `?org_id=` query parameter (by org
 GET /api/v1/database-servers?org_id=01JA2B3C4D5E6F7G8H9J0KMNPQ
 ```
 
-Alternatively, pass the `X-Organization-Id` header with the same value. If neither is provided, the main organization is used.
+Alternatively, pass the `X-Organization-Id` header with the same value. If neither is provided, the default organization is used.
 
 You can find the organization ID in **Configuration > Organizations**.
 
@@ -97,7 +97,7 @@ Agents belong to a single organization. They only execute jobs for servers withi
 
 ## OAuth / OIDC
 
-Auto-created OAuth users join the main organization by default. Set the `OAUTH_DEFAULT_ORGANIZATION_ID` environment variable to assign them to a different org instead.
+Auto-created OAuth users join the default organization by default. Set the `OAUTH_DEFAULT_ORGANIZATION_ID` environment variable to assign them to a different org instead.
 
 ## CLI Commands
 
@@ -107,6 +107,6 @@ Artisan commands (`backup:run`, `cleanup:snapshots`, `verify:files`) operate glo
 
 On first install:
 
-1. A **Main** organization is created automatically
-2. The first registered user becomes a super admin, attached to the main org as admin
+1. A **Default** organization is created automatically
+2. The first registered user becomes a super admin, attached to the default org as admin
 3. Additional organizations can be created from Configuration

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -21,13 +21,13 @@
             @scope('cell_name', $org)
                 <div class="flex items-center gap-2">
                     {{ $org->name }}
-                    @if($org->is_main)
+                    @if($org->is_default)
                         <x-popover>
                             <x-slot:trigger>
                                 <x-icon name="o-lock-closed" class="w-4 h-4 text-base-content/50 cursor-pointer" />
                             </x-slot:trigger>
                             <x-slot:content>
-                                {{ __('The main organization cannot be edited or deleted.') }}
+                                {{ __('The default organization cannot be edited or deleted.') }}
                             </x-slot:content>
                         </x-popover>
                     @endif
@@ -39,7 +39,7 @@
             @endscope
 
             @scope('cell_actions', $org)
-                @unless($org->is_main)
+                @unless($org->is_default)
                     <div class="text-right">
                         <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditModal('{{ $org->id }}')" :tooltip="__('Edit')" />
                         <x-button icon="o-trash" class="btn-ghost btn-xs text-error" wire:click="confirmDelete('{{ $org->id }}')" :tooltip="__('Delete')" />

--- a/tests/Feature/Api/OrganizationContextApiTest.php
+++ b/tests/Feature/Api/OrganizationContextApiTest.php
@@ -6,15 +6,15 @@ use App\Models\Organization;
 use App\Models\User;
 
 beforeEach(function () {
-    $this->mainOrg = Organization::main();
+    $this->defaultOrg = Organization::default();
     $this->otherOrg = Organization::factory()->create(['name' => 'Other Org']);
 });
 
 describe('org_id query parameter', function () {
-    test('defaults to main org when no org_id is provided', function () {
+    test('defaults to default org when no org_id is provided', function () {
         $user = User::factory()->create();
 
-        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->defaultOrg->id]);
         DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
 
         $response = $this->actingAs($user, 'sanctum')
@@ -28,7 +28,7 @@ describe('org_id query parameter', function () {
     test('org_id scopes resources to the specified organization', function () {
         $user = User::factory()->superAdmin()->create();
 
-        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->defaultOrg->id]);
         DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
 
         $response = $this->actingAs($user, 'sanctum')
@@ -73,7 +73,7 @@ describe('cross-org resource isolation', function () {
     test('user cannot see database servers from another organization', function () {
         $user = User::factory()->create();
 
-        DatabaseServer::factory()->create(['name' => 'My Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'My Server', 'organization_id' => $this->defaultOrg->id]);
         DatabaseServer::factory()->create(['name' => 'Their Server', 'organization_id' => $this->otherOrg->id]);
 
         $response = $this->actingAs($user, 'sanctum')
@@ -111,10 +111,10 @@ describe('cross-org resource isolation', function () {
         $user = User::factory()->create();
         $user->organizations()->attach($this->otherOrg->id, ['role' => UserRole::Member]);
 
-        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->mainOrg->id]);
+        DatabaseServer::factory()->create(['name' => 'Main Server', 'organization_id' => $this->defaultOrg->id]);
         DatabaseServer::factory()->create(['name' => 'Other Server', 'organization_id' => $this->otherOrg->id]);
 
-        // Default: main org
+        // Default: default org
         $this->actingAs($user, 'sanctum')
             ->getJson('/api/v1/database-servers')
             ->assertOk()

--- a/tests/Feature/Auth/OAuthTest.php
+++ b/tests/Feature/Auth/OAuthTest.php
@@ -79,7 +79,7 @@ test('oauth callback creates new user when email not found', function () {
     $user = User::where('email', 'newuser@example.com')->first();
     expect($user)->not->toBeNull()
         ->and($user->name)->toBe('New User')
-        ->and($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Member)
+        ->and($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Member)
         ->and($user->password)->toBeNull()
         ->and($user->email_verified_at)->not->toBeNull()
         ->and($user->invitation_accepted_at)->not->toBeNull();
@@ -117,7 +117,7 @@ test('oauth callback links to existing user by email and clears password', funct
 
     $existingUser->refresh();
     expect($existingUser->oauthIdentities)->toHaveCount(1)
-        ->and($existingUser->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin) // unchanged
+        ->and($existingUser->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin) // unchanged
         ->and($existingUser->password)->toBeNull(); // cleared to enforce OAuth-only login
 });
 
@@ -159,7 +159,7 @@ test('oauth uses configured default role for new users', function () {
     $this->get(route('oauth.callback', 'github'));
 
     $user = User::where('email', 'viewer@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Viewer);
 });
 
 test('oauth callback fails when auto-create is disabled and no matching user', function () {
@@ -269,7 +269,7 @@ test('oidc role mapping assigns admin role from matching group', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'admin@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping assigns member role from matching group', function () {
@@ -281,7 +281,7 @@ test('oidc role mapping assigns member role from matching group', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'member@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Member);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Member);
 });
 
 test('oidc role mapping assigns viewer role from matching group', function () {
@@ -293,7 +293,7 @@ test('oidc role mapping assigns viewer role from matching group', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'viewer@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping uses highest priority role when multiple groups match', function () {
@@ -306,7 +306,7 @@ test('oidc role mapping uses highest priority role when multiple groups match', 
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'multi@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping falls back to default role when no group matches and strict is off', function () {
@@ -319,7 +319,7 @@ test('oidc role mapping falls back to default role when no group matches and str
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'fallback@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping denies access when no group matches and strict is on', function () {
@@ -353,7 +353,7 @@ test('oidc role mapping syncs role for returning user', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user->refresh();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping updates role when groups change for returning user', function () {
@@ -375,7 +375,7 @@ test('oidc role mapping updates role when groups change for returning user', fun
     $this->get(route('oauth.callback', 'oidc'));
 
     $user->refresh();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping uses default role when no mapping is configured', function () {
@@ -388,7 +388,7 @@ test('oidc role mapping uses default role when no mapping is configured', functi
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'default@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping falls back to default role when groups claim is missing', function () {
@@ -401,7 +401,7 @@ test('oidc role mapping falls back to default role when groups claim is missing'
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'noclaimuser@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Viewer);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Viewer);
 });
 
 test('oidc role mapping strict mode denies access when groups claim is missing', function () {
@@ -436,7 +436,7 @@ test('oidc role mapping reads from custom claim name', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'custom@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping does not apply to non-oidc providers', function () {
@@ -456,7 +456,7 @@ test('oidc role mapping does not apply to non-oidc providers', function () {
     $this->get(route('oauth.callback', 'github'));
 
     $user = User::where('email', 'ghuser@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Member);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Member);
 });
 
 test('oidc role mapping supports comma-separated groups in env var', function () {
@@ -468,7 +468,7 @@ test('oidc role mapping supports comma-separated groups in env var', function ()
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'comma@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('oidc role mapping matches groups case-insensitively', function () {
@@ -480,7 +480,7 @@ test('oidc role mapping matches groups case-insensitively', function () {
     $this->get(route('oauth.callback', 'oidc'));
 
     $user = User::where('email', 'case@example.com')->first();
-    expect($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('new oauth user joins configured default organization', function () {
@@ -508,7 +508,7 @@ test('new oauth user falls back to main org when configured org does not exist',
 
     $user = User::where('email', 'fallbackorg@example.com')->first();
     expect($user)->not->toBeNull()
-        ->and($user->belongsToOrganization(\App\Models\Organization::main()))->toBeTrue();
+        ->and($user->belongsToOrganization(\App\Models\Organization::default()))->toBeTrue();
 });
 
 test('oidc role mapping syncs role in configured default organization', function () {

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -28,7 +28,7 @@ test('first user can register as admin', function () {
     // First user should be super admin
     $user = auth()->user();
     expect($user->super_admin)->toBeTrue()
-        ->and($user->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin);
+        ->and($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('first user can create demo backup during registration', function () {

--- a/tests/Feature/Configuration/OrganizationTest.php
+++ b/tests/Feature/Configuration/OrganizationTest.php
@@ -23,7 +23,7 @@ test('super admin can access organizations page', function () {
     Livewire::actingAs($admin)
         ->test(Organization::class)
         ->assertOk()
-        ->assertSee('Main');
+        ->assertSee('Default');
 });
 
 test('super admin can create an organization', function () {
@@ -59,11 +59,11 @@ test('super admin can rename a non-main organization', function () {
 
 test('super admin cannot rename the main organization', function () {
     $admin = User::factory()->superAdmin()->create();
-    $mainOrg = OrganizationModel::main();
+    $defaultOrg = OrganizationModel::default();
 
     Livewire::actingAs($admin)
         ->test(Organization::class)
-        ->call('openEditModal', $mainOrg->id)
+        ->call('openEditModal', $defaultOrg->id)
         ->assertForbidden();
 });
 
@@ -82,11 +82,11 @@ test('super admin can delete an empty non-main organization', function () {
 
 test('super admin cannot delete main organization', function () {
     $admin = User::factory()->superAdmin()->create();
-    $mainOrg = OrganizationModel::main();
+    $defaultOrg = OrganizationModel::default();
 
     Livewire::actingAs($admin)
         ->test(Organization::class)
-        ->call('confirmDelete', $mainOrg->id)
+        ->call('confirmDelete', $defaultOrg->id)
         ->assertForbidden();
 });
 

--- a/tests/Feature/Dashboard/SnapshotsCardTest.php
+++ b/tests/Feature/Dashboard/SnapshotsCardTest.php
@@ -95,7 +95,7 @@ test('verify files button prevents rapid re-dispatch via cache lock', function (
 
     $admin = User::factory()->create(['role' => UserRole::Admin]);
 
-    $org = \App\Models\Organization::main();
+    $org = \App\Models\Organization::default();
     Cache::lock('verify-snapshot-files:'.$org->id, 300)->get();
 
     Livewire::withoutLazyLoading()

--- a/tests/Feature/DemoModeTest.php
+++ b/tests/Feature/DemoModeTest.php
@@ -213,7 +213,7 @@ test('first admin can register even when demo mode is enabled', function () {
     // User should be authenticated as the new admin (not demo user)
     $this->assertAuthenticated();
     expect(auth()->user()->email)->toBe('admin@example.com')
-        ->and(auth()->user()->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Admin)
+        ->and(auth()->user()->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Admin)
         ->and(auth()->user()->isDemo())->toBeFalse();
 
     // Should be able to access dashboard
@@ -244,5 +244,5 @@ test('demo user is created when visiting login page in demo mode', function () {
         'email' => 'auto-demo@example.com',
     ]);
     $demoUser = User::where('email', 'auto-demo@example.com')->first();
-    expect($demoUser->roleIn(\App\Models\Organization::main()))->toBe(UserRole::Demo);
+    expect($demoUser->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Demo);
 });

--- a/tests/Feature/User/CreateTest.php
+++ b/tests/Feature/User/CreateTest.php
@@ -50,7 +50,7 @@ describe('invite new user', function () {
         $user = User::where('email', 'newuser@example.com')->first();
         expect($user)->not->toBeNull()
             ->and($user->name)->toBe('New User')
-            ->and($user->roleIn(Organization::main()))->toBe(UserRole::Member)
+            ->and($user->roleIn(Organization::default()))->toBe(UserRole::Member)
             ->and($user->invitation_token)->not->toBeNull()
             ->and($user->password)->toBeNull();
     });
@@ -100,7 +100,7 @@ describe('add existing user', function () {
             ->call('addExisting')
             ->assertHasNoErrors();
 
-        expect($existingUser->roleIn(Organization::main()))->toBe(UserRole::Viewer);
+        expect($existingUser->roleIn(Organization::default()))->toBe(UserRole::Viewer);
     });
 
     test('rejects adding user already in organization', function () {

--- a/tests/Feature/User/EditTest.php
+++ b/tests/Feature/User/EditTest.php
@@ -78,7 +78,7 @@ test('can update user name email and role', function () {
     $user->refresh();
     expect($user->name)->toBe('Updated Name')
         ->and($user->email)->toBe('updated@example.com')
-        ->and($user->roleIn(Organization::main()))->toBe(UserRole::Viewer);
+        ->and($user->roleIn(Organization::default()))->toBe(UserRole::Viewer);
 });
 
 test('cannot remove last super admin', function () {
@@ -107,7 +107,7 @@ test('can demote super admin when multiple exist', function () {
         ->assertRedirect(route('users.index'));
 
     $anotherAdmin->refresh();
-    expect($anotherAdmin->roleIn(Organization::main()))->toBe(UserRole::Member);
+    expect($anotherAdmin->roleIn(Organization::default()))->toBe(UserRole::Member);
 });
 
 test('can promote user to admin', function () {
@@ -121,7 +121,7 @@ test('can promote user to admin', function () {
         ->assertRedirect(route('users.index'));
 
     $member->refresh();
-    expect($member->roleIn(Organization::main()))->toBe(UserRole::Admin);
+    expect($member->roleIn(Organization::default()))->toBe(UserRole::Admin);
 });
 
 test('oauth user email field is disabled', function () {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -100,8 +100,8 @@ expect()->extend('toBeOne', function () {
 function setupOrgContext(): \App\Models\Organization
 {
     $org = \App\Models\Organization::firstOrCreate(
-        ['is_main' => true],
-        ['name' => 'Main'],
+        ['is_default' => true],
+        ['name' => 'Default'],
     );
 
     $currentOrg = app(\App\Services\CurrentOrganization::class);


### PR DESCRIPTION
## Summary

- Renames the primary organization concept from "Main" to "Default" across the entire codebase
- `is_main` column → `is_default`, `Organization::main()` → `Organization::default()`, factory state `main()` → `default()`
- "Default" better communicates the fallback/baseline role of the primary organization

## Changed areas

- **Model & migrations**: column rename, static helper, factory state
- **App code**: policies, services, middleware, Livewire components, MCP tools
- **Tests**: all references in Feature tests and Pest.php helper
- **Docs**: organizations guide and SSO configuration

## Test plan

- [x] All 954 tests pass
- [x] PHPStan clean
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Renamed "main organization" to "default organization" throughout the application for consistency and clarity. The default organization remains auto-created on first installation, cannot be edited or deleted, and serves as the fallback organization for API requests and OAuth user assignments.

* **Documentation**
  * Updated multi-organization guides and SSO configuration documentation to reflect default organization terminology and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->