### PR TITLE
fix: include postgres database in available-database list

### DIFF
--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -23,7 +23,6 @@ class PostgresqlDatabase implements DatabaseInterface
     ];
 
     private const array EXCLUDED_DATABASES = [
-        'postgres',          // Default administrative database
         'rdsadmin',          // AWS RDS internal database
         'azure_maintenance', // Azure Database for PostgreSQL internal database
         'azure_sys',         // Azure Database for PostgreSQL internal database

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -47,7 +47,7 @@ test('restore builds correct psql command', function () {
         ->and($result->command)->toBe("PGPASSWORD='pg_secret' psql --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/restore.sql'");
 });
 
-test('listDatabases returns databases excluding system databases', function () {
+test('listDatabases returns databases excluding managed-service internals but keeps postgres', function () {
     $pdoStatement = Mockery::mock(\PDOStatement::class);
     $pdoStatement->shouldReceive('fetchAll')
         ->once()
@@ -66,7 +66,7 @@ test('listDatabases returns databases excluding system databases', function () {
 
     $databases = $db->listDatabases();
 
-    expect($databases)->toBe(['app_database', 'analytics_db']);
+    expect($databases)->toBe(['postgres', 'app_database', 'analytics_db']);
 });
 
 test('testConnection returns success with version and SSL info', function () {


### PR DESCRIPTION
Closes #309.

## Summary

- Removes `postgres` from the `EXCLUDED_DATABASES` list in `PostgresqlDatabase`. The default `postgres` database is a regular user-facing database that `initdb` happens to create — it isn't a system catalog like MySQL's `mysql` db, and `pg_dumpall` / pgAdmin / DBeaver all treat it as a normal listable database.
- Genuine PostgreSQL internals (`template0`, `template1`) are still filtered by the existing `WHERE datistemplate = false` in the listing query.
- The remaining exclusions stay: `rdsadmin`, `azure_maintenance`, `azure_sys` — these are managed-service plumbing the user can't read anyway, so listing them would just produce broken backups.
- We continue to use `postgres` as the bootstrap connection target in `DatabaseProvider::getConnectionDatabaseName()` — that's unrelated and unaffected.

## Test plan
- [ ] In the database-server form, connect to a Postgres server and verify `postgres` now appears in the available-databases list alongside other user databases
- [ ] Running a backup against the `postgres` database completes successfully
- [ ] `rdsadmin` / `azure_maintenance` / `azure_sys` are still hidden when listing against a managed Postgres instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostgreSQL database listings now include the system postgres database in results, providing a complete list of all available databases for backup operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/315)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->