### PR TITLE
fix: drop mssql restore mv hack by embedding dump extension in working file

### DIFF
--- a/app/Services/Backup/Databases/MssqlDatabase.php
+++ b/app/Services/Backup/Databases/MssqlDatabase.php
@@ -58,15 +58,10 @@ class MssqlDatabase implements DatabaseInterface
 
     public function restore(string $inputPath): DatabaseOperationResult
     {
-        // sqlpackage Import refuses any SourceFile that doesn't end in `.bacpac`.
-        // RestoreTask hands us the decompressed file as `<workdir>/snapshot`, so
-        // we rename it in place before invoking sqlpackage.
-        $bacpacPath = str_ends_with($inputPath, '.bacpac') ? $inputPath : $inputPath.'.bacpac';
-
         $sqlpackage = implode(' ', [
             'sqlpackage',
             '/Action:Import',
-            '/SourceFile:'.escapeshellarg($bacpacPath),
+            '/SourceFile:'.escapeshellarg($inputPath),
             '/TargetServerName:'.escapeshellarg($this->buildServerName()),
             '/TargetDatabaseName:'.escapeshellarg($this->config['database']),
             '/TargetUser:'.escapeshellarg($this->config['user']),
@@ -75,16 +70,7 @@ class MssqlDatabase implements DatabaseInterface
             '/TargetEncryptConnection:True',
         ]);
 
-        if ($bacpacPath === $inputPath) {
-            return new DatabaseOperationResult(command: $sqlpackage);
-        }
-
-        return new DatabaseOperationResult(command: sprintf(
-            'mv %s %s && %s',
-            escapeshellarg($inputPath),
-            escapeshellarg($bacpacPath),
-            $sqlpackage,
-        ));
+        return new DatabaseOperationResult(command: $sqlpackage);
     }
 
     /**

--- a/app/Services/Backup/RestoreTask.php
+++ b/app/Services/Backup/RestoreTask.php
@@ -58,7 +58,7 @@ class RestoreTask
             }
 
             $humanFileSize = Formatters::humanFileSize($config->snapshotFileSize);
-            $compressedFile = $config->workingDirectory.'/snapshot.'.$config->snapshotCompressionType->extension();
+            $compressedFile = $config->workingDirectory.'/snapshot.'.$config->snapshotDatabaseType->dumpExtension().'.'.$config->snapshotCompressionType->extension();
             $compressor = $this->compressorFactory->make($config->snapshotCompressionType);
 
             // Download snapshot from volume

--- a/tests/Feature/Services/Backup/Databases/MssqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MssqlDatabaseTest.php
@@ -59,12 +59,6 @@ test('restore produces sqlpackage import command when input is already a .bacpac
         );
 });
 
-test('restore renames extensionless input to .bacpac before invoking sqlpackage', function () {
-    $result = $this->db->restore('/tmp/snapshot');
-
-    expect($result->command)->toStartWith("mv '/tmp/snapshot' '/tmp/snapshot.bacpac' && sqlpackage /Action:Import /SourceFile:'/tmp/snapshot.bacpac'");
-});
-
 test('listDatabases filters out system databases', function () {
     $statement = Mockery::mock(\PDOStatement::class);
     $statement->shouldReceive('fetchAll')


### PR DESCRIPTION
## Summary
- `RestoreTask` now names the downloaded snapshot `snapshot.<dumpExt>.<compressionExt>` (e.g. `snapshot.bacpac.gz`), mirroring the backup-side `dump.<dumpExt>.<compressionExt>`. Decompression then naturally produces a file with the right dump extension.
- `MssqlDatabase::restore` no longer needs to `mv` the working file into a `.bacpac` before invoking `sqlpackage /Action:Import` — the input path already ends in `.bacpac`.
- Drops the stale `restore renames extensionless input to .bacpac` test.

Other DB handlers consume `$inputPath` opaquely as a CLI argument, so they're unaffected by the extra extension (`snapshot.sql.gz`, `snapshot.archive.gz`, etc.).

## Test plan
- [x] `make test-filter FILTER=MssqlDatabase` (6 passed)
- [x] `make test-filter FILTER=Restore` (75 passed)
- [x] Full suite via pre-commit hook (969 passed)
- [x] `make lint-fix` clean
- [x] `make phpstan` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified MSSQL restore operation to streamline file handling
  * Updated compressed snapshot filename generation during restore operations

* **Tests**
  * Updated test coverage for restore functionality

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/294)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->