### PR TITLE
feat: add Microsoft SQL Server backup and restore support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,6 +63,19 @@ jobs:
           --health-timeout=5s
           --health-retries=5
 
+      mssql:
+        image: mcr.microsoft.com/azure-sql-edge:latest
+        env:
+          ACCEPT_EULA: "Y"
+          MSSQL_SA_PASSWORD: "Databasement!Strong1"
+        ports:
+          - 1433:1433
+        options: >-
+          --health-cmd="/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P Databasement!Strong1 -Q 'SELECT 1' || exit 0"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+
       ssh:
         image: linuxserver/openssh-server:latest
         env:
@@ -93,17 +106,25 @@ jobs:
           php-version: 8.5
           tools: composer:v2
           coverage: pcov
-          extensions: pdo, pdo_mysql, pdo_pgsql, mongodb-2.3.0, sockets
+          extensions: pdo, pdo_mysql, pdo_pgsql, pdo_sqlsrv, sqlsrv, mongodb-2.3.0, sockets
 
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y mysql-client postgresql-client redis-tools zstd p7zip-full sshpass sqlite3
+          sudo apt-get install -y mysql-client postgresql-client redis-tools zstd p7zip-full sshpass sqlite3 unzip
           # Install MongoDB tools (mongodump, mongorestore)
           wget -qO - https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg --dearmor -o /usr/share/keyrings/mongodb-server-8.0.gpg
           echo "deb [ signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
           sudo apt-get update
           sudo apt-get install -y mongodb-database-tools
+          # Install sqlpackage (.NET app; runs the actual MSSQL bacpac export).
+          # Refresh from https://aka.ms/sqlpackage-linux when bumping the URL.
+          SQLPACKAGE_URL=https://download.microsoft.com/download/c149d463-e758-4207-bf98-3ee0e2547faa/sqlpackage-linux-x64-en-170.3.93.6.zip
+          wget -qO /tmp/sqlpackage.zip "${SQLPACKAGE_URL}"
+          sudo mkdir -p /opt/sqlpackage
+          sudo unzip -q /tmp/sqlpackage.zip -d /opt/sqlpackage
+          sudo chmod +x /opt/sqlpackage/sqlpackage
+          sudo ln -sf /opt/sqlpackage/sqlpackage /usr/local/bin/sqlpackage
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -137,6 +158,7 @@ jobs:
           TEST_POSTGRES_HOST: 127.0.0.1
           TEST_REDIS_HOST: 127.0.0.1
           TEST_MONGODB_HOST: 127.0.0.1
+          TEST_MSSQL_HOST: 127.0.0.1
           TEST_SSH_HOST: 127.0.0.1
         run: |
           php artisan migrate --force

--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -11,6 +11,7 @@ enum DatabaseType: string
     case SQLITE = 'sqlite';
     case REDIS = 'redis';
     case MONGODB = 'mongodb';
+    case MSSQL = 'mssql';
 
     public function label(): string
     {
@@ -20,6 +21,7 @@ enum DatabaseType: string
             self::SQLITE => 'SQLite',
             self::REDIS => 'Redis / Valkey',
             self::MONGODB => 'MongoDB',
+            self::MSSQL => 'Microsoft SQL Server',
         };
     }
 
@@ -31,6 +33,7 @@ enum DatabaseType: string
             self::SQLITE => 'devicon.sqlite',
             self::REDIS => 'devicon.redis',
             self::MONGODB => 'devicon.mongodb',
+            self::MSSQL => 'devicon.microsoftsqlserver',
         };
     }
 
@@ -42,6 +45,7 @@ enum DatabaseType: string
             self::SQLITE => 0,
             self::REDIS => 6379,
             self::MONGODB => 27017,
+            self::MSSQL => 1433,
         };
     }
 
@@ -73,6 +77,9 @@ enum DatabaseType: string
             self::SQLITE => "sqlite:{$host}",
             self::REDIS => throw new \RuntimeException('Redis does not support PDO connections'),
             self::MONGODB => throw new \RuntimeException('MongoDB does not support PDO connections'),
+            self::MSSQL => $database
+                ? sprintf('sqlsrv:Server=%s,%d;Database=%s;TrustServerCertificate=true;Encrypt=true', $host, $port, $database)
+                : sprintf('sqlsrv:Server=%s,%d;TrustServerCertificate=true;Encrypt=true', $host, $port),
         };
     }
 
