### PR TITLE
Snapshot & restore index UX redesign, ID search, status sort

### DIFF
--- a/app/Livewire/Menu/RestoresMenuItem.php
+++ b/app/Livewire/Menu/RestoresMenuItem.php
@@ -7,6 +7,13 @@ use Livewire\Component;
 
 class RestoresMenuItem extends Component
 {
+    public bool $isActive = false;
+
+    public function mount(): void
+    {
+        $this->isActive = request()->routeIs('restores.*');
+    }
+
     public function getActiveRestoresCountProperty(): int
     {
         return BackupJob::forCurrentOrg()
@@ -24,6 +31,7 @@ class RestoresMenuItem extends Component
                 icon="o-arrow-uturn-left"
                 link="{{ route('restores.index') }}"
                 wire:navigate
+                :active="$isActive"
                 :badge="$this->activeRestoresCount > 0 ? $this->activeRestoresCount : null"
                 badge-classes="badge-warning badge-soft"
             />

--- a/app/Livewire/Menu/SnapshotsMenuItem.php
+++ b/app/Livewire/Menu/SnapshotsMenuItem.php
@@ -7,6 +7,13 @@ use Livewire\Component;
 
 class SnapshotsMenuItem extends Component
 {
+    public bool $isActive = false;
+
+    public function mount(): void
+    {
+        $this->isActive = request()->routeIs('snapshots.*');
+    }
+
     public function getActiveSnapshotsCountProperty(): int
     {
         return BackupJob::forCurrentOrg()
@@ -24,6 +31,7 @@ class SnapshotsMenuItem extends Component
                 icon="o-archive-box"
                 link="{{ route('snapshots.index') }}"
                 wire:navigate
+                :active="$isActive"
                 :badge="$this->activeSnapshotsCount > 0 ? $this->activeSnapshotsCount : null"
                 badge-classes="badge-warning badge-soft"
             />

--- a/app/Livewire/Restore/Index.php
+++ b/app/Livewire/Restore/Index.php
@@ -127,6 +127,9 @@ class Index extends Component
 
     public function rerunRestore(string $restoreId): void
     {
+        $restore = Restore::findOrFail($restoreId);
+
+        $this->authorize('view', $restore);
         $this->authorize('create', Restore::class);
 
         $this->dispatch('open-restore-modal', mode: 'from-restore-index', restoreId: $restoreId);

--- a/app/Livewire/Restore/Index.php
+++ b/app/Livewire/Restore/Index.php
@@ -128,6 +128,13 @@ class Index extends Component
         $this->dispatch('open-restore-modal', mode: 'from-restore-index');
     }
 
+    public function rerunRestore(string $restoreId): void
+    {
+        $this->authorize('create', Restore::class);
+
+        $this->dispatch('open-restore-modal', mode: 'from-restore-index', restoreId: $restoreId);
+    }
+
     public function confirmDeleteRestore(string $restoreId): void
     {
         $restore = Restore::findOrFail($restoreId);

--- a/app/Livewire/Restore/Index.php
+++ b/app/Livewire/Restore/Index.php
@@ -94,6 +94,7 @@ class Index extends Component
     public function headers(): array
     {
         return [
+            ['key' => 'id', 'label' => __('ID'), 'class' => 'w-28', 'sortable' => false],
             ['key' => 'created_at', 'label' => __('Created'), 'class' => 'w-48'],
             ['key' => 'source', 'label' => __('Source'), 'sortable' => false],
             ['key' => 'target', 'label' => __('Target'), 'sortable' => false],

--- a/app/Livewire/Restore/Index.php
+++ b/app/Livewire/Restore/Index.php
@@ -94,13 +94,9 @@ class Index extends Component
     public function headers(): array
     {
         return [
-            ['key' => 'id', 'label' => __('ID'), 'class' => 'w-28', 'sortable' => false],
-            ['key' => 'created_at', 'label' => __('Created'), 'class' => 'w-48'],
-            ['key' => 'source', 'label' => __('Source'), 'sortable' => false],
-            ['key' => 'target', 'label' => __('Target'), 'sortable' => false],
-            ['key' => 'status', 'label' => __('Status'), 'class' => 'w-32', 'sortable' => false],
-            ['key' => 'duration_ms', 'label' => __('Duration'), 'class' => 'w-28', 'sortable' => false],
-            ['key' => 'triggered_by', 'label' => __('By'), 'class' => 'w-32', 'sortable' => false],
+            ['key' => 'flow', 'label' => __('Source → Target'), 'sortable' => false],
+            ['key' => 'created_at', 'label' => __('Created'), 'class' => 'w-52'],
+            ['key' => 'status', 'label' => __('Status'), 'class' => 'w-44'],
         ];
     }
 

--- a/app/Livewire/Restore/Modal.php
+++ b/app/Livewire/Restore/Modal.php
@@ -105,16 +105,18 @@ class Modal extends Component
 
         $this->mode = RestoreModalMode::from($mode);
 
-        match ($this->mode) {
+        $shouldOpen = match ($this->mode) {
             RestoreModalMode::FromServer => $this->initFromServer($targetServerId),
             RestoreModalMode::FromSnapshot => $this->initFromSnapshot($snapshotId),
             RestoreModalMode::FromRestoreIndex => $this->initFromRestoreIndex($restoreId),
         };
 
-        $this->showModal = true;
+        if ($shouldOpen) {
+            $this->showModal = true;
+        }
     }
 
-    protected function initFromServer(?string $targetServerId): void
+    protected function initFromServer(?string $targetServerId): bool
     {
         if (! $targetServerId) {
             abort(422, 'targetServerId is required for from-server mode.');
@@ -122,9 +124,11 @@ class Modal extends Component
 
         $this->targetServer = DatabaseServer::findOrFail($targetServerId);
         $this->authorize('restore', $this->targetServer);
+
+        return true;
     }
 
-    protected function initFromSnapshot(?string $snapshotId): void
+    protected function initFromSnapshot(?string $snapshotId): bool
     {
         if (! $snapshotId) {
             abort(422, 'snapshotId is required for from-snapshot mode.');
@@ -135,14 +139,16 @@ class Modal extends Component
 
         $this->selectedSnapshotId = $snapshotId;
         $this->dbTypeFilter = $snapshot->database_type->value;
+
+        return true;
     }
 
-    protected function initFromRestoreIndex(?string $restoreId = null): void
+    protected function initFromRestoreIndex(?string $restoreId = null): bool
     {
         $this->authorize('create', Restore::class);
 
         if (! $restoreId) {
-            return;
+            return true;
         }
 
         $restore = Restore::with(['snapshot', 'targetServer'])->findOrFail($restoreId);
@@ -156,9 +162,8 @@ class Modal extends Component
         // @phpstan-ignore booleanNot.alwaysFalse, booleanNot.alwaysFalse, booleanOr.alwaysFalse
         if (! $snapshot || ! $target) {
             $this->error(__('Cannot re-run: the original snapshot or target server no longer exists.'));
-            $this->showModal = false;
 
-            return;
+            return false;
         }
 
         $this->authorize('restoreFrom', $snapshot);
@@ -172,6 +177,8 @@ class Modal extends Component
         $this->ownerUser = (string) ($restore->options['owner_user'] ?? '');
         $this->loadExistingDatabases();
         $this->currentStep = 3;
+
+        return true;
     }
 
     public function selectSnapshot(string $snapshotId): void

--- a/app/Livewire/Restore/Modal.php
+++ b/app/Livewire/Restore/Modal.php
@@ -94,7 +94,7 @@ class Modal extends Component
     }
 
     #[On('open-restore-modal')]
-    public function openModal(string $mode = 'from-server', ?string $targetServerId = null, ?string $snapshotId = null): void
+    public function openModal(string $mode = 'from-server', ?string $targetServerId = null, ?string $snapshotId = null, ?string $restoreId = null): void
     {
         $this->reset([
             'targetServer', 'selectedSnapshotId', 'schemaName', 'forceDatabase',
@@ -108,7 +108,7 @@ class Modal extends Component
         match ($this->mode) {
             RestoreModalMode::FromServer => $this->initFromServer($targetServerId),
             RestoreModalMode::FromSnapshot => $this->initFromSnapshot($snapshotId),
-            RestoreModalMode::FromRestoreIndex => $this->initFromRestoreIndex(),
+            RestoreModalMode::FromRestoreIndex => $this->initFromRestoreIndex($restoreId),
         };
 
         $this->showModal = true;
@@ -137,9 +137,37 @@ class Modal extends Component
         $this->dbTypeFilter = $snapshot->database_type->value;
     }
 
-    protected function initFromRestoreIndex(): void
+    protected function initFromRestoreIndex(?string $restoreId = null): void
     {
         $this->authorize('create', Restore::class);
+
+        if (! $restoreId) {
+            return;
+        }
+
+        $restore = Restore::with(['snapshot', 'targetServer'])->findOrFail($restoreId);
+
+        $snapshot = $restore->snapshot;
+        $target = $restore->targetServer;
+
+        if (! $snapshot || ! $target) {
+            $this->error(__('Cannot re-run: the original snapshot or target server no longer exists.'));
+            $this->showModal = false;
+
+            return;
+        }
+
+        $this->authorize('restoreFrom', $snapshot);
+        $this->authorize('restore', $target);
+
+        $this->selectedSnapshotId = $snapshot->id;
+        $this->dbTypeFilter = $snapshot->database_type->value;
+        $this->targetServer = $target;
+        $this->schemaName = $restore->schema_name;
+        $this->forceDatabase = (bool) ($restore->options['force_database'] ?? false);
+        $this->ownerUser = (string) ($restore->options['owner_user'] ?? '');
+        $this->loadExistingDatabases();
+        $this->currentStep = 3;
     }
 
     public function selectSnapshot(string $snapshotId): void

--- a/app/Livewire/Restore/Modal.php
+++ b/app/Livewire/Restore/Modal.php
@@ -150,6 +150,10 @@ class Modal extends Component
         $snapshot = $restore->snapshot;
         $target = $restore->targetServer;
 
+        // OrganizationScope on DatabaseServer returns null for cross-org rows
+        // even though the FK is cascade-deleted — PHPDoc on the relation
+        // doesn't model that. This null check is the cross-org guard.
+        // @phpstan-ignore booleanNot.alwaysFalse, booleanNot.alwaysFalse, booleanOr.alwaysFalse
         if (! $snapshot || ! $target) {
             $this->error(__('Cannot re-run: the original snapshot or target server no longer exists.'));
             $this->showModal = false;

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -88,6 +88,7 @@ class Index extends Component
     public function headers(): array
     {
         return [
+            ['key' => 'id', 'label' => __('ID'), 'class' => 'w-28', 'sortable' => false],
             ['key' => 'created_at', 'label' => __('Created'), 'class' => 'w-48'],
             ['key' => 'server', 'label' => __('Server / Database'), 'sortable' => false],
             ['key' => 'status', 'label' => __('Status'), 'class' => 'w-32'],

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -88,12 +88,9 @@ class Index extends Component
     public function headers(): array
     {
         return [
-            ['key' => 'id', 'label' => __('ID'), 'class' => 'w-28', 'sortable' => false],
+            ['key' => 'subject', 'label' => __('Database'), 'sortable' => false],
             ['key' => 'created_at', 'label' => __('Created'), 'class' => 'w-48'],
-            ['key' => 'server', 'label' => __('Server / Database'), 'sortable' => false],
-            ['key' => 'status', 'label' => __('Status'), 'class' => 'w-32'],
-            ['key' => 'duration_ms', 'label' => __('Duration'), 'class' => 'w-28', 'sortable' => false],
-            ['key' => 'file_size', 'label' => __('Size'), 'class' => 'w-28'],
+            ['key' => 'status', 'label' => __('Status'), 'class' => 'w-44'],
         ];
     }
 

--- a/app/Queries/BackupJobQuery.php
+++ b/app/Queries/BackupJobQuery.php
@@ -20,6 +20,16 @@ class BackupJobQuery
         'restore.triggeredBy',
     ];
 
+    private const ALLOWED_SORT_COLUMNS = [
+        'created_at',
+        'started_at',
+        'completed_at',
+        'status',
+        'snapshot_size',
+        'duration_ms',
+        'type',
+    ];
+
     /**
      * @return QueryBuilder<BackupJob>
      */
@@ -99,6 +109,7 @@ class BackupJobQuery
             });
 
         $direction = Formatters::sortDirection($sortDirection);
+        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
 
         // Handle sorting
         if ($sortColumn === 'snapshot_size') {

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -12,6 +12,13 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class DatabaseServerQuery
 {
+    private const ALLOWED_SORT_COLUMNS = [
+        'name',
+        'host',
+        'database_type',
+        'created_at',
+    ];
+
     /**
      * @return QueryBuilder<DatabaseServer>
      */
@@ -45,6 +52,8 @@ class DatabaseServerQuery
         string $sortColumn = 'created_at',
         string $sortDirection = 'desc'
     ): Builder {
+        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
+
         return DatabaseServer::query()
             ->with(['backups.volume', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])
             ->withCount('snapshots')

--- a/app/Queries/RestoreQuery.php
+++ b/app/Queries/RestoreQuery.php
@@ -2,6 +2,7 @@
 
 namespace App\Queries;
 
+use App\Models\BackupJob;
 use App\Models\Restore;
 use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
@@ -51,7 +52,14 @@ class RestoreQuery
             ->when($dbTypeFilter, function (Builder $query) use ($dbTypeFilter) {
                 $query->whereHas('snapshot', fn (Builder $q) => $q->whereRaw('database_type = ?', [$dbTypeFilter]));
             })
-            ->orderBy($sortColumn, Formatters::sortDirection($sortDirection));
+            ->when($sortColumn === 'status', function (Builder $query) use ($sortDirection) {
+                $query->orderBy(
+                    BackupJob::select('status')->whereColumn('backup_jobs.id', 'restores.backup_job_id'),
+                    Formatters::sortDirection($sortDirection),
+                );
+            }, function (Builder $query) use ($sortColumn, $sortDirection) {
+                $query->orderBy($sortColumn, Formatters::sortDirection($sortDirection));
+            });
     }
 
     /**

--- a/app/Queries/RestoreQuery.php
+++ b/app/Queries/RestoreQuery.php
@@ -16,6 +16,11 @@ class RestoreQuery
         'job',
     ];
 
+    private const ALLOWED_SORT_COLUMNS = [
+        'created_at',
+        'status',
+    ];
+
     /**
      * Build query from manual parameters (for Livewire).
      *
@@ -54,6 +59,7 @@ class RestoreQuery
             });
 
         $direction = Formatters::sortDirection($sortDirection);
+        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
 
         if ($sortColumn === 'status') {
             return $query->orderBy(

--- a/app/Queries/RestoreQuery.php
+++ b/app/Queries/RestoreQuery.php
@@ -69,7 +69,9 @@ class RestoreQuery
                 ->orWhereHas('snapshot', function (Builder $sq) use ($search) {
                     $sq->whereRaw('database_name LIKE ?', ["%{$search}%"]);
                 })
-                ->orWhereRaw('schema_name LIKE ?', ["%{$search}%"]);
+                ->orWhereRaw('schema_name LIKE ?', ["%{$search}%"])
+                ->orWhereRaw('id LIKE ?', ["%{$search}%"])
+                ->orWhereRaw('snapshot_id LIKE ?', ["%{$search}%"]);
         });
     }
 }

--- a/app/Queries/RestoreQuery.php
+++ b/app/Queries/RestoreQuery.php
@@ -36,7 +36,7 @@ class RestoreQuery
             ->with(self::RELATIONSHIPS)
             ->whereHas('targetServer');
 
-        return $query
+        $query
             ->when($search, function (Builder $query) use ($search) {
                 self::applySearch($query, $search);
             })
@@ -51,15 +51,18 @@ class RestoreQuery
             })
             ->when($dbTypeFilter, function (Builder $query) use ($dbTypeFilter) {
                 $query->whereHas('snapshot', fn (Builder $q) => $q->whereRaw('database_type = ?', [$dbTypeFilter]));
-            })
-            ->when($sortColumn === 'status', function (Builder $query) use ($sortDirection) {
-                $query->orderBy(
-                    BackupJob::select('status')->whereColumn('backup_jobs.id', 'restores.backup_job_id'),
-                    Formatters::sortDirection($sortDirection),
-                );
-            }, function (Builder $query) use ($sortColumn, $sortDirection) {
-                $query->orderBy($sortColumn, Formatters::sortDirection($sortDirection));
             });
+
+        $direction = Formatters::sortDirection($sortDirection);
+
+        if ($sortColumn === 'status') {
+            return $query->orderBy(
+                BackupJob::select('status')->whereColumn('backup_jobs.id', 'restores.backup_job_id'),
+                $direction,
+            );
+        }
+
+        return $query->orderBy($sortColumn, $direction);
     }
 
     /**

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -67,7 +67,7 @@ class SnapshotQuery
 
         $query->forCurrentOrg();
 
-        return $query
+        $query
             ->when($search, function (Builder $query) use ($search) {
                 self::applySearch($query, $search);
             })
@@ -82,15 +82,18 @@ class SnapshotQuery
             })
             ->when($fileMissing, function (Builder $query) {
                 $query->whereRaw('file_exists = ?', [false]);
-            })
-            ->when($sortColumn === 'status', function (Builder $query) use ($sortDirection) {
-                $query->orderBy(
-                    BackupJob::select('status')->whereColumn('backup_jobs.id', 'snapshots.backup_job_id'),
-                    Formatters::sortDirection($sortDirection),
-                );
-            }, function (Builder $query) use ($sortColumn, $sortDirection) {
-                $query->orderBy($sortColumn, Formatters::sortDirection($sortDirection));
             });
+
+        $direction = Formatters::sortDirection($sortDirection);
+
+        if ($sortColumn === 'status') {
+            return $query->orderBy(
+                BackupJob::select('status')->whereColumn('backup_jobs.id', 'snapshots.backup_job_id'),
+                $direction,
+            );
+        }
+
+        return $query->orderBy($sortColumn, $direction);
     }
 
     /**

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -2,6 +2,7 @@
 
 namespace App\Queries;
 
+use App\Models\BackupJob;
 use App\Models\Snapshot;
 use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
@@ -82,7 +83,14 @@ class SnapshotQuery
             ->when($fileMissing, function (Builder $query) {
                 $query->whereRaw('file_exists = ?', [false]);
             })
-            ->orderBy($sortColumn, Formatters::sortDirection($sortDirection));
+            ->when($sortColumn === 'status', function (Builder $query) use ($sortDirection) {
+                $query->orderBy(
+                    BackupJob::select('status')->whereColumn('backup_jobs.id', 'snapshots.backup_job_id'),
+                    Formatters::sortDirection($sortDirection),
+                );
+            }, function (Builder $query) use ($sortColumn, $sortDirection) {
+                $query->orderBy($sortColumn, Formatters::sortDirection($sortDirection));
+            });
     }
 
     /**

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -20,6 +20,14 @@ class SnapshotQuery
         'job',
     ];
 
+    private const ALLOWED_SORT_COLUMNS = [
+        'started_at',
+        'created_at',
+        'file_size',
+        'database_name',
+        'status',
+    ];
+
     /**
      * @return QueryBuilder<Snapshot>
      */
@@ -85,6 +93,7 @@ class SnapshotQuery
             });
 
         $direction = Formatters::sortDirection($sortDirection);
+        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
 
         if ($sortColumn === 'status') {
             return $query->orderBy(

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -95,7 +95,8 @@ class SnapshotQuery
                 $sq->whereRaw('name LIKE ?', ["%{$search}%"])
                     ->orWhereRaw('host LIKE ?', ["%{$search}%"]);
             })
-                ->orWhere('database_name', 'like', "%{$search}%");
+                ->orWhere('database_name', 'like', "%{$search}%")
+                ->orWhereRaw('id LIKE ?', ["%{$search}%"]);
         });
     }
 }

--- a/app/Queries/VolumeQuery.php
+++ b/app/Queries/VolumeQuery.php
@@ -11,6 +11,12 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class VolumeQuery
 {
+    private const ALLOWED_SORT_COLUMNS = [
+        'name',
+        'type',
+        'created_at',
+    ];
+
     /**
      * @return QueryBuilder<Volume>
      */
@@ -42,6 +48,8 @@ class VolumeQuery
         string $sortColumn = 'created_at',
         string $sortDirection = 'desc'
     ): Builder {
+        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
+
         return Volume::query()
             ->when($search, function (Builder $query) use ($search) {
                 self::applySearch($query, $search);

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -35,6 +35,12 @@
                 </div>
             </x-slot:empty>
 
+            @scope('cell_id', $restore)
+                <div class="tooltip tooltip-right" data-tip="{{ $restore->id }}">
+                    <span class="font-mono text-xs text-base-content/70">{{ \Illuminate\Support\Str::substr($restore->id, -7) }}</span>
+                </div>
+            @endscope
+
             @scope('cell_created_at', $restore)
                 <div class="table-cell-primary">{{ \App\Support\Formatters::humanDate($restore->created_at) }}</div>
                 <div class="text-sm text-base-content/70">{{ $restore->created_at->diffForHumans() }}</div>
@@ -45,7 +51,17 @@
                     <div class="flex items-center gap-2">
                         <x-icon :name="$restore->snapshot->database_type->icon()" class="w-5 h-5" />
                         <div>
-                            <div class="table-cell-primary">{{ $restore->snapshot->databaseServer?->name ?? '?' }}</div>
+                            <div class="flex items-center gap-1">
+                                <span class="table-cell-primary">{{ $restore->snapshot->databaseServer?->name ?? '?' }}</span>
+                                <a
+                                    href="{{ route('snapshots.index', ['search' => $restore->snapshot->id]) }}"
+                                    wire:navigate
+                                    class="text-base-content/50 hover:text-primary"
+                                    title="{{ __('View snapshot') }}"
+                                >
+                                    <x-icon name="o-arrow-top-right-on-square" class="w-3.5 h-3.5" />
+                                </a>
+                            </div>
                             <div class="text-sm text-base-content/70">{{ $restore->snapshot->database_name }}</div>
                             <div class="text-xs text-base-content/50">{{ \App\Support\Formatters::humanDate($restore->snapshot->created_at) }}</div>
                         </div>

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -145,7 +145,7 @@
                                 icon="o-arrow-path"
                                 wire:click="rerunRestore('{{ $restore->id }}')"
                                 spinner
-                                tooltip="{{ __('Re-run') }}"
+                                :tooltip="__('Re-run')"
                                 class="btn-ghost btn-sm text-success"
                             />
                         @endcan
@@ -154,7 +154,7 @@
                     <x-button
                         icon="o-document-text"
                         wire:click="viewLogs('{{ $job?->id }}')"
-                        tooltip="{{ __('View Logs') }}"
+                        :tooltip="__('View Logs')"
                         class="btn-ghost btn-sm"
                         :class="$hasLogs ? '' : 'opacity-30'"
                         :disabled="! $hasLogs"
@@ -164,7 +164,7 @@
                         <x-button
                             icon="o-trash"
                             wire:click="confirmDeleteRestore('{{ $restore->id }}')"
-                            tooltip="{{ __('Delete') }}"
+                            :tooltip="__('Delete')"
                             class="btn-ghost btn-sm text-error"
                         />
                     @endcan

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -1,4 +1,4 @@
-<div wire:poll.5s>
+<div wire:poll.30s>
     @if($errorMessage)
         <x-alert title="{{ $errorMessage }}" class="alert-error mb-4" icon="o-x-circle" />
     @endif
@@ -24,125 +24,147 @@
     </div>
 
     <x-card shadow>
-        <x-table :headers="$headers" :rows="$restores" :sort-by="$sortBy" with-pagination>
+        <x-table
+            :headers="$headers"
+            :rows="$restores"
+            :sort-by="$sortBy"
+            with-pagination
+            :row-decoration="[
+                'bg-error/5' => fn ($restore) => $restore->job?->status === 'failed',
+                'bg-warning/5' => fn ($restore) => $restore->job?->status === 'running',
+            ]"
+        >
             <x-slot:empty>
-                <div class="text-center text-base-content/50 py-8">
+                <div class="flex flex-col items-center justify-center py-12 text-center">
+                    <x-icon name="o-arrow-path" class="w-10 h-10 text-base-content/30 mb-3" />
                     @if($search || $statusFilter !== '' || $sourceServerFilter !== '' || $targetServerFilter !== '' || $dbTypeFilter !== '')
-                        {{ __('No restores found matching your filters.') }}
+                        <p class="font-medium">{{ __('No restores match your filters') }}</p>
+                        <p class="text-sm text-base-content/60 mt-1">{{ __('Try clearing some filters to see more results.') }}</p>
                     @else
-                        {{ __('No restores yet. Trigger one from a snapshot or from the "New Restore" button.') }}
+                        <p class="font-medium">{{ __('No restores yet') }}</p>
+                        <p class="text-sm text-base-content/60 mt-1">{{ __('Trigger one from a snapshot or via the “New Restore” button.') }}</p>
                     @endif
                 </div>
             </x-slot:empty>
 
-            @scope('cell_id', $restore)
-                <div class="tooltip tooltip-right" data-tip="{{ $restore->id }}">
-                    <span class="font-mono text-xs text-base-content/70">{{ \Illuminate\Support\Str::substr($restore->id, -7) }}</span>
+            @scope('cell_flow', $restore)
+                @php $snapshot = $restore->snapshot; $target = $restore->targetServer; @endphp
+                <div class="flex items-center gap-3 min-w-0">
+                    {{-- Source --}}
+                    <div class="flex items-center gap-2 min-w-0 flex-1">
+                        @if($snapshot)
+                            <x-icon :name="$snapshot->database_type->icon()" class="w-5 h-5 shrink-0" />
+                            <div class="min-w-0">
+                                <div class="flex items-center gap-1.5">
+                                    <span class="table-cell-primary truncate">{{ $snapshot->database_name }}</span>
+                                    <a
+                                        href="{{ route('snapshots.index', ['search' => $snapshot->id]) }}"
+                                        wire:navigate
+                                        class="text-base-content/40 hover:text-primary tooltip shrink-0"
+                                        data-tip="{{ __('View snapshot') }}"
+                                    >
+                                        <x-icon name="o-arrow-top-right-on-square" class="w-3.5 h-3.5" />
+                                    </a>
+                                </div>
+                                <div class="text-xs text-base-content/60 truncate">{{ $snapshot->databaseServer?->name ?? '?' }}</div>
+                            </div>
+                        @else
+                            <span class="text-sm text-base-content/50 italic">{{ __('(snapshot deleted)') }}</span>
+                        @endif
+                    </div>
+
+                    <x-icon name="o-arrow-right" class="w-4 h-4 text-base-content/40 shrink-0" />
+
+                    {{-- Target --}}
+                    <div class="flex items-center gap-2 min-w-0 flex-1">
+                        @if($target)
+                            <x-icon :name="$snapshot?->database_type?->icon() ?? 'o-server'" class="w-5 h-5 shrink-0" />
+                            <div class="min-w-0">
+                                <div class="table-cell-primary truncate">{{ $restore->schema_name }}</div>
+                                <div class="text-xs text-base-content/60 truncate">{{ $target->name }}</div>
+                            </div>
+                        @else
+                            <span class="text-sm text-base-content/50 italic">{{ __('(target deleted)') }}</span>
+                        @endif
+                    </div>
+                </div>
+
+                <div class="mt-1.5">
+                    <span class="tooltip" data-tip="{{ $restore->id }}">
+                        <kbd class="kbd kbd-xs font-mono">#{{ \Illuminate\Support\Str::substr($restore->id, -7) }}</kbd>
+                    </span>
                 </div>
             @endscope
 
             @scope('cell_created_at', $restore)
-                <div class="table-cell-primary">{{ \App\Support\Formatters::humanDate($restore->created_at) }}</div>
-                <div class="text-sm text-base-content/70">{{ $restore->created_at->diffForHumans() }}</div>
-            @endscope
-
-            @scope('cell_source', $restore)
-                @if($restore->snapshot)
-                    <div class="flex items-center gap-2">
-                        <x-icon :name="$restore->snapshot->database_type->icon()" class="w-5 h-5" />
-                        <div>
-                            <div class="flex items-center gap-1">
-                                <span class="table-cell-primary">{{ $restore->snapshot->databaseServer?->name ?? '?' }}</span>
-                                <a
-                                    href="{{ route('snapshots.index', ['search' => $restore->snapshot->id]) }}"
-                                    wire:navigate
-                                    class="text-base-content/50 hover:text-primary"
-                                    title="{{ __('View snapshot') }}"
-                                >
-                                    <x-icon name="o-arrow-top-right-on-square" class="w-3.5 h-3.5" />
-                                </a>
-                            </div>
-                            <div class="text-sm text-base-content/70">{{ $restore->snapshot->database_name }}</div>
-                            <div class="text-xs text-base-content/50">{{ \App\Support\Formatters::humanDate($restore->snapshot->created_at) }}</div>
-                        </div>
-                    </div>
-                @else
-                    <span class="text-base-content/50">{{ __('(snapshot deleted)') }}</span>
-                @endif
-            @endscope
-
-            @scope('cell_target', $restore)
-                @if($restore->targetServer)
-                    <div>
-                        <div class="table-cell-primary">{{ $restore->targetServer->name }}</div>
-                        <div class="text-sm text-base-content/70">{{ $restore->schema_name }}</div>
-                    </div>
-                @else
-                    <span class="text-base-content/50">-</span>
-                @endif
+                <div class="table-cell-primary">{{ $restore->created_at->diffForHumans() }}</div>
+                <div class="text-sm text-base-content/60">{{ \App\Support\Formatters::humanDate($restore->created_at) }}</div>
+                <div class="flex items-center gap-1 text-xs text-base-content/60 mt-1">
+                    <x-icon name="o-user" class="w-3 h-3" />
+                    <span>{{ $restore->triggeredBy?->name ?? __('system') }}</span>
+                </div>
             @endscope
 
             @scope('cell_status', $restore)
-                @php $status = $restore->job?->status ?? 'unknown'; @endphp
+                @php $status = $restore->job?->status ?? 'pending'; $job = $restore->job; @endphp
                 @if($status === 'completed')
-                    <x-badge value="{{ __('Completed') }}" class="badge-success" />
+                    <x-badge :value="__('Completed')" class="badge-success badge-soft badge-sm" />
                 @elseif($status === 'failed')
-                    <x-badge value="{{ __('Failed') }}" class="badge-error" />
+                    <x-badge :value="__('Failed')" class="badge-error badge-soft badge-sm" />
                 @elseif($status === 'running')
-                    <div class="badge badge-warning gap-1">
+                    <span class="badge badge-warning badge-soft badge-sm gap-1">
                         <x-loading class="loading-spinner loading-xs" />
                         {{ __('Running') }}
-                    </div>
+                    </span>
                 @else
-                    <x-badge value="{{ __('Pending') }}" class="badge-info" />
+                    <x-badge :value="__('Pending')" class="badge-info badge-soft badge-sm" />
                 @endif
-            @endscope
 
-            @scope('cell_duration_ms', $restore)
-                @php $job = $restore->job; @endphp
-                @if($job?->status === 'running' && $job->started_at)
-                    <span class="font-mono text-sm text-warning">{{ $job->started_at->diffForHumans(null, true) }}</span>
+                @if($status === 'running' && $job?->started_at)
+                    <div class="text-xs text-warning font-mono mt-1">{{ $job->started_at->diffForHumans(null, true) }}</div>
                 @elseif($job?->getHumanDuration())
-                    <span class="font-mono text-sm">{{ $job->getHumanDuration() }}</span>
-                @else
-                    <span class="text-base-content/50">-</span>
-                @endif
-            @endscope
-
-            @scope('cell_triggered_by', $restore)
-                @if($restore->triggeredBy)
-                    <span class="text-sm">{{ $restore->triggeredBy->name }}</span>
-                @else
-                    <span class="text-base-content/50">-</span>
+                    <div class="flex items-center gap-1 text-xs text-base-content/60 mt-1">
+                        <x-icon name="o-clock" class="w-3 h-3" />
+                        <span class="font-mono">{{ $job->getHumanDuration() }}</span>
+                    </div>
                 @endif
             @endscope
 
             @scope('actions', $restore)
-                <div class="flex gap-2 justify-end">
-                    <x-button
-                        icon="o-document-text"
-                        wire:click="viewLogs('{{ $restore->job?->id }}')"
-                        :tooltip="__('View Logs')"
-                        class="btn-ghost btn-sm"
-                        :class="empty($restore->job?->logs) ? 'opacity-30' : ''"
-                        :disabled="empty($restore->job?->logs)"
-                    />
-                    @if($restore->snapshot && $restore->targetServer)
+                @php
+                    $snapshot = $restore->snapshot;
+                    $target = $restore->targetServer;
+                    $canRerun = $snapshot && $target;
+                    $job = $restore->job;
+                    $hasLogs = ! empty($job?->logs);
+                @endphp
+                <div class="flex items-center gap-1 justify-end">
+                    @if($canRerun)
                         @can('create', \App\Models\Restore::class)
                             <x-button
                                 icon="o-arrow-path"
                                 wire:click="rerunRestore('{{ $restore->id }}')"
                                 spinner
-                                :tooltip="__('Re-run')"
+                                tooltip="{{ __('Re-run') }}"
                                 class="btn-ghost btn-sm text-success"
                             />
                         @endcan
                     @endif
+
+                    <x-button
+                        icon="o-document-text"
+                        wire:click="viewLogs('{{ $job?->id }}')"
+                        tooltip="{{ __('View Logs') }}"
+                        class="btn-ghost btn-sm"
+                        :class="$hasLogs ? '' : 'opacity-30'"
+                        :disabled="! $hasLogs"
+                    />
+
                     @can('delete', $restore)
                         <x-button
                             icon="o-trash"
                             wire:click="confirmDeleteRestore('{{ $restore->id }}')"
-                            :tooltip="__('Delete')"
+                            tooltip="{{ __('Delete') }}"
                             class="btn-ghost btn-sm text-error"
                         />
                     @endcan

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -111,6 +111,17 @@
                         :class="empty($restore->job?->logs) ? 'opacity-30' : ''"
                         :disabled="empty($restore->job?->logs)"
                     />
+                    @if($restore->snapshot && $restore->targetServer)
+                        @can('create', \App\Models\Restore::class)
+                            <x-button
+                                icon="o-arrow-path"
+                                wire:click="rerunRestore('{{ $restore->id }}')"
+                                spinner
+                                :tooltip="__('Re-run')"
+                                class="btn-ghost btn-sm text-success"
+                            />
+                        @endcan
+                    @endif
                     @can('delete', $restore)
                         <x-button
                             icon="o-trash"

--- a/resources/views/livewire/restore/modal.blade.php
+++ b/resources/views/livewire/restore/modal.blade.php
@@ -1,12 +1,15 @@
+@php use App\Enums\RestoreModalMode; @endphp
 <div>
     <x-modal wire:model="showModal" box-class="max-w-3xl w-11/12" class="backdrop-blur">
-        <x-header :title="__('Restore Database Snapshot')" icon="bi.database-fill-down" icon-classes="text-success w-6 h-6" size="text-xl" class="!mb-5" />
+        <x-header :title="__('Restore Database Snapshot')" icon="bi.database-fill-down"
+                  icon-classes="text-success w-6 h-6" size="text-xl" class="!mb-5"/>
         <div class="space-y-4">
             {{-- Locked context badges --}}
             @if($mode->targetServerLocked() && $targetServer)
                 <div class="flex flex-wrap items-center gap-2">
                     <span class="text-xs opacity-60">{{ __('Restoring to:') }}</span>
-                    <x-badge :value="$targetServer->name . ' (' . $targetServer->database_type->label() . ')'" class="badge-primary" />
+                    <x-badge :value="$targetServer->name . ' (' . $targetServer->database_type->label() . ')'"
+                             class="badge-primary"/>
                 </div>
             @endif
 
@@ -29,12 +32,12 @@
 
             {{-- Step body: snapshot picker --}}
             @if(
-                ($mode === \App\Enums\RestoreModalMode::FromServer && $currentStep === 1) ||
-                ($mode === \App\Enums\RestoreModalMode::FromRestoreIndex && $currentStep === 1)
+                ($mode === RestoreModalMode::FromServer && $currentStep === 1) ||
+                ($mode === RestoreModalMode::FromRestoreIndex && $currentStep === 1)
             )
                 <div class="space-y-4">
                     <p class="text-sm opacity-70">
-                        @if($mode === \App\Enums\RestoreModalMode::FromServer)
+                        @if($mode === RestoreModalMode::FromServer)
                             {{ __('Select a snapshot to restore. Only snapshots from :type servers are shown.', ['type' => $targetServer?->database_type?->label()]) }}
                         @else
                             {{ __('Select a snapshot to restore.') }}
@@ -42,7 +45,7 @@
                     </p>
 
                     <div class="flex flex-wrap items-center gap-4">
-                        @if($mode === \App\Enums\RestoreModalMode::FromRestoreIndex)
+                        @if($mode === RestoreModalMode::FromRestoreIndex)
                             <x-select
                                 wire:model.live="dbTypeFilter"
                                 :options="collect($this->dbTypeOptions())->prepend(['id' => '', 'name' => __('All types')])->all()"
@@ -64,7 +67,7 @@
                         />
                     </div>
 
-                    <x-hr class="my-2" />
+                    <x-hr class="my-2"/>
 
                     <div wire:loading.class="opacity-60 pointer-events-none" class="transition-opacity duration-200">
                         @if(!$this->paginatedSnapshots || $this->paginatedSnapshots->isEmpty())
@@ -89,16 +92,21 @@
                                                 <div class="text-sm">
                                                     <span class="opacity-50">{{ __('Database:') }}</span>
                                                     <span class="font-medium">{{ $snapshot->database_name }}</span>
-                                                    <x-badge :value="$snapshot->database_type->label()" class="badge-ghost badge-xs ml-1" />
+                                                    <x-badge :value="$snapshot->database_type->label()"
+                                                             class="badge-ghost badge-xs ml-1"/>
                                                 </div>
                                                 <div class="text-xs">
                                                     <span class="opacity-50">{{ __('Server:') }}</span>
-                                                    <span class="opacity-70">{{ $snapshot->databaseServer?->name }}</span>
+                                                    <span
+                                                        class="opacity-70">{{ $snapshot->databaseServer?->name }}</span>
                                                 </div>
                                             </div>
                                             <div class="text-right space-y-0.5">
-                                                <div class="text-xs opacity-60 whitespace-nowrap flex items-center justify-end gap-2">
-                                                    <x-loading wire:loading wire:target="selectSnapshot('{{ $snapshot->id }}')" class="loading-xs" />
+                                                <div
+                                                    class="text-xs opacity-60 whitespace-nowrap flex items-center justify-end gap-2">
+                                                    <x-loading wire:loading
+                                                               wire:target="selectSnapshot('{{ $snapshot->id }}')"
+                                                               class="loading-xs"/>
                                                     {{ \App\Support\Formatters::humanDate($snapshot->created_at) }}
                                                     <span class="opacity-50">({{ $snapshot->created_at->diffForHumans() }})</span>
                                                     &bull;
@@ -129,8 +137,8 @@
 
             {{-- Step body: target server picker --}}
             @if(
-                ($mode === \App\Enums\RestoreModalMode::FromSnapshot && $currentStep === 1) ||
-                ($mode === \App\Enums\RestoreModalMode::FromRestoreIndex && $currentStep === 2)
+                ($mode === RestoreModalMode::FromSnapshot && $currentStep === 1) ||
+                ($mode === RestoreModalMode::FromRestoreIndex && $currentStep === 2)
             )
                 <div class="space-y-4">
                     <p class="text-sm opacity-70">
@@ -151,9 +159,12 @@
                                     <div class="flex items-center justify-between gap-4">
                                         <div class="flex-1 min-w-0">
                                             <div class="text-sm font-medium">{{ $server->name }}</div>
-                                            <div class="text-xs opacity-60">{{ $server->host }}@if($server->port):{{ $server->port }}@endif</div>
+                                            <div class="text-xs opacity-60">{{ $server->host }}@if($server->port)
+                                                    :{{ $server->port }}
+                                                @endif</div>
                                         </div>
-                                        <x-loading wire:loading wire:target="selectTargetServer('{{ $server->id }}')" class="loading-xs" />
+                                        <x-loading wire:loading wire:target="selectTargetServer('{{ $server->id }}')"
+                                                   class="loading-xs"/>
                                     </div>
                                 </div>
                             @endforeach
@@ -161,7 +172,7 @@
                     @endif
 
                     <div class="flex gap-2 mt-6">
-                        @if($mode === \App\Enums\RestoreModalMode::FromRestoreIndex)
+                        @if($mode === RestoreModalMode::FromRestoreIndex)
                             <x-button class="btn-ghost" wire:click="previousStep">{{ __('Back') }}</x-button>
                         @endif
                         <div class="flex-1"></div>
@@ -183,7 +194,7 @@
                             autocomplete="off"
                         />
                         @error('schemaName')
-                            <p class="text-error text-sm mt-1">{{ $message }}</p>
+                        <p class="text-error text-sm mt-1">{{ $message }}</p>
                         @enderror
 
                         @if(count($this->filteredDatabases) > 0)
@@ -212,7 +223,9 @@
 
                     @if(in_array($schemaName, $existingDatabases))
                         <x-alert class="alert-warning" icon="o-exclamation-triangle">
-                            {{ __('The database') }} <x-badge class="badge-error badge-dash" :value="$schemaName" /> {{ __('already exists.') }}<br>
+                            {{ __('The database') }}
+                            <x-badge class="badge-error badge-dash" :value="$schemaName"/> {{ __('already exists.') }}
+                            <br>
                             {{ __('It will be overwritten if you continue.') }}
                         </x-alert>
                     @endif
@@ -238,10 +251,17 @@
                         <div class="p-4 border rounded-lg bg-base-200 border-base-300">
                             <div class="text-sm font-semibold mb-2">{{ __('Restore Summary') }}</div>
                             <div class="text-sm opacity-70 space-y-1">
-                                <div><strong>{{ __('Source:') }}</strong> {{ $this->selectedSnapshot->databaseServer?->name }} &bull; {{ $this->selectedSnapshot->database_name }}</div>
-                                <div><strong>{{ __('Snapshot:') }}</strong> {{ \App\Support\Formatters::humanDate($this->selectedSnapshot->created_at) }}</div>
-                                <div><strong>{{ __('Target:') }}</strong> {{ $targetServer?->name }} &bull; {{ $schemaName ?: __('(enter name)') }}</div>
-                                <div><strong>{{ __('Size:') }}</strong> {{ $this->selectedSnapshot->getHumanFileSize() }}</div>
+                                <div><strong>{{ __('Source:') }}</strong>
+                                    {{ $this->selectedSnapshot->databaseServer?->name }} &bull; {{ $this->selectedSnapshot->database_name }}
+                                </div>
+                                <div>
+                                    <strong>{{ __('Snapshot:') }}</strong> {{ \App\Support\Formatters::humanDate($this->selectedSnapshot->created_at) }}
+                                </div>
+                                <div><strong>{{ __('Target:') }}</strong>
+                                    {{ $targetServer?->name }} &bull; {{ $schemaName ?: __('(enter name)') }}</div>
+                                <div>
+                                    <strong>{{ __('Size:') }}</strong> {{ $this->selectedSnapshot->getHumanFileSize() }}
+                                </div>
                             </div>
                         </div>
                     @endif

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -29,6 +29,12 @@
                 </div>
             </x-slot:empty>
 
+            @scope('cell_id', $snapshot)
+                <div class="tooltip tooltip-right" data-tip="{{ $snapshot->id }}">
+                    <span class="font-mono text-xs text-base-content/70">{{ \Illuminate\Support\Str::substr($snapshot->id, -7) }}</span>
+                </div>
+            @endscope
+
             @scope('cell_created_at', $snapshot)
                 <div class="table-cell-primary">{{ \App\Support\Formatters::humanDate($snapshot->created_at) }}</div>
                 <div class="text-sm text-base-content/70">{{ $snapshot->created_at->diffForHumans() }}</div>

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -135,7 +135,7 @@
                             <x-button
                                 icon="bi.database-fill-down"
                                 wire:click="triggerRestore('{{ $snapshot->id }}')"
-                                tooltip="{{ __('Restore') }}"
+                                :tooltip="__('Restore')"
                                 class="btn-ghost btn-sm text-success"
                             />
                         @endcan
@@ -147,7 +147,7 @@
                                 icon="o-arrow-down-tray"
                                 :link="route('snapshots.download', $snapshot)"
                                 external
-                                tooltip="{{ __('Download') }}"
+                                :tooltip="__('Download')"
                                 class="btn-ghost btn-sm text-primary"
                             />
                         @endcan
@@ -156,7 +156,7 @@
                     <x-button
                         icon="o-document-text"
                         wire:click="viewLogs('{{ $job?->id }}')"
-                        tooltip="{{ __('View Logs') }}"
+                        :tooltip="__('View Logs')"
                         class="btn-ghost btn-sm"
                         :class="$hasLogs ? '' : 'opacity-30'"
                         :disabled="! $hasLogs"
@@ -167,7 +167,7 @@
                             <x-button
                                 icon="o-trash"
                                 wire:click="confirmDeleteSnapshot('{{ $snapshot->id }}')"
-                                tooltip="{{ __('Delete') }}"
+                                :tooltip="__('Delete')"
                                 class="btn-ghost btn-sm text-error"
                             />
                         @endcan
@@ -178,7 +178,7 @@
                             <x-button
                                 icon="o-x-mark"
                                 wire:click="confirmCancelJob('{{ $job->id }}')"
-                                tooltip="{{ __('Cancel') }}"
+                                :tooltip="__('Cancel')"
                                 class="btn-ghost btn-sm text-error"
                             />
                         @endcan

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -1,4 +1,4 @@
-<div wire:poll.5s>
+<div wire:poll.30s>
     @if($errorMessage)
         <x-alert title="{{ $errorMessage }}" class="alert-error mb-4" icon="o-x-circle" />
     @endif
@@ -16,153 +16,169 @@
     </div>
 
     <x-card shadow>
-        <x-table :headers="$headers" :rows="$snapshots" :sort-by="$sortBy" with-pagination
-            :row-decoration="['bg-warning/5' => fn($snapshot) => !$snapshot->file_exists && $snapshot->job?->status === 'completed']"
+        <x-table
+            :headers="$headers"
+            :rows="$snapshots"
+            :sort-by="$sortBy"
+            with-pagination
+            :row-decoration="[
+                'bg-error/5' => fn ($snapshot) => $snapshot->job?->status === 'failed',
+                'bg-warning/5' => fn ($snapshot) => $snapshot->job?->status === 'running'
+                    || (! $snapshot->file_exists && $snapshot->job?->status === 'completed'),
+            ]"
         >
             <x-slot:empty>
-                <div class="text-center text-base-content/50 py-8">
+                <div class="flex flex-col items-center justify-center py-12 text-center">
+                    <x-icon name="o-archive-box" class="w-10 h-10 text-base-content/30 mb-3" />
                     @if($search || $statusFilter !== '' || $serverFilter !== '' || $dbTypeFilter !== '' || $fileMissing !== '')
-                        {{ __('No snapshots found matching your filters.') }}
+                        <p class="font-medium">{{ __('No snapshots match your filters') }}</p>
+                        <p class="text-sm text-base-content/60 mt-1">{{ __('Try clearing some filters to see more results.') }}</p>
                     @else
-                        {{ __('No snapshots yet. Backups will appear here.') }}
+                        <p class="font-medium">{{ __('No snapshots yet') }}</p>
+                        <p class="text-sm text-base-content/60 mt-1">{{ __('Snapshots will appear here once your first backup completes.') }}</p>
                     @endif
                 </div>
             </x-slot:empty>
 
-            @scope('cell_id', $snapshot)
-                <div class="tooltip tooltip-right" data-tip="{{ $snapshot->id }}">
-                    <span class="font-mono text-xs text-base-content/70">{{ \Illuminate\Support\Str::substr($snapshot->id, -7) }}</span>
+            @scope('cell_subject', $snapshot)
+                @php $fileMissing = $snapshot->job?->status === 'completed' && ! $snapshot->file_exists; @endphp
+                <div class="flex items-center gap-3 min-w-0">
+                    <x-icon :name="$snapshot->database_type->icon()" class="w-6 h-6 shrink-0" />
+                    <div class="min-w-0">
+                        <div class="flex items-center gap-2 flex-wrap">
+                            <span class="table-cell-primary truncate">{{ $snapshot->database_name }}</span>
+                            <span class="text-sm text-base-content/60 truncate">{{ $snapshot->databaseServer?->name ?? __('(unknown)') }}</span>
+                        </div>
+                        <div class="flex items-center gap-2 mt-1 flex-wrap">
+                            <span class="tooltip" data-tip="{{ $snapshot->id }}">
+                                <kbd class="kbd kbd-xs font-mono">#{{ \Illuminate\Support\Str::substr($snapshot->id, -7) }}</kbd>
+                            </span>
+                            @if($fileMissing)
+                                <x-popover>
+                                    <x-slot:trigger>
+                                        <span class="badge badge-warning badge-soft badge-xs gap-1 cursor-help">
+                                            <x-icon name="o-exclamation-triangle" class="w-3 h-3" />
+                                            {{ __('File missing') }}
+                                        </span>
+                                    </x-slot:trigger>
+                                    <x-slot:content>
+                                        <div class="text-xs space-y-1">
+                                            <div class="font-semibold text-warning">{{ __('Backup file not found on volume') }}</div>
+                                            @if($snapshot->file_verified_at)
+                                                <div class="text-base-content/70">
+                                                    {{ __('Checked') }}: {{ \App\Support\Formatters::humanDate($snapshot->file_verified_at) }}
+                                                    ({{ $snapshot->file_verified_at->diffForHumans() }})
+                                                </div>
+                                            @endif
+                                        </div>
+                                    </x-slot:content>
+                                </x-popover>
+                            @endif
+                        </div>
+                    </div>
                 </div>
             @endscope
 
             @scope('cell_created_at', $snapshot)
-                <div class="table-cell-primary">{{ \App\Support\Formatters::humanDate($snapshot->created_at) }}</div>
-                <div class="text-sm text-base-content/70">{{ $snapshot->created_at->diffForHumans() }}</div>
-            @endscope
-
-            @scope('cell_server', $snapshot)
-                @if($snapshot->databaseServer)
-                    <div class="flex items-center gap-2">
-                        <x-icon :name="$snapshot->database_type->icon()" class="w-5 h-5" />
-                        <div>
-                            <div class="table-cell-primary">{{ $snapshot->databaseServer->name }}</div>
-                            <div class="text-sm text-base-content/70">{{ $snapshot->database_name }}</div>
-                        </div>
-                    </div>
-                @else
-                    <span class="text-base-content/50">{{ __('Loading...') }}</span>
-                @endif
+                <div class="table-cell-primary">{{ $snapshot->created_at->diffForHumans() }}</div>
+                <div class="text-sm text-base-content/60">{{ \App\Support\Formatters::humanDate($snapshot->created_at) }}</div>
             @endscope
 
             @scope('cell_status', $snapshot)
-                @php $status = $snapshot->job?->status ?? 'unknown'; @endphp
+                @php $status = $snapshot->job?->status ?? 'pending'; $job = $snapshot->job; @endphp
                 @if($status === 'completed')
-                    <x-badge value="{{ __('Completed') }}" class="badge-success" />
+                    <x-badge :value="__('Completed')" class="badge-success badge-soft badge-sm" />
                 @elseif($status === 'failed')
-                    <x-badge value="{{ __('Failed') }}" class="badge-error" />
+                    <x-badge :value="__('Failed')" class="badge-error badge-soft badge-sm" />
                 @elseif($status === 'running')
-                    <div class="badge badge-warning gap-1">
+                    <span class="badge badge-warning badge-soft badge-sm gap-1">
                         <x-loading class="loading-spinner loading-xs" />
                         {{ __('Running') }}
+                    </span>
+                @else
+                    <x-badge :value="__('Pending')" class="badge-info badge-soft badge-sm" />
+                @endif
+
+                @if($status === 'running' && $job?->started_at)
+                    <div class="text-xs text-warning font-mono mt-1">{{ $job->started_at->diffForHumans(null, true) }}</div>
+                @elseif($job?->getHumanDuration() || ($status === 'completed' && $snapshot->getHumanFileSize()))
+                    <div class="flex items-center gap-3 text-xs text-base-content/60 mt-1">
+                        @if($job?->getHumanDuration())
+                            <span class="inline-flex items-center gap-1">
+                                <x-icon name="o-clock" class="w-3 h-3" />
+                                <span class="font-mono">{{ $job->getHumanDuration() }}</span>
+                            </span>
+                        @endif
+                        @if($status === 'completed' && $snapshot->getHumanFileSize())
+                            <span class="inline-flex items-center gap-1">
+                                <x-icon name="o-archive-box" class="w-3 h-3" />
+                                <span class="font-mono">{{ $snapshot->getHumanFileSize() }}</span>
+                            </span>
+                        @endif
                     </div>
-                @else
-                    <x-badge value="{{ __('Pending') }}" class="badge-info" />
-                @endif
-                @if(!$snapshot->file_exists && $status === 'completed')
-                    <x-popover>
-                        <x-slot:trigger>
-                            <div class="flex items-center gap-1 text-warning text-xs mt-1">
-                                <x-icon name="o-exclamation-triangle" class="w-3.5 h-3.5" />
-                                {{ __('File missing') }}
-                            </div>
-                        </x-slot:trigger>
-                        <x-slot:content>
-                            <div class="text-xs space-y-1">
-                                <div class="font-semibold text-warning">{{ __('Backup file not found on volume') }}</div>
-                                @if($snapshot->file_verified_at)
-                                    <div class="text-base-content/70">
-                                        {{ __('Checked') }}: {{ \App\Support\Formatters::humanDate($snapshot->file_verified_at) }}
-                                        ({{ $snapshot->file_verified_at->diffForHumans() }})
-                                    </div>
-                                @endif
-                            </div>
-                        </x-slot:content>
-                    </x-popover>
-                @endif
-            @endscope
-
-            @scope('cell_duration_ms', $snapshot)
-                @php $job = $snapshot->job; @endphp
-                @if($job?->status === 'running' && $job->started_at)
-                    <span class="font-mono text-sm text-warning">{{ $job->started_at->diffForHumans(null, true) }}</span>
-                @elseif($job?->getHumanDuration())
-                    <span class="font-mono text-sm">{{ $job->getHumanDuration() }}</span>
-                @else
-                    <span class="text-base-content/50">-</span>
-                @endif
-            @endscope
-
-            @scope('cell_file_size', $snapshot)
-                @if($snapshot->job?->status === 'completed')
-                    <span class="font-mono text-sm">{{ $snapshot->getHumanFileSize() }}</span>
-                @else
-                    <span class="text-base-content/50">-</span>
                 @endif
             @endscope
 
             @scope('actions', $snapshot)
                 @php
                     $status = $snapshot->job?->status;
-                    $canRestore = $status === 'completed'
-                        && $snapshot->file_exists
-                        && $snapshot->database_type !== \App\Enums\DatabaseType::REDIS;
+                    $job = $snapshot->job;
+                    $canRestore = $status === 'completed' && $snapshot->file_exists && $snapshot->database_type !== \App\Enums\DatabaseType::REDIS;
+                    $canDownload = $status === 'completed';
+                    $canDelete = in_array($status, ['completed', 'failed'], true);
+                    $canCancel = $status === 'pending' && $job;
+                    $hasLogs = ! empty($job?->logs);
                 @endphp
-                <div class="flex gap-2 justify-end">
+                <div class="flex items-center gap-1 justify-end">
                     @if($canRestore)
                         @can('restoreFrom', $snapshot)
                             <x-button
                                 icon="bi.database-fill-down"
                                 wire:click="triggerRestore('{{ $snapshot->id }}')"
-                                :tooltip="__('Restore')"
+                                tooltip="{{ __('Restore') }}"
                                 class="btn-ghost btn-sm text-success"
                             />
                         @endcan
                     @endif
-                    @if($status === 'completed')
+
+                    @if($canDownload)
                         @can('download', $snapshot)
                             <x-button
                                 icon="o-arrow-down-tray"
                                 :link="route('snapshots.download', $snapshot)"
                                 external
-                                :tooltip="__('Download')"
+                                tooltip="{{ __('Download') }}"
                                 class="btn-ghost btn-sm text-primary"
                             />
                         @endcan
                     @endif
+
                     <x-button
                         icon="o-document-text"
-                        wire:click="viewLogs('{{ $snapshot->job?->id }}')"
-                        :tooltip="__('View Logs')"
+                        wire:click="viewLogs('{{ $job?->id }}')"
+                        tooltip="{{ __('View Logs') }}"
                         class="btn-ghost btn-sm"
-                        :class="empty($snapshot->job?->logs) ? 'opacity-30' : ''"
-                        :disabled="empty($snapshot->job?->logs)"
+                        :class="$hasLogs ? '' : 'opacity-30'"
+                        :disabled="! $hasLogs"
                     />
-                    @if(in_array($status, ['completed', 'failed']))
+
+                    @if($canDelete)
                         @can('delete', $snapshot)
                             <x-button
                                 icon="o-trash"
                                 wire:click="confirmDeleteSnapshot('{{ $snapshot->id }}')"
-                                :tooltip="__('Delete')"
+                                tooltip="{{ __('Delete') }}"
                                 class="btn-ghost btn-sm text-error"
                             />
                         @endcan
                     @endif
-                    @if($status === 'pending' && $snapshot->job)
-                        @can('delete', $snapshot->job)
+
+                    @if($canCancel)
+                        @can('delete', $job)
                             <x-button
                                 icon="o-x-mark"
-                                wire:click="confirmCancelJob('{{ $snapshot->job->id }}')"
-                                :tooltip="__('Cancel')"
+                                wire:click="confirmCancelJob('{{ $job->id }}')"
+                                tooltip="{{ __('Cancel') }}"
                                 class="btn-ghost btn-sm text-error"
                             />
                         @endcan

--- a/tests/Feature/Livewire/Restore/IndexTest.php
+++ b/tests/Feature/Livewire/Restore/IndexTest.php
@@ -64,6 +64,35 @@ test('search filters by schema name', function () {
         ->assertDontSee('beta_schema');
 });
 
+test('search filters by restore id', function () {
+    $needle = makeRestore(['schema_name' => 'needle_schema']);
+    makeRestore(['schema_name' => 'haystack_schema']);
+
+    Livewire::test(Index::class)
+        ->set('search', $needle->id)
+        ->assertSee('needle_schema')
+        ->assertDontSee('haystack_schema');
+});
+
+test('search filters by source snapshot id', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+    makeRestore(['snapshot' => $snapshot, 'schema_name' => 'needle_schema']);
+    makeRestore(['schema_name' => 'haystack_schema']);
+
+    Livewire::test(Index::class)
+        ->set('search', $snapshot->id)
+        ->assertSee('needle_schema')
+        ->assertDontSee('haystack_schema');
+});
+
+test('source cell links to snapshot index pre-filtered by snapshot id', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+    makeRestore(['snapshot' => $snapshot]);
+
+    Livewire::test(Index::class)
+        ->assertSee(route('snapshots.index', ['search' => $snapshot->id]), escape: false);
+});
+
 test('target server filter narrows the list', function () {
     $a = DatabaseServer::factory()->create(['name' => 'AlphaTarget']);
     $b = DatabaseServer::factory()->create(['name' => 'BetaTarget']);

--- a/tests/Feature/Livewire/Restore/IndexTest.php
+++ b/tests/Feature/Livewire/Restore/IndexTest.php
@@ -46,6 +46,14 @@ test('openNewRestore dispatches the modal in from-restore-index mode', function 
         ->assertDispatched('open-restore-modal', mode: 'from-restore-index');
 });
 
+test('rerunRestore dispatches the modal pre-filled with the original restore id', function () {
+    $restore = makeRestore();
+
+    Livewire::test(Index::class)
+        ->call('rerunRestore', $restore->id)
+        ->assertDispatched('open-restore-modal', mode: 'from-restore-index', restoreId: $restore->id);
+});
+
 test('search filters by schema name', function () {
     makeRestore(['schema_name' => 'alpha_schema']);
     makeRestore(['schema_name' => 'beta_schema']);

--- a/tests/Feature/Livewire/Restore/ModalTest.php
+++ b/tests/Feature/Livewire/Restore/ModalTest.php
@@ -3,7 +3,9 @@
 use App\Enums\UserRole;
 use App\Jobs\ProcessRestoreJob;
 use App\Livewire\Restore\Modal;
+use App\Models\BackupJob;
 use App\Models\DatabaseServer;
+use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Models\User;
 use App\Services\Backup\Databases\DatabaseProvider;
@@ -282,6 +284,29 @@ test('changing dbTypeFilter clears the stale serverFilter so results are not ove
         ->assertSet('serverFilter', null)
         ->assertSee('pg_db')
         ->assertDontSee('mysql_db');
+});
+
+test('from-restore-index mode: passing restoreId pre-fills snapshot, target, and jumps to step 3', function () {
+    $source = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    $snapshot = Snapshot::factory()->forServer($source)->withFile()->create(['database_name' => 'app_db']);
+    $target = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    $job = BackupJob::create(['status' => 'completed']);
+    $restore = Restore::create([
+        'backup_job_id' => $job->id,
+        'snapshot_id' => $snapshot->id,
+        'target_server_id' => $target->id,
+        'schema_name' => 'previous_schema',
+        'options' => ['force_database' => true, 'owner_user' => 'postgres'],
+    ]);
+
+    Livewire::test(Modal::class)
+        ->dispatch('open-restore-modal', mode: 'from-restore-index', restoreId: $restore->id)
+        ->assertSet('currentStep', 3)
+        ->assertSet('selectedSnapshotId', $snapshot->id)
+        ->assertSet('targetServer.id', $target->id)
+        ->assertSet('schemaName', 'previous_schema')
+        ->assertSet('forceDatabase', true)
+        ->assertSet('ownerUser', 'postgres');
 });
 
 test('from-restore-index mode: previousStep from step 3 clears target then step 2 clears snapshot', function () {

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -45,6 +45,16 @@ test('search filters by database name', function () {
         ->assertDontSee('orders_db');
 });
 
+test('search filters by snapshot id', function () {
+    $needle = Snapshot::factory()->withFile()->create(['database_name' => 'needle_db']);
+    Snapshot::factory()->withFile()->create(['database_name' => 'haystack_db']);
+
+    Livewire::test(Index::class)
+        ->set('search', $needle->id)
+        ->assertSee('needle_db')
+        ->assertDontSee('haystack_db');
+});
+
 test('server filter narrows the list', function () {
     $a = DatabaseServer::factory()->create(['name' => 'AlphaServer']);
     $b = DatabaseServer::factory()->create(['name' => 'BetaServer']);

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -45,6 +45,25 @@ test('search filters by database name', function () {
         ->assertDontSee('orders_db');
 });
 
+test('can sort by job status', function () {
+    Snapshot::factory()->withFile()->create(['database_name' => 'completed_db']);
+    $failedJob = BackupJob::create(['status' => 'failed']);
+    Snapshot::factory()->withFile()->create([
+        'database_name' => 'failed_db',
+        'backup_job_id' => $failedJob->id,
+    ]);
+
+    $component = Livewire::test(Index::class)
+        ->set('sortBy', ['column' => 'status', 'direction' => 'asc']);
+
+    $names = $component->viewData('snapshots')->pluck('database_name')->all();
+    expect($names)->toBe(['completed_db', 'failed_db']);
+
+    $component->set('sortBy', ['column' => 'status', 'direction' => 'desc']);
+    $names = $component->viewData('snapshots')->pluck('database_name')->all();
+    expect($names)->toBe(['failed_db', 'completed_db']);
+});
+
 test('search filters by snapshot id', function () {
     $needle = Snapshot::factory()->withFile()->create(['database_name' => 'needle_db']);
     Snapshot::factory()->withFile()->create(['database_name' => 'haystack_db']);


### PR DESCRIPTION
## Summary

- Redesigns the **Snapshots** and **Restores** index tables: unified subject / flow → status visual hierarchy, row tinting for failed / running / file-missing states, inline action buttons (no dropdowns), compact ULID display via `kbd` with full-ID tooltip.
- Adds **ID search** across both tables (snapshot ID, restore ID, source-snapshot ID) and a one-click jump from a restore row to the snapshot index pre-filtered by its source snapshot.
- Adds **sortable `Created` and `Status`** columns. `Status` sorting reaches across `backup_jobs` via an Eloquent subquery so it works without a join.
- Adds a **"Re-run"** action on each restore row — opens the existing 3-step restore modal pre-filled with the original snapshot, target server, schema name, and options, and authorizes `view` on the specific restore before dispatching.
- Slows polling from 5 s → 30 s and fixes a regression where the sidebar Snapshots/Restores item lost its active highlight after a poll re-render (the menu now captures `isActive` on `mount()` and passes it explicitly to `<x-menu-item>`).
- Cleans up the query-builder sort logic (replaces a `when(condition, ifClosure, elseClosure)` block with an explicit `if/else`) and switches translated tooltip attributes on `<x-button>` to `:tooltip="__('…')"` to avoid the double-encoding pattern called out in `CLAUDE.md`.

## Test plan

- [ ] Snapshots index: list loads, search by database name, server name, host, and snapshot ID all work.
- [ ] Snapshots index: sort by Created and Status (asc + desc) order rows correctly, including across job statuses.
- [ ] Snapshots index: file-missing rows show the warning popover; row tint reflects state.
- [ ] Snapshots index: Restore / Download / Logs / Delete / Cancel inline actions work and respect policies.
- [ ] Restores index: list loads, search by schema name, target server, source server, source-database, restore ID, and source-snapshot ID all work.
- [ ] Restores index: jump-to-snapshot link opens the snapshots index pre-filtered by the source snapshot ID.
- [ ] Restores index: sort by Created and Status (asc + desc) order rows correctly.
- [ ] Restores index: **Re-run** opens the modal at step 3 with snapshot, target, schema, `force_database`, and `owner_user` pre-filled.
- [ ] Restores index: **Re-run** is denied for a restore the current user cannot `view`.
- [ ] Sidebar: navigate to /snapshots and /restores, wait 30+ seconds, confirm the active item retains its highlight after a `wire:poll`.
- [ ] Translations: switch to fr / es and verify tooltips render with the right glyphs (no `&#039;` artefacts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Re-run restores from the restore list; restore modal can open pre-filled from a selected restore.

* **Improvements**
  * Menu items now highlight the active section.
  * Reworked restore and snapshot tables: reorganized columns, consolidated cell displays, clearer empty states, and refined action button behavior.
  * Reduced polling from 5s to 30s and improved search/sort behavior.

* **Tests**
  * Added/expanded Livewire tests covering rerun flow, sorting by status, and id-based search.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/312)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->