### PR TITLE
Harden dev docker-compose: bind DB ports to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+# Local development compose. DB ports are bound to 127.0.0.1 only.
+# For production self-hosting: https://david-crty.github.io/databasement/self-hosting/docker-compose
+
 services:
   app:
     image: davidcrty/databasement-php
@@ -44,7 +47,7 @@ services:
       MYSQL_ROOT_PASSWORD: root
       MYSQL_DATABASE: databasement
     ports:
-      - "3307:3306"
+      - "127.0.0.1:3307:3306"
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:
@@ -61,7 +64,7 @@ services:
       POSTGRES_PASSWORD: root
       POSTGRES_DB: databasement
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -77,7 +80,7 @@ services:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: root
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongodb-data:/data/db
     healthcheck:
@@ -90,7 +93,7 @@ services:
     image: redis:7
     container_name: databasement-redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis-data:/data
     healthcheck:
@@ -107,7 +110,7 @@ services:
       ACCEPT_EULA: "Y"
       MSSQL_SA_PASSWORD: "Databasement!Strong1"
     ports:
-      - "1433:1433"
+      - "127.0.0.1:1433:1433"
     volumes:
       - mssql-data:/var/opt/mssql
     healthcheck:
@@ -128,7 +131,7 @@ services:
       PASSWORD_ACCESS: "true"
       DOCKER_MODS: linuxserver/mods:openssh-server-ssh-tunnel
     ports:
-      - "2222:2222"
+      - "127.0.0.1:2222:2222"
     healthcheck:
       test: [ "CMD-SHELL", "netstat -tlnp | grep -q ':2222'" ]
       interval: 10s
@@ -139,8 +142,8 @@ services:
     image: rustfs/rustfs:latest
     container_name: databasement-rustfs
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     environment:
       RUSTFS_ACCESS_KEY: rustfsadmin
       RUSTFS_SECRET_KEY: rustfsadmin
@@ -197,7 +200,7 @@ services:
     volumes:
       - ./docker/dex/config.yaml:/etc/dex/config.yaml:ro
     ports:
-      - "5556:5556"
+      - "127.0.0.1:5556:5556"
     command: ["dex", "serve", "/etc/dex/config.yaml"]
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:5556/dex/.well-known/openid-configuration"]


### PR DESCRIPTION
## Summary
- Bind all dev DB and adjacent service ports (mysql, postgres, mongodb, redis, mssql, mssh, rustfs, dex) to `127.0.0.1` in the local development compose. The app port (`2226`) is intentionally left public so devs can still reach the UI from LAN/phone.
- Add a short header comment at the top of `docker-compose.yml` pointing to the production self-hosting docs.

The production self-hosting guide already doesn't publish DB ports, so users who follow the docs were never exposed. This just removes the footgun for anyone who clones the repo and runs `docker compose up` on a public-facing host.

Closes #306

## Test plan
- [x] `docker compose config --quiet` passes
- [x] `make start` still brings the stack up locally
- [ ] DB containers reachable from host on `127.0.0.1:<port>` but not from another machine on the LAN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration to restrict local service access to localhost only, enhancing security for local development setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->