@@ -103,10 +110,18 @@ enum DatabaseType: string
         }
 
         $dsn = $this->buildDsn($host, $server->port, $database);
-        $options = [
-            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-            \PDO::ATTR_TIMEOUT => $timeout,
-        ];
+
+        // sqlsrv encodes the connection timeout in the DSN itself (LoginTimeout)
+        // and rejects PDO::ATTR_TIMEOUT as an unsupported attribute.
+        if ($this === self::MSSQL) {
+            $dsn .= ';LoginTimeout='.$timeout;
+            $options = [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION];
+        } else {
+            $options = [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_TIMEOUT => $timeout,
+            ];
+        }
 
         return new \PDO($dsn, $server->username, $server->getDecryptedPassword(), $options);
     }
@@ -120,6 +135,7 @@ enum DatabaseType: string
             self::SQLITE => 'db',
             self::REDIS => 'rdb',
             self::MONGODB => 'archive',
+            self::MSSQL => 'bacpac',
             default => 'sql',
         };
     }

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -555,6 +555,14 @@ class DatabaseServerForm extends Form
     }
 
     /**
+     * Check if current database type is Microsoft SQL Server
+     */
+    public function isMssql(): bool
+    {
+        return $this->database_type === 'mssql';
+    }
+
+    /**
      * Check if current database type has optional credentials (username/password not required).
      */
     public function hasOptionalCredentials(): bool

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -26,6 +26,7 @@ class DatabaseProvider
             DatabaseType::SQLITE => new SqliteDatabase($this->sftpFilesystem),
             DatabaseType::REDIS => new RedisDatabase,
             DatabaseType::MONGODB => new MongodbDatabase,
+            DatabaseType::MSSQL => new MssqlDatabase,
         };
     }
 
@@ -223,6 +224,10 @@ class DatabaseProvider
             return $paths[0] ?? '';
         }
 
-        return $server->database_type === DatabaseType::POSTGRESQL ? 'postgres' : '';
+        return match ($server->database_type) {
+            DatabaseType::POSTGRESQL => 'postgres',
+            DatabaseType::MSSQL => 'master',
+            default => '',
+        };
     }
 }

