### PR TITLE
fix: switch MSSQL backups to DACPAC to bypass Azure validation (#316)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For production deployments, see our [configuration guide](https://david-crty.git
 | MySQL      | 5.6, 5.7, 8.x, 9.x           | `mariadb-dump`               | Yes     |
 | MariaDB    | 10.x, 11.x, 12.x             | `mariadb-dump`               | Yes     |
 | PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v18                | Yes     |
-| SQL Server | 2017, 2019, 2022, Azure SQL  | `sqlpackage` (`.bacpac`)     | Yes     |
+| SQL Server | 2017, 2019, 2022, Azure SQL  | `sqlpackage` (`.dacpac`)     | Yes     |
 | MongoDB    | 4.2, 4.4, 5.0, 6.0, 7.0, 8.0 | `mongodump` / `mongorestore` | Yes     |
 | SQLite     | 3.x                          | `sqlite3 .backup`            | Yes     |
 | Redis      | 2.8+                         | `redis-cli --rdb`            | No      |

--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -135,7 +135,7 @@ enum DatabaseType: string
             self::SQLITE => 'db',
             self::REDIS => 'rdb',
             self::MONGODB => 'archive',
-            self::MSSQL => 'bacpac',
+            self::MSSQL => 'dacpac',
             default => 'sql',
         };
     }

--- a/app/Services/Backup/Databases/MssqlDatabase.php
+++ b/app/Services/Backup/Databases/MssqlDatabase.php
@@ -11,8 +11,14 @@ use App\Support\Formatters;
  * Microsoft SQL Server handler.
  *
  * Backup and restore both go through Microsoft's `sqlpackage` CLI
- * (`/Action:Export` produces a `.bacpac`, `/Action:Import` consumes one).
- * Connection tests, listDatabases, and the drop-before-import step in
+ * (`/Action:Extract` produces a `.dacpac` with table data, `/Action:Publish`
+ * consumes one). We chose Extract/Publish over Export/Import because BACPAC
+ * validates against Azure SQL Database compatibility and rejects on-prem
+ * artefacts like `[NT AUTHORITY\SYSTEM]` Windows logins (SQL71627). DACPAC
+ * lets us exclude server-bound objects (users, logins, permissions) that we
+ * don't want to round-trip anyway.
+ *
+ * Connection tests, listDatabases, and the drop-before-publish step in
  * prepareForRestore use the `pdo_sqlsrv` extension.
  */
 class MssqlDatabase implements DatabaseInterface
