### PR TITLE
fix: invalidate stale version cache after app upgrade

### DIFF
--- a/app/Livewire/VersionStatus.php
+++ b/app/Livewire/VersionStatus.php
@@ -76,10 +76,21 @@ class VersionStatus extends Component
         $cached = Cache::get($cacheKey);
 
         if (is_string($cached)) {
-            $this->latestVersion = $cached === '' ? null : $cached;
-            $this->releaseUrl = $this->latestVersion ? $this->releaseUrl($this->latestVersion) : null;
+            $cachedVersion = $cached === '' ? null : $cached;
 
-            return;
+            // If the app version is newer than the cached latest, the cache is stale — re-fetch
+            if ($cachedVersion && $this->appVersion && version_compare(
+                ltrim($this->appVersion, 'v'),
+                ltrim($cachedVersion, 'v'),
+                '>'
+            )) {
+                Cache::forget($cacheKey);
+            } else {
+                $this->latestVersion = $cachedVersion;
+                $this->releaseUrl = $this->latestVersion ? $this->releaseUrl($this->latestVersion) : null;
+
+                return;
+            }
         }
 
         try {

--- a/tests/Feature/Livewire/VersionStatusTest.php
+++ b/tests/Feature/Livewire/VersionStatusTest.php
@@ -136,6 +136,23 @@ test('github response is cached and reused on subsequent mounts', function () {
         ->assertSet('latestVersion', 'v1.2.3');
 });
 
+test('stale cache is invalidated when app version is newer than cached latest', function () {
+    // Simulate cache from before upgrade (old latest was v1.1.7)
+    Cache::put('github_latest_release', 'v1.1.7', now()->addDay());
+    config(['app.version' => 'v1.2.0']);
+
+    Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.2.0'])]);
+
+    Livewire::actingAs(User::factory()->create())
+        ->test(VersionStatus::class)
+        ->assertSet('latestVersion', 'v1.2.0')
+        ->call('open')
+        ->assertSee(__('You are running the latest version'));
+
+    // Cache should now hold the fresh value
+    expect(Cache::get('github_latest_release'))->toBe('v1.2.0');
+});
+
 test('github api failure is cached to avoid retries', function () {
     Http::fake(['api.github.com/*' => Http::response([], 500)]);
     config(['app.version' => 'v1.0.0']);


### PR DESCRIPTION
## Summary
- After upgrading the app, the cached GitHub latest release could be stale (e.g., cache holds v1.1.7 while app is already v1.2.0), causing the update modal to display "You are running the latest version v1.1.7"
- The fix detects when the app version is newer than the cached latest version and automatically re-fetches from GitHub, ensuring the modal always shows accurate version info

## Test plan
- [x] Added test: stale cache is invalidated when app version is newer than cached latest
- [x] All 955 existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version checking to properly refresh cached version information when the app is updated to a newer version, ensuring users always see accurate latest release details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/288)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->