--- a/app/Services/Backup/Databases/MssqlDatabase.php
+++ b/app/Services/Backup/Databases/MssqlDatabase.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Services\Backup\Databases;
+
+use App\Contracts\BackupLogger;
+use App\Exceptions\Backup\ConnectionException;
+use App\Services\Backup\DTO\DatabaseOperationResult;
+use App\Support\Formatters;
+
+/**
+ * Microsoft SQL Server handler.
+ *
+ * Backup and restore both go through Microsoft's `sqlpackage` CLI
+ * (`/Action:Export` produces a `.bacpac`, `/Action:Import` consumes one).
+ * Connection tests, listDatabases, and the drop-before-import step in
+ * prepareForRestore use the `pdo_sqlsrv` extension.
+ */
+class MssqlDatabase implements DatabaseInterface
+{
+    /** @var array<string, mixed> */
+    private array $config;
+
+    private const array EXCLUDED_DATABASES = [
+        'master',
+        'tempdb',
+        'model',
+        'msdb',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function setConfig(array $config): void
+    {
+        $this->config = $config;
+    }
+
+    public function dump(string $outputPath): DatabaseOperationResult
+    {
+        $parts = [
+            'sqlpackage',
+            '/Action:Export',
+            '/TargetFile:'.escapeshellarg($outputPath),
+            '/SourceServerName:'.escapeshellarg($this->buildServerName()),
+            '/SourceDatabaseName:'.escapeshellarg($this->config['database']),
+            '/SourceUser:'.escapeshellarg($this->config['user']),
+            '/SourcePassword:'.escapeshellarg($this->config['pass']),
+            '/SourceTrustServerCertificate:True',
+            '/SourceEncryptConnection:True',
+        ];
+
+        if (! empty($this->config['dump_flags'])) {
+            $parts[] = DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+        }
+
+        return new DatabaseOperationResult(command: implode(' ', $parts));
+    }
+
+    public function restore(string $inputPath): DatabaseOperationResult
+    {
+        // sqlpackage Import refuses any SourceFile that doesn't end in `.bacpac`.
+        // RestoreTask hands us the decompressed file as `<workdir>/snapshot`, so
+        // we rename it in place before invoking sqlpackage.
+        $bacpacPath = str_ends_with($inputPath, '.bacpac') ? $inputPath : $inputPath.'.bacpac';
+
+        $sqlpackage = implode(' ', [
+            'sqlpackage',
+            '/Action:Import',
+            '/SourceFile:'.escapeshellarg($bacpacPath),
+            '/TargetServerName:'.escapeshellarg($this->buildServerName()),
+            '/TargetDatabaseName:'.escapeshellarg($this->config['database']),
+            '/TargetUser:'.escapeshellarg($this->config['user']),
+            '/TargetPassword:'.escapeshellarg($this->config['pass']),
+            '/TargetTrustServerCertificate:True',
+            '/TargetEncryptConnection:True',
+        ]);
+
+        if ($bacpacPath === $inputPath) {
+            return new DatabaseOperationResult(command: $sqlpackage);
+        }
+
+        return new DatabaseOperationResult(command: sprintf(
+            'mv %s %s && %s',
+            escapeshellarg($inputPath),
+            escapeshellarg($bacpacPath),
+            $sqlpackage,
+        ));
+    }
+
+    /**
+     * sqlpackage Import refuses to run if the target database already exists,
+     * so we drop it first. ALTER ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE
+     * evicts any lingering sessions before the DROP.
+     */
+    public function prepareForRestore(string $schemaName, BackupLogger $logger, bool $forceDatabase = false): void
+    {
+        try {
+            $sql = self::dropDatabaseIfExistsSql($schemaName);
+            $logger->log("Ensuring target database {$schemaName} is dropped before sqlpackage Import", 'info');
+            $logger->logCommand($sql, null, 0);
+            $this->createPdoForDatabase('master')->exec($sql);
+        } catch (\PDOException $e) {
+            throw new ConnectionException("Failed to prepare database: {$e->getMessage()}", 0, $e);
+        }
+    }
+
+    /**
+     * Build a T-SQL block that drops a database iff it currently exists,
+     * evicting any active sessions first. Shared with integration test
+     * helpers so the prod and test drop paths cannot drift apart.
+     */
+    public static function dropDatabaseIfExistsSql(string $name): string
+    {
+        $bracketed = '['.str_replace(']', ']]', $name).']';
+        $quoted = "'".str_replace("'", "''", $name)."'";
+
+        return "IF DB_ID({$quoted}) IS NOT NULL BEGIN "
+            ."ALTER DATABASE {$bracketed} SET SINGLE_USER WITH ROLLBACK IMMEDIATE; "
+            ."DROP DATABASE {$bracketed}; "
+            .'END';
+    }
+
+    public function listDatabases(): array
+    {
+        $pdo = $this->createPdo();
+
+        $statement = $pdo->query('SELECT name FROM sys.databases ORDER BY name');
+        if ($statement === false) {
+            throw new \RuntimeException('Failed to execute query: SELECT name FROM sys.databases');
+        }
+
+        $databases = $statement->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+        return array_values(array_filter(
+            $databases,
+            fn ($db): bool => ! in_array($db, self::EXCLUDED_DATABASES, true),
+        ));
+    }
+
+    public function testConnection(): array
+    {
+        $startTime = microtime(true);
+
+        try {
+            $pdo = $this->createPdo();
+            $statement = $pdo->query('SELECT @@VERSION');
+            $version = $statement === false ? null : (string) $statement->fetchColumn();
+        } catch (\PDOException $e) {
+            $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+
+            if ($durationMs >= 9500) {
+                return [
+                    'success' => false,
+                    'message' => 'Connection timed out after '.Formatters::humanDuration($durationMs).'. Please check the host and port are correct and accessible.',
+                    'details' => [],
+                ];
+            }
+
+            return [
+                'success' => false,
+                'message' => $e->getMessage(),
+                'details' => [],
+            ];
+        }
+
+        $durationMs = (int) round((microtime(true) - $startTime) * 1000);
+        $shortVersion = $version !== null ? $this->extractShortVersion($version) : null;
+
+        return [
+            'success' => true,
+            'message' => 'Connection successful',
+            'details' => [
+                'ping_ms' => $durationMs,
+                'output' => json_encode([
+                    'dbms' => $shortVersion ?? 'Microsoft SQL Server',
+                    'version' => $version,
+                ], JSON_PRETTY_PRINT),
+            ],
+        ];
+    }
+
+    /**
+     * Create a PDO connection. Protected so tests can override it.
+     */
+    protected function createPdo(): \PDO
+    {
+        return $this->createPdoForDatabase($this->config['database'] ?? '');
+    }
+
+    protected function createPdoForDatabase(string $database): \PDO
+    {
+        $dsn = sprintf(
+            'sqlsrv:Server=%s;TrustServerCertificate=true;Encrypt=true;LoginTimeout=10%s',
+            $this->buildServerName(),
+            $database !== '' ? ';Database='.$database : '',
+        );
+
+        return new \PDO($dsn, $this->config['user'], $this->config['pass'], [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        ]);
+    }
+
+    private function buildServerName(): string
+    {
+        return sprintf('%s,%d', $this->config['host'], (int) $this->config['port']);
+    }
+
+    /**
+     * Extract a short product name from the verbose `@@VERSION` string, e.g.
+     * "Microsoft SQL Server 2022 (RTM)".
+     */
+    private function extractShortVersion(string $fullVersion): ?string
+    {
+        if (preg_match('/Microsoft SQL [^\r\n]*?\d{4}[^\r\n(]*/i', $fullVersion, $matches) === 1) {
+            return trim($matches[0]);
+        }
+
+        if (preg_match('/Microsoft Azure SQL[^\r\n]*/i', $fullVersion, $matches) === 1) {
+            return trim($matches[0]);
+        }
+
+        return null;
+    }
+}

--- a/config/testing.php
+++ b/config/testing.php
@@ -45,6 +45,14 @@ return [
             'database' => env('TEST_MONGODB_DATABASE', 'databasement_test'),
             'auth_source' => env('TEST_MONGODB_AUTH_SOURCE', 'admin'),
         ],
+
+        'mssql' => [
+            'host' => env('TEST_MSSQL_HOST', 'mssql'),
+            'port' => env('TEST_MSSQL_PORT', 1433),
+            'username' => env('TEST_MSSQL_USERNAME', 'sa'),
+            'password' => env('TEST_MSSQL_PASSWORD', 'Databasement!Strong1'),
+            'database' => env('TEST_MSSQL_DATABASE', 'databasement_test'),
+        ],
     ],
 
     /*

--- a/database/factories/DatabaseServerFactory.php
+++ b/database/factories/DatabaseServerFactory.php
@@ -127,6 +127,22 @@ class DatabaseServerFactory extends Factory
     }
 
     /**
+     * Configure the factory for Microsoft SQL Server database type.
+     */
+    public function mssql(): static
+    {
+        return $this->state(fn () => [
+            'name' => fake()->company().' SQL Server',
+            'database_type' => 'mssql',
+            'host' => fake()->randomElement(['localhost', '127.0.0.1']),
+            'port' => 1433,
+            'username' => 'sa',
+            'password' => 'Databasement!Strong1',
+            'database_names' => null,
+        ]);
+    }
+
+    /**
      * Configure the factory with SSH tunnel using password authentication.
      *
      * Note: Uses afterCreating() hook, so only works with create(), not make().

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -111,6 +111,17 @@ class DatabaseSeeder extends Seeder
             'organization_id' => $defaultOrg->id,
         ]);
 
+        // Microsoft SQL Server (from docker-compose)
+        $mssql = DatabaseServer::create([
+            'name' => 'Local SQL Server',
+            'host' => 'mssql',
+            'port' => 1433,
+            'database_type' => 'mssql',
+            'username' => 'sa',
+            'password' => 'Databasement!Strong1',
+            'organization_id' => $defaultOrg->id,
+        ]);
+
         // Backup configurations (database_selection_mode lives on Backup now)
         $backupDefaults = [
             'volume_id' => $volume->id,
@@ -120,7 +131,7 @@ class DatabaseSeeder extends Seeder
             'database_selection_mode' => 'all',
         ];
 
-        foreach ([$mysql, $postgres, $redis, $mongodb] as $server) {
+        foreach ([$mysql, $postgres, $redis, $mongodb, $mssql] as $server) {
             Backup::create(array_merge($backupDefaults, [
                 'database_server_id' => $server->id,
             ]));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,23 @@ services:
       timeout: 5s
       retries: 5
 
+  mssql:
+    # azure-sql-edge is multi-arch (works on Apple Silicon); same TDS protocol as SQL Server
+    image: mcr.microsoft.com/azure-sql-edge:latest
+    container_name: databasement-mssql
+    environment:
+      ACCEPT_EULA: "Y"
+      MSSQL_SA_PASSWORD: "Databasement!Strong1"
+    ports:
+      - "1433:1433"
+    volumes:
+      - mssql-data:/var/opt/mssql
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 1433 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   ssh:
     image: linuxserver/openssh-server:latest
     container_name: databasement-ssh
@@ -196,4 +213,5 @@ volumes:
   sftp-data:
   mongodb-data:
   redis-data:
+  mssql-data:
   ftp-data:

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -16,6 +16,8 @@ RUN install-php-extensions \
     xml \
     pdo_mysql \
     pdo_pgsql \
+    pdo_sqlsrv \
+    sqlsrv \
     intl \
     pcntl \
     opcache \
@@ -39,10 +41,29 @@ RUN apk add --no-cache git \
         openssh-client \
         sshpass \
         redis \
-        sqlite
+        sqlite \
+        curl \
+        unzip \
+        icu-libs krb5-libs libgcc libssl3 libstdc++ zlib \
+        gcompat
 
 # Install MongoDB tools (mongodump, mongorestore) from Alpine edge community repo
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community mongodb-tools
+
+# Install .NET 8 ASP.NET runtime (required by sqlpackage). Pulled from edge/community
+# because Alpine stable repos lag behind the .NET LTS Microsoft supports for musl.
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community aspnetcore8-runtime
+
+# Install sqlpackage (Microsoft SQL Server export tool). Pinned for reproducible
+# builds; refresh from https://aka.ms/sqlpackage-linux when bumping versions.
+# Relies on the .NET 8 runtime installed above.
+ARG SQLPACKAGE_URL=https://download.microsoft.com/download/c149d463-e758-4207-bf98-3ee0e2547faa/sqlpackage-linux-x64-en-170.3.93.6.zip
+RUN curl -fsSL -o /tmp/sqlpackage.zip "${SQLPACKAGE_URL}" \
+    && mkdir -p /opt/sqlpackage \
+    && unzip -q /tmp/sqlpackage.zip -d /opt/sqlpackage \
+    && chmod +x /opt/sqlpackage/sqlpackage \
+    && ln -s /opt/sqlpackage/sqlpackage /usr/local/bin/sqlpackage \
+    && rm /tmp/sqlpackage.zip
 
 COPY supervisord.conf /config/supervisord.conf
 COPY php-custom-production.ini /usr/local/etc/php/php-custom-production.ini

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -188,4 +188,5 @@
             <x-button label="{{ __('Close') }}" @click="$wire.showRedisRestoreModal = false" />
         </x-slot:actions>
     </x-modal>
+
 </div>

--- a/tests/Feature/Services/Backup/Databases/MssqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MssqlDatabaseTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Services\Backup\Databases\MssqlDatabase;
+use App\Services\Backup\DTO\DatabaseOperationResult;
+
+beforeEach(function () {
+    $this->db = new MssqlDatabase;
+    $this->db->setConfig([
+        'host' => 'mssql.example.com',
+        'port' => 1433,
+        'user' => 'sa',
+        'pass' => 'Pa55w0rd!',
+        'database' => 'app_db',
+    ]);
+});
+
+test('dump produces sqlpackage export command', function () {
+    $result = $this->db->dump('/tmp/snapshot.bacpac');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe(
+            "sqlpackage /Action:Export /TargetFile:'/tmp/snapshot.bacpac' "
+            ."/SourceServerName:'mssql.example.com,1433' "
+            ."/SourceDatabaseName:'app_db' "
+            ."/SourceUser:'sa' "
+            ."/SourcePassword:'Pa55w0rd!' "
+            .'/SourceTrustServerCertificate:True '
+            .'/SourceEncryptConnection:True'
+        );
+});
+
+test('dump appends user-provided dump flags', function () {
+    $this->db->setConfig([
+        'host' => 'mssql.example.com',
+        'port' => 1433,
+        'user' => 'sa',
+        'pass' => 'Pa55w0rd!',
+        'database' => 'app_db',
+        'dump_flags' => '/Verbose:True',
+    ]);
+
+    $result = $this->db->dump('/tmp/snapshot.bacpac');
+
+    expect($result->command)->toEndWith("/SourceEncryptConnection:True '/Verbose:True'");
+});
+
+test('restore produces sqlpackage import command when input is already a .bacpac', function () {
+    $result = $this->db->restore('/tmp/snapshot.bacpac');
+
+    expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
+        ->and($result->command)->toBe(
+            "sqlpackage /Action:Import /SourceFile:'/tmp/snapshot.bacpac' "
+            ."/TargetServerName:'mssql.example.com,1433' "
+            ."/TargetDatabaseName:'app_db' "
+            ."/TargetUser:'sa' "
+            ."/TargetPassword:'Pa55w0rd!' "
+            .'/TargetTrustServerCertificate:True '
+            .'/TargetEncryptConnection:True'
+        );
+});
+
+test('restore renames extensionless input to .bacpac before invoking sqlpackage', function () {
+    $result = $this->db->restore('/tmp/snapshot');
+
+    expect($result->command)->toStartWith("mv '/tmp/snapshot' '/tmp/snapshot.bacpac' && sqlpackage /Action:Import /SourceFile:'/tmp/snapshot.bacpac'");
+});
+
+test('listDatabases filters out system databases', function () {
+    $statement = Mockery::mock(\PDOStatement::class);
+    $statement->shouldReceive('fetchAll')
+        ->once()
+        ->with(PDO::FETCH_COLUMN, 0)
+        ->andReturn(['master', 'tempdb', 'model', 'msdb', 'app_db', 'reports']);
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->shouldReceive('query')
+        ->once()
+        ->with('SELECT name FROM sys.databases ORDER BY name')
+        ->andReturn($statement);
+
+    $db = Mockery::mock(MssqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldReceive('createPdo')->once()->andReturn($pdo);
+    $db->setConfig(['host' => 'h', 'port' => 1433, 'user' => 'u', 'pass' => 'p', 'database' => '']);
+
+    expect($db->listDatabases())->toBe(['app_db', 'reports']);
+});
+
+test('testConnection returns success with parsed version', function () {
+    $version = 'Microsoft SQL Server 2022 (RTM) - 16.0.1000.6 (X64)';
+    $statement = Mockery::mock(\PDOStatement::class);
+    $statement->shouldReceive('fetchColumn')->andReturn($version);
+
+    $pdo = Mockery::mock(PDO::class);
+    $pdo->shouldReceive('query')->with('SELECT @@VERSION')->andReturn($statement);
+
+    $db = Mockery::mock(MssqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldReceive('createPdo')->once()->andReturn($pdo);
+    $db->setConfig(['host' => 'h', 'port' => 1433, 'user' => 'u', 'pass' => 'p', 'database' => 'app_db']);
+
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeTrue()
+        ->and($result['message'])->toBe('Connection successful')
+        ->and($result['details'])->toHaveKey('ping_ms')
+        ->and($result['details']['output'])->toContain('Microsoft SQL Server 2022');
+});
+
+test('testConnection returns failure when PDO throws', function () {
+    $db = Mockery::mock(MssqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldReceive('createPdo')->once()->andThrow(new PDOException('Login failed for user'));
+    $db->setConfig(['host' => 'h', 'port' => 1433, 'user' => 'u', 'pass' => 'p', 'database' => 'app_db']);
+
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeFalse()
+        ->and($result['message'])->toContain('Login failed');
+});

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -244,6 +244,50 @@ test('mongodb backup and restore workflow', function () {
     expect($collectionCount)->toBeGreaterThanOrEqual(2);
 });
 
+test('mssql backup and restore workflow', function () {
+    // Create models
+    $this->volume = IntegrationTestHelpers::createVolume('mssql');
+    $this->databaseServer = IntegrationTestHelpers::createDatabaseServer('mssql');
+    $this->backup = IntegrationTestHelpers::createBackup($this->databaseServer, $this->volume);
+    $this->databaseServer->load('backups.volume');
+
+    // Load test data (resets the target database and runs the fixture script)
+    IntegrationTestHelpers::loadTestData('mssql', $this->databaseServer);
+
+    // Run backup
+    $snapshots = $this->backupJobFactory->createSnapshots(
+        backup: $this->backup,
+        method: 'manual',
+    );
+    $this->snapshot = $snapshots[0];
+    ProcessBackupJob::dispatchSync($this->snapshot->id);
+    $this->snapshot->refresh();
+    $this->snapshot->load('job');
+
+    $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
+
+    expect($this->snapshot->job->status)->toBe('completed')
+        ->and($this->snapshot->file_size)->toBeGreaterThan(0)
+        ->and($this->snapshot->filename)->toEndWith('.bacpac.gz')
+        ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
+
+    // Run restore (use unique name with parallel token and microseconds to avoid collisions)
+    $suffix = IntegrationTestHelpers::getParallelSuffix();
+    $this->restoredDatabaseName = 'testdb_restored_'.hrtime(true).$suffix;
+    $restore = $this->backupJobFactory->createRestore(
+        snapshot: $this->snapshot,
+        targetServer: $this->databaseServer,
+        schemaName: $this->restoredDatabaseName,
+    );
+    ProcessRestoreJob::dispatchSync($restore->id);
+
+    // Verify restore — the fixture inserts 2 users; sqlpackage Import recreates schema + data.
+    $pdo = IntegrationTestHelpers::connectToDatabase('mssql', $this->databaseServer, $this->restoredDatabaseName);
+    $stmt = $pdo->query('SELECT COUNT(*) FROM dbo.users');
+    expect($stmt)->not->toBeFalse()
+        ->and((int) $stmt->fetchColumn())->toBe(2);
+});
+
 test('redis backup workflow', function () {
     // Create models
     $this->volume = IntegrationTestHelpers::createVolume('redis');

--- a/tests/Integration/fixtures/mssql-init.sql
+++ b/tests/Integration/fixtures/mssql-init.sql
@@ -1,0 +1,36 @@
+-- Microsoft SQL Server test data for integration tests.
+-- Assumes the target database has already been created with USE [<db>].
+
+IF OBJECT_ID('dbo.users', 'U') IS NOT NULL DROP TABLE dbo.users;
+GO
+
+CREATE TABLE dbo.users (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    name NVARCHAR(100) NOT NULL,
+    email NVARCHAR(100) NOT NULL UNIQUE,
+    created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+);
+GO
+
+INSERT INTO dbo.users (name, email) VALUES
+    ('John Doe', 'john.doe@example.com'),
+    ('Jane Smith', 'jane.smith@example.com');
+GO
+
+IF OBJECT_ID('dbo.products', 'U') IS NOT NULL DROP TABLE dbo.products;
+GO
+
+CREATE TABLE dbo.products (
+    id INT IDENTITY(1,1) PRIMARY KEY,
+    name NVARCHAR(100) NOT NULL,
+    description NVARCHAR(MAX) NULL,
+    price DECIMAL(10, 2) NOT NULL,
+    stock INT NOT NULL DEFAULT 0,
+    created_at DATETIME2 NOT NULL DEFAULT SYSUTCDATETIME()
+);
+GO
+
+INSERT INTO dbo.products (name, description, price, stock) VALUES
+    ('Laptop', 'High-performance laptop for developers', 1299.99, 15),
+    ('Mouse', 'Wireless ergonomic mouse', 29.99, 50);
+GO

--- a/tests/Support/IntegrationTestHelpers.php
+++ b/tests/Support/IntegrationTestHelpers.php
@@ -10,6 +10,7 @@ use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
 use App\Models\Volume;
 use App\Services\Backup\Databases\MongodbDatabase;
+use App\Services\Backup\Databases\MssqlDatabase;
 use Illuminate\Support\Facades\ParallelTesting;
 use InvalidArgumentException;
 use MongoDB\Client as MongoClient;
@@ -79,6 +80,14 @@ class IntegrationTestHelpers
                 'database' => config('testing.databases.mongodb.database').$suffix,
                 'database_type' => 'mongodb',
                 'auth_source' => config('testing.databases.mongodb.auth_source'),
+            ],
+            'mssql' => [
+                'host' => config('testing.databases.mssql.host'),
+                'port' => (int) config('testing.databases.mssql.port'),
+                'username' => config('testing.databases.mssql.username'),
+                'password' => config('testing.databases.mssql.password'),
+                'database' => config('testing.databases.mssql.database').$suffix,
+                'database_type' => 'mssql',
             ],
             default => throw new InvalidArgumentException("Unsupported database type: {$type}"),
         };
@@ -432,6 +441,8 @@ class IntegrationTestHelpers
         } elseif ($type === 'postgres') {
             $pdo->exec("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{$databaseName}' AND pid <> pg_backend_pid()");
             $pdo->exec("DROP DATABASE IF EXISTS \"{$databaseName}\"");
+        } elseif ($type === 'mssql') {
+            $pdo->exec(MssqlDatabase::dropDatabaseIfExistsSql($databaseName));
         }
     }
 
@@ -450,6 +461,14 @@ class IntegrationTestHelpers
         // MongoDB uses its own data loading mechanism
         if ($type === 'mongodb') {
             self::loadMongodbTestData($server);
+
+            return;
+        }
+
+        // MSSQL fixture loading needs T-SQL `GO` batch splitting (PDO can't run a
+        // raw script with batch separators in one exec).
+        if ($type === 'mssql') {
+            self::loadMssqlTestData($server);
 
             return;
         }
@@ -475,5 +494,43 @@ class IntegrationTestHelpers
 
         $pdo = self::connectToDatabase($type, $server, $databaseName);
         $pdo->exec(file_get_contents($fixtureFile));
+    }
+
+    /**
+     * Drop+recreate the target MSSQL database, then run the fixture script.
+     * The script uses `GO` batch separators which PDO cannot execute in one
+     * call, so they're split client-side.
+     */
+    public static function loadMssqlTestData(DatabaseServer $server): void
+    {
+        $databaseName = self::resolveTestDatabaseName($server);
+        $bracketedName = '['.str_replace(']', ']]', $databaseName).']';
+
+        $adminPdo = DatabaseType::MSSQL->createPdo($server);
+        $adminPdo->exec(MssqlDatabase::dropDatabaseIfExistsSql($databaseName));
+        $adminPdo->exec("CREATE DATABASE {$bracketedName}");
+
+        $pdo = DatabaseType::MSSQL->createPdo($server, $databaseName);
+
+        $sql = file_get_contents(__DIR__.'/../Integration/fixtures/mssql-init.sql');
+        foreach (self::splitTsqlBatches($sql) as $batch) {
+            $pdo->exec($batch);
+        }
+    }
+
+    /**
+     * Split a T-SQL script on `GO` batch separators (case-insensitive, lines
+     * containing only `GO` plus optional whitespace).
+     *
+     * @return array<int, string>
+     */
+    private static function splitTsqlBatches(string $sql): array
+    {
+        $batches = preg_split('/^\s*GO\s*$/im', $sql) ?: [];
+
+        return array_values(array_filter(
+            array_map('trim', $batches),
+            fn (string $batch): bool => $batch !== '',
+        ));
     }
 }