@@ -39,7 +45,7 @@ class MssqlDatabase implements DatabaseInterface
     {
         $parts = [
             'sqlpackage',
-            '/Action:Export',
+            '/Action:Extract',
             '/TargetFile:'.escapeshellarg($outputPath),
             '/SourceServerName:'.escapeshellarg($this->buildServerName()),
             '/SourceDatabaseName:'.escapeshellarg($this->config['database']),
@@ -47,6 +53,10 @@ class MssqlDatabase implements DatabaseInterface
             '/SourcePassword:'.escapeshellarg($this->config['pass']),
             '/SourceTrustServerCertificate:True',
             '/SourceEncryptConnection:True',
+            '/p:ExtractAllTableData=True',
+            '/p:ExtractReferencedServerScopedElements=False',
+            '/p:IgnoreUserLoginMappings=True',
+            '/p:IgnorePermissions=True',
         ];
 
         if (! empty($this->config['dump_flags'])) {
@@ -60,7 +70,7 @@ class MssqlDatabase implements DatabaseInterface
     {
         $sqlpackage = implode(' ', [
             'sqlpackage',
-            '/Action:Import',
+            '/Action:Publish',
             '/SourceFile:'.escapeshellarg($inputPath),
             '/TargetServerName:'.escapeshellarg($this->buildServerName()),
             '/TargetDatabaseName:'.escapeshellarg($this->config['database']),
@@ -74,15 +84,16 @@ class MssqlDatabase implements DatabaseInterface
     }
 
     /**
-     * sqlpackage Import refuses to run if the target database already exists,
-     * so we drop it first. ALTER ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE
-     * evicts any lingering sessions before the DROP.
+     * Publish will incrementally migrate an existing database, which is not
+     * what a restore should do, so we drop it first to guarantee a clean
+     * recreate. ALTER ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE evicts any
+     * lingering sessions before the DROP.
      */
     public function prepareForRestore(string $schemaName, BackupLogger $logger, bool $forceDatabase = false): void
     {
         try {
             $sql = self::dropDatabaseIfExistsSql($schemaName);
-            $logger->log("Ensuring target database {$schemaName} is dropped before sqlpackage Import", 'info');
+            $logger->log("Ensuring target database {$schemaName} is dropped before sqlpackage Publish", 'info');
             $logger->logCommand($sql, null, 0);
             $this->createPdoForDatabase('master')->exec($sql);
         } catch (\PDOException $e) {

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -15,7 +15,7 @@ Databasement uses standard CLI tools to perform backup and restore operations. T
 | MySQL      | 5.6, 5.7, 8.x, 9.x           | `mariadb-dump`               | Yes     |
 | MariaDB    | 10.x, 11.x, 12.x             | `mariadb-dump`               | Yes     |
 | PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v18                | Yes     |
-| SQL Server | 2017, 2019, 2022, Azure SQL  | `sqlpackage` (`.bacpac`)     | Yes     |
+| SQL Server | 2017, 2019, 2022, Azure SQL  | `sqlpackage` (`.dacpac`)     | Yes     |
 | MongoDB    | 4.2, 4.4, 5.0, 6.0, 7.0, 8.0 | `mongodump` / `mongorestore` | Yes     |
 | SQLite     | 3.x                          | File copy                    | Yes     |
 | Redis      | 2.8+                         | `redis-cli --rdb`            | No      |
@@ -24,7 +24,7 @@ Databasement uses standard CLI tools to perform backup and restore operations. T
 :::info How this works
 - **MySQL / MariaDB**: Databasement ships the MariaDB 11.4 client (`mariadb-dump`), which is wire-protocol compatible with MySQL servers.
 - **PostgreSQL**: The `pg_dump` v18 client can dump from any server version back to 9.2. Versions below 12 have reached end-of-life and are not recommended.
-- **SQL Server**: Backups are exported as `.bacpac` files using Microsoft's `sqlpackage` CLI (`/Action:Export`) and re-imported with `/Action:Import`. Works against on-prem SQL Server 2017+ and Azure SQL Database. Connections use the `pdo_sqlsrv` PHP extension.
+- **SQL Server**: Backups are extracted as `.dacpac` files (schema + table data) using Microsoft's `sqlpackage` CLI (`/Action:Extract`) and re-applied with `/Action:Publish`. Server-bound objects (logins, users, permissions, role memberships) are excluded so backups stay portable across instances and don't fail on Windows-auth principals like `[NT AUTHORITY\SYSTEM]`. Works against on-prem SQL Server 2017+ and Azure SQL Database. Connections use the `pdo_sqlsrv` PHP extension.
 - **MongoDB**: The MongoDB Database Tools (`mongodump` / `mongorestore`) officially support server versions 4.2 through 8.0.
 - **SQLite**: Backups are performed by copying the database file over SFTP. The SQLite 3.x file format has been backwards-compatible since 3.0.0 (2004).
 - **Redis / Valkey**: `redis-cli --rdb` creates a point-in-time RDB snapshot via the replication protocol. Valkey 7.2+ is supported as a drop-in replacement for Redis. Restore is not supported.
@@ -113,7 +113,7 @@ For single-database access without `CREATEDB`, the target database must already 
 
 ### Microsoft SQL Server
 
-SQL Server uses `sqlpackage` to export and import `.bacpac` files. Supports on-prem SQL Server 2017+ and Azure SQL Database (default port: 1433).
+SQL Server uses `sqlpackage` to extract and publish `.dacpac` files (schema + table data). Supports on-prem SQL Server 2017+ and Azure SQL Database (default port: 1433). Server-level objects (logins, users, permissions, role memberships) are excluded from the backup.
 
 The login needs `db_owner` on each target database, plus permission to drop and create databases (restore drops the target first). `sysadmin` works; on Azure SQL, use a server admin or grant `dbmanager` on `master`.
 

--- a/tests/Feature/Services/Backup/Databases/MssqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MssqlDatabaseTest.php
@@ -14,18 +14,22 @@ beforeEach(function () {
     ]);
 });
 
-test('dump produces sqlpackage export command', function () {
-    $result = $this->db->dump('/tmp/snapshot.bacpac');
+test('dump produces sqlpackage extract command', function () {
+    $result = $this->db->dump('/tmp/snapshot.dacpac');
 
     expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
         ->and($result->command)->toBe(
-            "sqlpackage /Action:Export /TargetFile:'/tmp/snapshot.bacpac' "
+            "sqlpackage /Action:Extract /TargetFile:'/tmp/snapshot.dacpac' "
             ."/SourceServerName:'mssql.example.com,1433' "
             ."/SourceDatabaseName:'app_db' "
             ."/SourceUser:'sa' "
             ."/SourcePassword:'Pa55w0rd!' "
             .'/SourceTrustServerCertificate:True '
-            .'/SourceEncryptConnection:True'
+            .'/SourceEncryptConnection:True '
+            .'/p:ExtractAllTableData=True '
+            .'/p:ExtractReferencedServerScopedElements=False '
+            .'/p:IgnoreUserLoginMappings=True '
+            .'/p:IgnorePermissions=True'
         );
 });
 
@@ -39,17 +43,17 @@ test('dump appends user-provided dump flags', function () {
         'dump_flags' => '/Verbose:True',
     ]);
 
-    $result = $this->db->dump('/tmp/snapshot.bacpac');
+    $result = $this->db->dump('/tmp/snapshot.dacpac');
 
-    expect($result->command)->toEndWith("/SourceEncryptConnection:True '/Verbose:True'");
+    expect($result->command)->toEndWith("/p:IgnorePermissions=True '/Verbose:True'");
 });
 
-test('restore produces sqlpackage import command when input is already a .bacpac', function () {
-    $result = $this->db->restore('/tmp/snapshot.bacpac');
+test('restore produces sqlpackage publish command', function () {
+    $result = $this->db->restore('/tmp/snapshot.dacpac');
 
     expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
         ->and($result->command)->toBe(
-            "sqlpackage /Action:Import /SourceFile:'/tmp/snapshot.bacpac' "
+            "sqlpackage /Action:Publish /SourceFile:'/tmp/snapshot.dacpac' "
             ."/TargetServerName:'mssql.example.com,1433' "
             ."/TargetDatabaseName:'app_db' "
             ."/TargetUser:'sa' "

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -268,7 +268,7 @@ test('mssql backup and restore workflow', function () {
 
     expect($this->snapshot->job->status)->toBe('completed')
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
-        ->and($this->snapshot->filename)->toEndWith('.bacpac.gz')
+        ->and($this->snapshot->filename)->toEndWith('.dacpac.gz')
         ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
 
     // Run restore (use unique name with parallel token and microseconds to avoid collisions)
@@ -281,7 +281,7 @@ test('mssql backup and restore workflow', function () {
     );
     ProcessRestoreJob::dispatchSync($restore->id);
 
-    // Verify restore — the fixture inserts 2 users; sqlpackage Import recreates schema + data.
+    // Verify restore — the fixture inserts 2 users; sqlpackage Publish recreates schema + data.
     $pdo = IntegrationTestHelpers::connectToDatabase('mssql', $this->databaseServer, $this->restoredDatabaseName);
     $stmt = $pdo->query('SELECT COUNT(*) FROM dbo.users');
     expect($stmt)->not->toBeFalse()


### PR DESCRIPTION
## Why

Fixes #316. SQL Server backups crashed on any on-prem instance that carried a Windows-mapped principal (the default `[NT AUTHORITY\SYSTEM]` login is the usual culprit):

```
SQL71627: The element User: [NT AUTHORITY\SYSTEM] has property AuthenticationType set to a value that is not supported in Microsoft Azure SQL Database v12.
SQL71627: The element Login: [NT AUTHORITY\SYSTEM] has property IsMappedToWindowsLogin set to a value that is not supported in Microsoft Azure SQL Database v12.
```

The root cause: `sqlpackage /Action:Export` produces a **BACPAC**, and BACPAC is by design an Azure SQL Database–portable format. `sqlpackage` validates every object in the source DB against Azure SQL DB rules before writing the file. Windows authentication isn't supported in Azure SQL DB, so the validator hard-fails on Windows logins. There is no `/p:` knob on `Action:Export` to bypass this — it's a precondition of the format. The credential used to connect (e.g. `sa`) is irrelevant; what matters is what's *inside* the database.

## What

Switch the SQL Server handler from BACPAC to **DACPAC** (`/Action:Extract` + `/Action:Publish`). DACPAC has no Azure compatibility precondition and supports the properties we actually need:

- `/p:ExtractAllTableData=True` — keeps full schema + data parity with what BACPAC was giving us.
- `/p:ExtractReferencedServerScopedElements=False` — keeps the dacpac portable.
- `/p:IgnoreUserLoginMappings=True` and `/p:IgnorePermissions=True` — skip the Windows-auth principals (and any other server-bound objects) that caused #316. These objects don't belong in an application backup anyway — they're server-level concerns.

Restore uses `/Action:Publish`. `prepareForRestore` still drops the target DB first, so Publish recreates cleanly instead of trying to incrementally migrate an existing schema.

### Files changed

- `app/Services/Backup/Databases/MssqlDatabase.php` — Export→Extract, Import→Publish, new `/p:` flags, updated docblock and log message.
- `app/Enums/DatabaseType.php` — dump extension `bacpac` → `dacpac`.
- `tests/Feature/Services/Backup/Databases/MssqlDatabaseTest.php` — updated all command-string assertions.
- `tests/Integration/BackupRestoreTest.php` — `.bacpac.gz` → `.dacpac.gz`; integration test exercises the real round-trip and passes.
- `README.md` and `docs/docs/user-guide/database-servers.md` — three references updated, behaviour explained.

### Breaking change

**Pre-existing `.bacpac.gz` snapshots are no longer restorable.** `Action:Publish` rejects `.bacpac` and `Action:Import` rejects `.dacpac`, and we did not ship a compatibility branch. New backups produced from this commit forward are `.dacpac.gz` and restore cleanly. Anyone with a SQL Server backup history they care about should keep the old image around or take a fresh backup against the new image before deleting old snapshots.

### Docker

No image changes. `sqlpackage` is a single binary that already supports Extract/Publish — the pinned version `170.3.93.6` in `docker/php/Dockerfile` was tested end-to-end.

## Test plan

Run a fresh image built from this branch (the maintainer will publish one) and verify:

- [x] Register an MSSQL server that exhibited #316 previously (any on-prem SQL Server with the default `[NT AUTHORITY\SYSTEM]` login is fine).
- [x] Trigger a backup. It should complete and produce a `.dacpac.gz` snapshot — no SQL71627.
- [x] Trigger a restore from that snapshot to a new target database name. It should complete and the restored database should contain the same tables and rows as the source.
- [ ] Optional: try a cross-server restore (e.g. prod → staging) using the new image to confirm the dacpac is portable.

Automated coverage (already green in CI):

- [x] `make test-filter FILTER=MssqlDatabaseTest` — unit tests on the new command strings (6 passed).
- [x] `make test-filter FILTER="mssql backup and restore workflow"` — full integration round-trip against a live SQL Server container (1 passed).
- [x] Full suite: 998 passed, 2899 assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SQL Server backup artifacts now use `.dacpac` format instead of `.bacpac`
  * Server-scoped objects (logins, users, permissions) excluded from backups

* **Documentation**
  * Updated SQL Server backup/restore documentation to reflect new format, Extract/Publish workflow, and excluded object types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->