### PR DESCRIPTION
Closes #292

## Summary
- Adds Microsoft SQL Server as a first-class database type. Backups produce `.bacpac` files via Microsoft's `sqlpackage` CLI (`/Action:Export`); restores re-import them with `/Action:Import` after a drop-if-exists guard on the target database (sqlpackage Import refuses to write into an existing DB).
- Connection testing and `listDatabases` use the `pdo_sqlsrv` PHP extension. The DSN embeds `LoginTimeout` because `sqlsrv` rejects `PDO::ATTR_TIMEOUT`.
- Image plumbing: Dockerfile installs `aspnetcore8-runtime` (from Alpine edge/community) + a pinned `sqlpackage` zip + `gcompat` (sqlpackage ships glibc-built `libhostpolicy.so`). CI mirrors the install on Ubuntu and adds an `azure-sql-edge` service.
- Restore path detail: `RestoreTask` hands the decompressed working file in as `<workdir>/snapshot` (extension stripped by the compressor); sqlpackage validates the `.bacpac` extension by filename only, so `MssqlDatabase::restore()` prepends a `mv` to the command when needed.
- `MssqlDatabase::dropDatabaseIfExistsSql()` is a shared static helper used by both the production drop path (`prepareForRestore`) and the integration test helpers (`dropDatabase`, `loadMssqlTestData`) so the two cannot drift.

## Test plan
- [x] `make lint-fix` clean
- [x] `make phpstan` clean
- [x] `make test` — 968 passing (2870 assertions). Includes a new `mssql backup and restore workflow` integration test that round-trips a fixture (2 users / 2 products) through `sqlpackage` Export → compress → upload to volume → download → decompress → Import, then asserts the restored DB has the expected row count.
- [x] New unit tests in `MssqlDatabaseTest.php` cover the Export/Import command shape, dump-flag appending, the `mv` rename branch, system-database filtering in `listDatabases`, and PDO success/failure paths in `testConnection`.
- [ ] Manual smoke test against a real Azure SQL / on-prem MSSQL instance (CI uses `azure-sql-edge` which behaves like SQL Server 2022 for backup/restore but isn't byte-identical).

## Notes / follow-ups
- The Alpine `aspnetcore8-runtime` package pulls .NET in for sqlpackage — this will noticeably increase the image size (will measure and report).
- Restore is unsupported for snapshots taken from an Azure SQL Database that uses features the target SQL Server edition doesn't support — that's a sqlpackage constraint, not something this PR can address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Microsoft SQL Server (MSSQL) support for database backup and restore operations
  * MSSQL databases can now be managed and backed up alongside other supported database types

* **Tests**
  * Added comprehensive test coverage for MSSQL backup/restore workflows and database operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/293)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->