### PR TITLE
feat: database server show page + row actions dropdown

### DIFF
--- a/app/Livewire/Dashboard/LatestJobs.php
+++ b/app/Livewire/Dashboard/LatestJobs.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Dashboard;
 
 use App\Models\BackupJob;
+use App\Queries\BackupJobQuery;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
 use Livewire\Attributes\Lazy;
@@ -23,8 +24,12 @@ class LatestJobs extends Component
     #[Locked]
     public ?string $selectedJobId = null;
 
-    public function mount(): void
+    #[Locked]
+    public ?string $serverId = null;
+
+    public function mount(?string $serverId = null): void
     {
+        $this->serverId = $serverId;
         $this->jobs = new Collection;
         $this->fetchJobs();
     }
@@ -86,6 +91,10 @@ class LatestJobs extends Component
 
         if ($this->statusFilter !== 'all') {
             $query->where('status', $this->statusFilter);
+        }
+
+        if ($this->serverId !== null) {
+            BackupJobQuery::applyServerFilter($query, $this->serverId);
         }
 
         $this->jobs = $query->get();

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -74,7 +74,7 @@ class Index extends Component
             ['key' => 'name', 'label' => __('Name'), 'class' => 'w-48'],
             ['key' => 'backup', 'label' => __('Backup'), 'sortable' => false, 'class' => 'overflow-hidden hidden sm:table-cell'],
             ['key' => 'jobs', 'label' => __('Jobs'), 'sortable' => false, 'class' => 'w-16 hidden sm:table-cell'],
-            ['key' => 'actions', 'label' => null, 'sortable' => false, 'class' => 'w-32'],
+            ['key' => 'actions', 'label' => null, 'sortable' => false, 'class' => 'w-12'],
         ];
     }
 

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -8,6 +8,7 @@ use App\Models\DatabaseServer;
 use App\Models\NotificationChannel;
 use App\Queries\DatabaseServerQuery;
 use App\Services\Backup\TriggerBackupAction;
+use App\Traits\RunsServerBackups;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -21,7 +22,7 @@ use Livewire\WithPagination;
 #[Title('Database Servers')]
 class Index extends Component
 {
-    use AuthorizesRequests, Toast, WithPagination;
+    use AuthorizesRequests, RunsServerBackups, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -155,50 +156,7 @@ class Index extends Component
 
         $this->authorize('backup', $server);
 
-        $userId = auth()->id();
-        $results = [];
-
-        foreach ($server->backups as $backup) {
-            try {
-                $action->execute($backup, is_int($userId) ? $userId : null);
-                $results[$backup->getDisplayLabel()] = 'success';
-            } catch (\Throwable $e) {
-                $results[$backup->getDisplayLabel()] = $e->getMessage();
-            }
-        }
-
-        // Determine overall status
-        $successCount = count(array_filter($results, fn ($v) => $v === 'success'));
-        $failureCount = count(array_filter($results, fn ($v) => $v !== 'success'));
-
-        // Build description with one line per backup config
-        $description = implode("\n", array_map(function ($label, $status) {
-            $icon = $status === 'success' ? '✓' : '✗';
-
-            return "{$icon} {$label}";
-        }, array_keys($results), array_values($results)));
-
-        // Determine toast type based on results
-        if ($failureCount === 0) {
-            $this->success(
-                title: __('All backups started successfully!'),
-                description: $description,
-            );
-        } elseif ($successCount === 0) {
-            $this->error(
-                title: __('All backups failed!'),
-                description: $description,
-                timeout: 0
-            );
-        } else {
-            $this->warning(
-                title: __(':count backups started, :failures failed', [
-                    'count' => $successCount,
-                    'failures' => $failureCount,
-                ]),
-                description: $description,
-            );
-        }
+        $this->triggerAllBackups($server, $action);
     }
 
     public function render(): View

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -72,7 +72,7 @@ class Index extends Component
     public function headers(): array
     {
         return [
-            ['key' => 'name', 'label' => __('Name'), 'class' => 'w-48'],
+            ['key' => 'name', 'label' => __('Name'), 'class' => 'w-72'],
             ['key' => 'backup', 'label' => __('Backup'), 'sortable' => false, 'class' => 'overflow-hidden hidden sm:table-cell'],
             ['key' => 'jobs', 'label' => __('Jobs'), 'sortable' => false, 'class' => 'w-16 hidden sm:table-cell'],
             ['key' => 'actions', 'label' => null, 'sortable' => false, 'class' => 'w-12'],

--- a/app/Livewire/DatabaseServer/Show.php
+++ b/app/Livewire/DatabaseServer/Show.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Livewire\DatabaseServer;
+
+use App\Enums\DatabaseType;
+use App\Enums\NotificationChannelSelection;
+use App\Enums\NotificationTrigger;
+use App\Models\DatabaseServer;
+use App\Models\NotificationChannel;
+use App\Models\Restore;
+use App\Services\Backup\TriggerBackupAction;
+use App\Traits\Toast;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\Title;
+use Livewire\Component;
+
+#[Title('Database Server')]
+class Show extends Component
+{
+    use AuthorizesRequests, Toast;
+
+    public DatabaseServer $server;
+
+    public int $snapshotsCount = 0;
+
+    public int $restoresCount = 0;
+
+    public bool $showDeleteModal = false;
+
+    public bool $showRedisRestoreModal = false;
+
+    public int $deleteSnapshotCount = 0;
+
+    public bool $keepFiles = false;
+
+    public function mount(DatabaseServer $server): void
+    {
+        $this->authorize('view', $server);
+
+        $server->load([
+            'sshConfig',
+            'agent',
+            'backups.volume',
+            'backups.backupSchedule',
+            'notificationChannels',
+        ]);
+
+        $this->server = $server;
+        $this->snapshotsCount = $server->snapshots()->count();
+        $this->restoresCount = Restore::where('target_server_id', $server->id)->count();
+    }
+
+    public function runBackupAll(TriggerBackupAction $action): void
+    {
+        $this->authorize('backup', $this->server);
+
+        $this->server->load(['backups.volume', 'backups.backupSchedule']);
+
+        $userId = auth()->id();
+        $results = [];
+
+        foreach ($this->server->backups as $backup) {
+            try {
+                $action->execute($backup, is_int($userId) ? $userId : null);
+                $results[$backup->getDisplayLabel()] = 'success';
+            } catch (\Throwable $e) {
+                $results[$backup->getDisplayLabel()] = $e->getMessage();
+            }
+        }
+
+        $successCount = count(array_filter($results, fn ($v) => $v === 'success'));
+        $failureCount = count(array_filter($results, fn ($v) => $v !== 'success'));
+
+        $description = implode("\n", array_map(function ($label, $status) {
+            $icon = $status === 'success' ? '✓' : '✗';
+
+            return "{$icon} {$label}";
+        }, array_keys($results), array_values($results)));
+
+        if ($failureCount === 0) {
+            $this->success(
+                title: __('All backups started successfully!'),
+                description: $description,
+            );
+        } elseif ($successCount === 0) {
+            $this->error(
+                title: __('All backups failed!'),
+                description: $description,
+                timeout: 0
+            );
+        } else {
+            $this->warning(
+                title: __(':count backups started, :failures failed', [
+                    'count' => $successCount,
+                    'failures' => $failureCount,
+                ]),
+                description: $description,
+            );
+        }
+    }
+
+    public function confirmRestore(): void
+    {
+        $this->authorize('restore', $this->server);
+
+        if ($this->server->agent_id) {
+            $this->error(__('Restore is not yet supported for agent-backed servers.'));
+
+            return;
+        }
+
+        if ($this->server->database_type === DatabaseType::REDIS) {
+            $this->showRedisRestoreModal = true;
+
+            return;
+        }
+
+        $this->dispatch('open-restore-modal', mode: 'from-server', targetServerId: $this->server->id);
+    }
+
+    public function confirmDelete(): void
+    {
+        $this->authorize('delete', $this->server);
+
+        $this->deleteSnapshotCount = $this->server->snapshots()->count();
+        $this->keepFiles = false;
+        $this->showDeleteModal = true;
+    }
+
+    public function delete(): void
+    {
+        $this->authorize('delete', $this->server);
+
+        $this->server->skipFileCleanup = $this->keepFiles;
+        $this->server->delete();
+        $this->showDeleteModal = false;
+
+        $this->success(
+            title: __('Database server deleted successfully!'),
+            redirectTo: route('database-servers.index'),
+        );
+    }
+
+    /**
+     * Notification channels actually delivered to for this server. Empty when
+     * the trigger is disabled.
+     *
+     * @return Collection<int, NotificationChannel>
+     */
+    public function activeChannels(): Collection
+    {
+        if ($this->server->notification_trigger === NotificationTrigger::None) {
+            return new Collection;
+        }
+
+        return $this->server->notification_channel_selection === NotificationChannelSelection::All
+            ? NotificationChannel::orderBy('name')->get()
+            : $this->server->notificationChannels;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.database-server.show', [
+            'activeChannels' => $this->activeChannels(),
+        ]);
+    }
+}

--- a/app/Livewire/DatabaseServer/Show.php
+++ b/app/Livewire/DatabaseServer/Show.php
@@ -9,6 +9,7 @@ use App\Models\DatabaseServer;
 use App\Models\NotificationChannel;
 use App\Models\Restore;
 use App\Services\Backup\TriggerBackupAction;
+use App\Traits\RunsServerBackups;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
@@ -19,7 +20,7 @@ use Livewire\Component;
 #[Title('Database Server')]
 class Show extends Component
 {
-    use AuthorizesRequests, Toast;
+    use AuthorizesRequests, RunsServerBackups, Toast;
 
     public DatabaseServer $server;
 
@@ -58,47 +59,7 @@ class Show extends Component
 
         $this->server->load(['backups.volume', 'backups.backupSchedule']);
 
-        $userId = auth()->id();
-        $results = [];
-
-        foreach ($this->server->backups as $backup) {
-            try {
-                $action->execute($backup, is_int($userId) ? $userId : null);
-                $results[$backup->getDisplayLabel()] = 'success';
-            } catch (\Throwable $e) {
-                $results[$backup->getDisplayLabel()] = $e->getMessage();
-            }
-        }
-
-        $successCount = count(array_filter($results, fn ($v) => $v === 'success'));
-        $failureCount = count(array_filter($results, fn ($v) => $v !== 'success'));
-
-        $description = implode("\n", array_map(function ($label, $status) {
-            $icon = $status === 'success' ? '✓' : '✗';
-
-            return "{$icon} {$label}";
-        }, array_keys($results), array_values($results)));
-
-        if ($failureCount === 0) {
-            $this->success(
-                title: __('All backups started successfully!'),
-                description: $description,
-            );
-        } elseif ($successCount === 0) {
-            $this->error(
-                title: __('All backups failed!'),
-                description: $description,
-                timeout: 0
-            );
-        } else {
-            $this->warning(
-                title: __(':count backups started, :failures failed', [
-                    'count' => $successCount,
-                    'failures' => $failureCount,
-                ]),
-                description: $description,
-            );
-        }
+        $this->triggerAllBackups($this->server, $action);
     }
 
     public function confirmRestore(): void

--- a/app/Notifications/BackupFailedNotification.php
+++ b/app/Notifications/BackupFailedNotification.php
@@ -16,14 +16,14 @@ class BackupFailedNotification extends BaseFailedNotification
     public function getMessage(): FailedNotificationMessage
     {
         return $this->message(
-            title: '🚨 Backup Failed: '.($this->snapshot->databaseServer->name ?? 'Unknown'),
+            title: '🚨 Backup Failed: '.$this->snapshot->databaseServer->name,
             body: 'A backup job has failed and requires your attention.',
             actionText: '🔗 View Job Details',
             actionUrl: route('snapshots.index', ['job' => $this->snapshot->backup_job_id]),
             footerText: '🕐 '.now()->toDateTimeString(),
             errorLabel: '❌ Error Details',
             fields: [
-                'Server' => $this->snapshot->databaseServer->name ?? 'Unknown',
+                'Server' => $this->snapshot->databaseServer->name,
                 'Database' => $this->snapshot->database_name ?? 'Unknown',
             ],
         );

--- a/app/Notifications/BackupSuccessNotification.php
+++ b/app/Notifications/BackupSuccessNotification.php
@@ -13,13 +13,13 @@ class BackupSuccessNotification extends BaseSuccessNotification
     public function getMessage(): SuccessNotificationMessage
     {
         return $this->message(
-            title: '✅ Backup Succeeded: '.($this->snapshot->databaseServer->name ?? 'Unknown'),
+            title: '✅ Backup Succeeded: '.$this->snapshot->databaseServer->name,
             body: 'A backup job completed successfully.',
             actionText: '🔗 View Job Details',
             actionUrl: route('snapshots.index', ['job' => $this->snapshot->backup_job_id]),
             footerText: '🕐 '.now()->toDateTimeString(),
             fields: [
-                'Server' => $this->snapshot->databaseServer->name ?? 'Unknown',
+                'Server' => $this->snapshot->databaseServer->name,
                 'Database' => $this->snapshot->database_name ?? 'Unknown',
             ],
         );

--- a/app/Queries/BackupJobQuery.php
+++ b/app/Queries/BackupJobQuery.php
@@ -152,7 +152,7 @@ class BackupJobQuery
      *
      * @param  Builder<BackupJob>  $query
      */
-    private static function applyServerFilter(Builder $query, string $serverId): void
+    public static function applyServerFilter(Builder $query, string $serverId): void
     {
         $query->where(function (Builder $q) use ($serverId) {
             $q->whereHas('snapshot', function ($sq) use ($serverId) {

--- a/app/Services/Backup/SnapshotVerificationService.php
+++ b/app/Services/Backup/SnapshotVerificationService.php
@@ -79,7 +79,7 @@ class SnapshotVerificationService
 
             if (! $exists && $wasPreviouslyExisting) {
                 $this->newlyMissing->push([
-                    'server' => $snapshot->databaseServer->name ?? 'Unknown',
+                    'server' => $snapshot->databaseServer->name,
                     'database' => $snapshot->database_name,
                     'filename' => $snapshot->filename,
                     'database_server_id' => $snapshot->database_server_id,

--- a/app/Traits/RunsServerBackups.php
+++ b/app/Traits/RunsServerBackups.php
@@ -25,6 +25,14 @@ trait RunsServerBackups
             }
         }
 
+        if ($results === []) {
+            $this->warning(
+                title: __('No backup configurations to start'),
+            );
+
+            return;
+        }
+
         $successCount = count(array_filter($results, fn ($v): bool => $v === 'success'));
         $failureCount = count($results) - $successCount;
 

--- a/app/Traits/RunsServerBackups.php
+++ b/app/Traits/RunsServerBackups.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Traits;
+
+use App\Models\DatabaseServer;
+use App\Services\Backup\TriggerBackupAction;
+
+/**
+ * Triggers every backup configuration on a server and renders a single toast
+ * summarising the outcome. Requires the {@see Toast} trait.
+ */
+trait RunsServerBackups
+{
+    protected function triggerAllBackups(DatabaseServer $server, TriggerBackupAction $action): void
+    {
+        $userId = auth()->id();
+        $results = [];
+
+        foreach ($server->backups as $backup) {
+            try {
+                $action->execute($backup, is_int($userId) ? $userId : null);
+                $results[$backup->getDisplayLabel()] = 'success';
+            } catch (\Throwable $e) {
+                $results[$backup->getDisplayLabel()] = $e->getMessage();
+            }
+        }
+
+        $successCount = count(array_filter($results, fn ($v): bool => $v === 'success'));
+        $failureCount = count($results) - $successCount;
+
+        $description = implode("\n", array_map(
+            fn (string $label, string $status): string => ($status === 'success' ? '✓' : '✗')." {$label}",
+            array_keys($results),
+            array_values($results),
+        ));
+
+        if ($failureCount === 0) {
+            $this->success(
+                title: __('All backups started successfully!'),
+                description: $description,
+            );
+
+            return;
+        }
+
+        if ($successCount === 0) {
+            $this->error(
+                title: __('All backups failed!'),
+                description: $description,
+                timeout: 0,
+            );
+
+            return;
+        }
+
+        $this->warning(
+            title: __(':count backups started, :failures failed', [
+                'count' => $successCount,
+                'failures' => $failureCount,
+            ]),
+            description: $description,
+        );
+    }
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -24,3 +24,7 @@
 .mary-table-pagination > div:last-child {
     overflow-y: visible;
 }
+
+[x-cloak] {
+    display: none !important;
+}

--- a/resources/views/components/floating-dropdown.blade.php
+++ b/resources/views/components/floating-dropdown.blade.php
@@ -1,0 +1,35 @@
+@props([
+    'right' => false,
+    'top' => false,
+    'offset' => 6,
+])
+
+@php
+    $placement = match (true) {
+        $top && $right => 'top-end',
+        $top => 'top-start',
+        $right => 'bottom-end',
+        default => 'bottom-start',
+    };
+@endphp
+
+<div x-data="{ open: false }" class="inline-block">
+    <div x-ref="trigger" @click="open = !open" class="inline-flex">
+        {{ $trigger }}
+    </div>
+
+    <template x-teleport="body">
+        <ul
+            x-show="open"
+            x-cloak
+            x-anchor.{{ $placement }}.offset.{{ (int) $offset }}="$refs.trigger"
+            x-transition.opacity.duration.100ms
+            @click="open = false"
+            @click.outside="if (! $refs.trigger.contains($event.target)) open = false"
+            @keydown.escape.window="open = false"
+            class="z-50 p-2 shadow menu border border-base-content/10 bg-base-100 rounded-box w-auto min-w-max"
+        >
+            {{ $slot }}
+        </ul>
+    </template>
+</div>

--- a/resources/views/livewire/dashboard/job-status-grid.blade.php
+++ b/resources/views/livewire/dashboard/job-status-grid.blade.php
@@ -15,8 +15,8 @@
                             default => 'bg-info',
                         };
 
-                        $serverName = $job->snapshot?->databaseServer?->name
-                            ?? $job->restore?->targetServer?->name
+                        $serverName = $job->snapshot?->databaseServer->name
+                            ?? $job->restore?->targetServer->name
                             ?? __('Unknown');
 
                         $databaseName = $job->snapshot?->database_name

--- a/resources/views/livewire/dashboard/latest-jobs.blade.php
+++ b/resources/views/livewire/dashboard/latest-jobs.blade.php
@@ -36,7 +36,7 @@
 
                                 {{-- Server Name (icon visible on desktop only in line 1) --}}
                                 <div class="flex items-center gap-2 flex-1 min-w-0">
-                                    @if($job->snapshot && $job->snapshot->databaseServer)
+                                    @if($job->snapshot)
                                         <x-icon :name="$job->snapshot->database_type->icon()" class="w-4 h-4 shrink-0 hidden sm:block" />
                                         @if($serverId)
                                             <span class="truncate text-sm font-medium">{{ $job->snapshot->databaseServer->name }}</span>
@@ -47,7 +47,7 @@
                                             </a>
                                         @endif
                                         <span class="text-xs text-base-content/50 truncate hidden sm:inline">{{ $job->snapshot->database_name }}</span>
-                                    @elseif($job->restore && $job->restore->targetServer)
+                                    @elseif($job->restore)
                                         @if($job->restore->snapshot)
                                             <x-icon :name="$job->restore->snapshot->database_type->icon()" class="w-4 h-4 shrink-0 hidden sm:block" />
                                         @endif
@@ -82,10 +82,10 @@
 
                             {{-- Line 2 on mobile: DB icon + name + time + logs --}}
                             <div class="flex items-center gap-2 sm:hidden text-base-content/70">
-                                @if($job->snapshot && $job->snapshot->databaseServer)
+                                @if($job->snapshot)
                                     <x-icon :name="$job->snapshot->database_type->icon()" class="w-4 h-4 shrink-0" />
                                     <span class="text-xs truncate flex-1">{{ $job->snapshot->database_name }}</span>
-                                @elseif($job->restore && $job->restore->targetServer)
+                                @elseif($job->restore)
                                     @if($job->restore->snapshot)
                                         <x-icon :name="$job->restore->snapshot->database_type->icon()" class="w-4 h-4 shrink-0" />
                                     @endif

--- a/resources/views/livewire/dashboard/latest-jobs.blade.php
+++ b/resources/views/livewire/dashboard/latest-jobs.blade.php
@@ -38,13 +38,27 @@
                                 <div class="flex items-center gap-2 flex-1 min-w-0">
                                     @if($job->snapshot && $job->snapshot->databaseServer)
                                         <x-icon :name="$job->snapshot->database_type->icon()" class="w-4 h-4 shrink-0 hidden sm:block" />
-                                        <span class="truncate text-sm font-medium">{{ $job->snapshot->databaseServer->name }}</span>
+                                        @if($serverId)
+                                            <span class="truncate text-sm font-medium">{{ $job->snapshot->databaseServer->name }}</span>
+                                        @else
+                                            <a href="{{ route('database-servers.show', $job->snapshot->databaseServer) }}" wire:navigate
+                                               class="truncate text-sm font-medium hover:text-primary hover:underline">
+                                                {{ $job->snapshot->databaseServer->name }}
+                                            </a>
+                                        @endif
                                         <span class="text-xs text-base-content/50 truncate hidden sm:inline">{{ $job->snapshot->database_name }}</span>
                                     @elseif($job->restore && $job->restore->targetServer)
                                         @if($job->restore->snapshot)
                                             <x-icon :name="$job->restore->snapshot->database_type->icon()" class="w-4 h-4 shrink-0 hidden sm:block" />
                                         @endif
-                                        <span class="truncate text-sm font-medium">{{ $job->restore->targetServer->name }}</span>
+                                        @if($serverId)
+                                            <span class="truncate text-sm font-medium">{{ $job->restore->targetServer->name }}</span>
+                                        @else
+                                            <a href="{{ route('database-servers.show', $job->restore->targetServer) }}" wire:navigate
+                                               class="truncate text-sm font-medium hover:text-primary hover:underline">
+                                                {{ $job->restore->targetServer->name }}
+                                            </a>
+                                        @endif
                                         <span class="text-xs text-base-content/50 truncate hidden sm:inline">{{ $job->restore->schema_name }}</span>
                                     @endif
                                 </div>

--- a/resources/views/livewire/dashboard/latest-jobs.blade.php
+++ b/resources/views/livewire/dashboard/latest-jobs.blade.php
@@ -106,11 +106,11 @@
             {{-- View All Link --}}
             <div class="mt-4 pt-3 border-t border-base-200">
                 <div class="flex flex-wrap items-center gap-3">
-                    <a href="{{ route('snapshots.index') }}" wire:navigate class="text-sm text-primary hover:underline flex items-center gap-1">
+                    <a href="{{ route('snapshots.index', $serverId ? ['serverFilter' => $serverId] : []) }}" wire:navigate class="text-sm text-primary hover:underline flex items-center gap-1">
                         {{ __('View all snapshots') }}
                         <x-icon name="o-arrow-right" class="w-4 h-4" />
                     </a>
-                    <a href="{{ route('restores.index') }}" wire:navigate class="text-sm text-primary hover:underline flex items-center gap-1">
+                    <a href="{{ route('restores.index', $serverId ? ['targetServerFilter' => $serverId] : []) }}" wire:navigate class="text-sm text-primary hover:underline flex items-center gap-1">
                         {{ __('View all restores') }}
                         <x-icon name="o-arrow-right" class="w-4 h-4" />
                     </a>

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -123,7 +123,7 @@
             <div class="flex justify-end">
                 <x-floating-dropdown right>
                     <x-slot:trigger>
-                        <x-button icon="o-ellipsis-vertical" class="btn-ghost btn-sm" tooltip-left="{{ __('Actions') }}" />
+                        <x-button icon="o-ellipsis-vertical" class="btn-ghost btn-sm" :tooltip-left="__('Actions')" />
                     </x-slot:trigger>
 
                     @can('view', $server)

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -120,25 +120,37 @@
             @endscope
 
             @scope('cell_actions', $server)
-            <div>
-                @can('backup', $server)
-                    <x-button icon="bi.database-fill-up" wire:click="runBackupAll('{{ $server->id }}')" spinner
-                              tooltip="{{ __('Backup now') }}" class="btn-ghost btn-sm text-info" />
-                @endcan
-                @can('restore', $server)
-                    <x-button icon="bi.database-fill-down" wire:click="confirmRestore('{{ $server->id }}')" spinner
-                              tooltip="{{ __('Restore') }}" class="btn-ghost btn-sm text-success" />
-                @endcan
-            </div>
-            <div>
-                @can('viewForm', $server)
-                    <x-button icon="o-pencil" link="{{ route('database-servers.edit', $server) }}" wire:navigate
-                              tooltip="{{ __('Edit') }}" class="btn-ghost btn-sm" />
-                @endcan
-                @can('delete', $server)
-                    <x-button icon="o-trash" wire:click="confirmDelete('{{ $server->id }}')"
-                              tooltip="{{ __('Delete') }}" class="btn-ghost btn-sm text-error" />
-                @endcan
+            <div class="flex justify-end">
+                <x-floating-dropdown right>
+                    <x-slot:trigger>
+                        <x-button icon="o-ellipsis-vertical" class="btn-ghost btn-sm" tooltip-left="{{ __('Actions') }}" />
+                    </x-slot:trigger>
+
+                    @can('view', $server)
+                        <x-menu-item :title="__('View')" icon="o-eye"
+                                     link="{{ route('database-servers.show', $server) }}" wire:navigate />
+                    @endcan
+                    @can('backup', $server)
+                        <x-menu-item :title="__('Backup now')" icon="bi.database-fill-up"
+                                     wire:click="runBackupAll('{{ $server->id }}')" spinner
+                                     class="text-info" />
+                    @endcan
+                    @can('restore', $server)
+                        <x-menu-item :title="__('Restore')" icon="bi.database-fill-down"
+                                     wire:click="confirmRestore('{{ $server->id }}')" spinner
+                                     class="text-success" />
+                    @endcan
+                    @can('viewForm', $server)
+                        <x-menu-item :title="__('Edit')" icon="o-pencil"
+                                     link="{{ route('database-servers.edit', $server) }}" wire:navigate />
+                    @endcan
+                    @can('delete', $server)
+                        <x-menu-separator />
+                        <x-menu-item :title="__('Delete')" icon="o-trash"
+                                     wire:click="confirmDelete('{{ $server->id }}')"
+                                     class="text-error" />
+                    @endcan
+                </x-floating-dropdown>
             </div>
             @endscope
         </x-table>

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -1,0 +1,506 @@
+<div>
+    @php
+        use App\Enums\DatabaseType;
+        use App\Enums\NotificationChannelSelection;
+        use App\Enums\NotificationTrigger;
+
+        $sshConfig = $server->sshConfig;
+        $agent = $server->agent;
+        $isSqlite = $server->database_type === DatabaseType::SQLITE;
+        $sslEnabled = (bool) $server->getExtraConfig('ssl_enabled', false);
+        $authSource = $server->getExtraConfig('auth_source');
+        $dumpFlags = $server->getExtraConfig('dump_flags');
+
+        $trigger = $server->notification_trigger;
+        $selection = $server->notification_channel_selection;
+        $channelCount = $activeChannels->count();
+        $notifDisabled = $trigger === NotificationTrigger::None;
+        $notifNoChannels = ! $notifDisabled && $channelCount === 0;
+
+        $triggerMeta = [
+            'all' => [
+                'icon' => 'o-bell-alert',
+                'figure' => 'text-success',
+                'status' => 'status-success',
+                'alert' => 'alert-success',
+                'summary' => __('all events'),
+            ],
+            'success' => [
+                'icon' => 'o-check-circle',
+                'figure' => 'text-info',
+                'status' => 'status-info',
+                'alert' => 'alert-info',
+                'summary' => __('successful backups'),
+            ],
+            'failure' => [
+                'icon' => 'o-exclamation-triangle',
+                'figure' => 'text-warning',
+                'status' => 'status-warning',
+                'alert' => 'alert-warning',
+                'summary' => __('failures'),
+            ],
+            'none' => [
+                'icon' => 'o-bell-slash',
+                'figure' => 'text-base-content/40',
+                'status' => '',
+                'alert' => '',
+                'summary' => __('no events'),
+            ],
+        ][$trigger->value];
+    @endphp
+
+    {{-- ── Hero header ── --}}
+    <div class="card card-border bg-base-100 shadow-sm mb-6">
+        <div class="card-body p-5 sm:p-6">
+            <div class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+                <div class="flex items-start gap-4 min-w-0">
+                    <div class="avatar avatar-placeholder shrink-0">
+                        <div class="bg-base-200 rounded-box w-14 h-14">
+                            <x-icon :name="$server->database_type->icon()" class="w-9 h-9 text-base-content" />
+                        </div>
+                    </div>
+                    <div class="min-w-0 flex-1">
+                        <h1 class="text-xl font-semibold leading-tight">{{ $server->name }}</h1>
+                        @if($server->description)
+                            <p class="mt-1 line-clamp-2 text-sm opacity-60 leading-relaxed">{{ $server->description }}</p>
+                        @endif
+
+                        <div class="mt-3 flex flex-wrap items-center gap-2">
+                            <span class="badge badge-ghost gap-1.5">
+                                <x-icon name="o-circle-stack" class="w-3.5 h-3.5" />
+                                {{ $server->database_type->label() }}
+                            </span>
+
+                            <span class="badge badge-outline gap-1.5">
+                                <x-icon name="o-wifi" class="w-3.5 h-3.5 opacity-60" />
+                                <code class="font-mono">{{ $server->getConnectionLabel() }}</code>
+                            </span>
+
+                            @if($sshConfig)
+                                <span class="badge badge-warning badge-soft gap-1.5">
+                                    <x-icon name="o-shield-check" class="w-3.5 h-3.5" />
+                                    {{ __('SSH tunnel via') }}
+                                    <code class="font-mono">{{ $sshConfig->host }}</code>
+                                </span>
+                            @endif
+
+                            @if($agent)
+                                @php $online = $agent->isOnline(); @endphp
+                                <span class="badge {{ $online ? 'badge-success' : 'badge-error' }} badge-soft gap-1.5">
+                                    <x-icon :name="$online ? 'o-signal' : 'o-signal-slash'" class="w-3.5 h-3.5" />
+                                    {{ __('Agent') }}: {{ $agent->name }}
+                                    <span class="status {{ $online ? 'status-success animate-pulse' : 'status-error' }}"></span>
+                                </span>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex shrink-0 flex-wrap items-center gap-2">
+                    <x-button :label="__('Back')" icon="o-arrow-left" link="{{ route('database-servers.index') }}"
+                              class="btn-ghost btn-sm" wire:navigate />
+                    @can('backup', $server)
+                        <x-button :label="__('Backup now')" icon="bi.database-fill-up" wire:click="runBackupAll" spinner
+                                  class="btn-outline btn-info btn-sm" />
+                    @endcan
+                    @can('restore', $server)
+                        <x-button :label="__('Restore')" icon="bi.database-fill-down" wire:click="confirmRestore" spinner
+                                  class="btn-outline btn-success btn-sm" />
+                    @endcan
+                    @can('viewForm', $server)
+                        <x-button :label="__('Edit')" icon="o-pencil" link="{{ route('database-servers.edit', $server) }}"
+                                  class="btn-primary btn-sm" wire:navigate />
+                    @endcan
+                    @can('delete', $server)
+                        <x-button icon="o-trash" wire:click="confirmDelete" tooltip-left="{{ __('Delete') }}"
+                                  class="btn-ghost btn-sm text-error" />
+                    @endcan
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- ── Stat strip ── --}}
+    <div class="stats stats-vertical lg:stats-horizontal shadow-sm border border-base-200 w-full mb-6">
+        <a href="{{ route('snapshots.index', ['serverFilter' => $server->id]) }}" wire:navigate
+           class="stat group cursor-pointer transition-colors hover:bg-base-200">
+            <div class="stat-figure text-info transition-transform group-hover:scale-110">
+                <x-icon name="o-archive-box" class="w-8 h-8" />
+            </div>
+            <div class="stat-title group-hover:text-base-content">{{ __('Snapshots') }}</div>
+            <div class="stat-value font-mono transition-colors group-hover:text-info">{{ $snapshotsCount }}</div>
+            <div class="stat-desc inline-flex items-center gap-1 group-hover:text-info">
+                {{ __('Click to view all') }}
+                <x-icon name="o-arrow-right" class="w-3 h-3 transition-transform group-hover:translate-x-0.5" />
+            </div>
+        </a>
+
+        <a href="{{ route('restores.index', ['targetServerFilter' => $server->id]) }}" wire:navigate
+           class="stat group cursor-pointer transition-colors hover:bg-base-200">
+            <div class="stat-figure text-warning transition-transform group-hover:scale-110">
+                <x-icon name="o-arrow-uturn-left" class="w-8 h-8" />
+            </div>
+            <div class="stat-title group-hover:text-base-content">{{ __('Restores') }}</div>
+            <div class="stat-value font-mono transition-colors group-hover:text-warning">{{ $restoresCount }}</div>
+            <div class="stat-desc inline-flex items-center gap-1 group-hover:text-warning">
+                {{ __('Click to view all') }}
+                <x-icon name="o-arrow-right" class="w-3 h-3 transition-transform group-hover:translate-x-0.5" />
+            </div>
+        </a>
+
+        <div class="stat">
+            <div class="stat-figure {{ $server->backups_enabled ? 'text-success' : 'text-base-content/40' }}">
+                <x-icon name="o-server-stack" class="w-8 h-8" />
+            </div>
+            <div class="stat-title">{{ __('Backup configs') }}</div>
+            <div class="stat-value font-mono">{{ $server->backups->count() }}</div>
+            <div class="stat-desc {{ $server->backups_enabled ? 'text-success' : '' }}">
+                {{ $server->backups_enabled ? __('Enabled') : __('Disabled') }}
+            </div>
+        </div>
+
+        <div class="stat">
+            <div class="stat-figure {{ $triggerMeta['figure'] }}">
+                <x-icon :name="$triggerMeta['icon']" class="w-8 h-8" />
+            </div>
+            <div class="stat-title">{{ __('Notifications') }}</div>
+            <div class="stat-value text-lg! flex items-center gap-2">
+                @if($triggerMeta['status'])
+                    <span class="status {{ $triggerMeta['status'] }}"></span>
+                @endif
+                {{ $trigger->label() }}
+            </div>
+            <div class="stat-desc {{ $notifNoChannels ? 'text-warning' : '' }}">
+                @if($notifDisabled)
+                    {{ __('No alerts') }}
+                @else
+                    {{ trans_choice('{0} no channels|{1} :count channel|[2,*] :count channels', $channelCount, ['count' => $channelCount]) }}
+                @endif
+            </div>
+        </div>
+    </div>
+
+    {{-- ── Two-column body ── --}}
+    <div class="flex flex-col gap-6 lg:flex-row lg:items-start">
+        {{-- Main: Backup Configurations --}}
+        <div class="min-w-0 flex-1 lg:basis-2/3">
+            <div class="card card-border bg-base-100 shadow-sm overflow-hidden">
+                <div class="flex items-center justify-between border-b border-base-200 px-4 py-3">
+                    <div class="flex items-center gap-2.5">
+                        <x-icon name="o-server-stack" class="w-4 h-4 opacity-60" />
+                        <h2 class="text-sm font-semibold">{{ __('Backup Configurations') }}</h2>
+                        <span class="badge badge-ghost badge-sm">{{ $server->backups->count() }}</span>
+                    </div>
+                    @if(! $server->backups_enabled)
+                        <span class="badge badge-warning badge-soft badge-sm">{{ __('Disabled') }}</span>
+                    @endif
+                </div>
+
+                <div class="p-4">
+                    @if($server->backups->isEmpty())
+                        <div class="flex flex-col items-center gap-3 py-10 text-center">
+                            <div class="avatar avatar-placeholder">
+                                <div class="bg-base-200 rounded-full w-12 h-12">
+                                    <x-icon name="o-server-stack" class="w-6 h-6 opacity-50" />
+                                </div>
+                            </div>
+                            <div>
+                                <p class="text-sm font-medium">{{ __('No backup configurations') }}</p>
+                                <p class="mt-1 text-xs opacity-60">
+                                    {{ __('Add a backup configuration to start protecting this server.') }}
+                                </p>
+                            </div>
+                            @can('viewForm', $server)
+                                <x-button :label="__('Add a backup configuration')" icon="o-plus"
+                                          link="{{ route('database-servers.edit', $server) }}"
+                                          class="btn-primary btn-sm" wire:navigate />
+                            @endcan
+                        </div>
+                    @else
+                        <div class="flex flex-col gap-3">
+                            @foreach($server->backups as $backup)
+                                @php $label = $backup->getDisplayLabel(false); @endphp
+                                <div class="rounded-box border border-base-200 bg-base-200/40 p-3 sm:p-4 space-y-3">
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        <span class="badge badge-primary badge-soft gap-1.5">
+                                            <x-icon name="o-clock" class="w-3.5 h-3.5" />
+                                            {{ $label['schedule'] }}
+                                        </span>
+                                        <x-icon name="o-arrow-right" class="w-3.5 h-3.5 shrink-0 opacity-40" />
+                                        <span class="badge badge-ghost gap-1.5">
+                                            <x-volume-type-icon :type="$backup->volume->type" class="w-3.5 h-3.5" />
+                                            {{ $label['volume'] }}
+                                        </span>
+                                    </div>
+
+                                    <div class="flex flex-wrap items-center gap-2">
+                                        @if($label['databases'])
+                                            <span class="badge badge-ghost badge-sm gap-1">
+                                                <x-icon name="o-circle-stack" class="w-3 h-3" />
+                                                <span class="opacity-60">{{ __('Databases') }}:</span>
+                                                <span class="font-medium">{{ $label['databases'] }}</span>
+                                            </span>
+                                        @endif
+                                        @if($label['retention'])
+                                            <span class="badge badge-info badge-soft badge-sm gap-1">
+                                                <x-icon name="o-archive-box" class="w-3 h-3" />
+                                                <span class="opacity-70">{{ __('Retention') }}:</span>
+                                                <span class="font-medium">{{ $label['retention'] }}</span>
+                                            </span>
+                                        @endif
+                                        @if($backup->path)
+                                            <span class="badge badge-ghost badge-sm gap-1">
+                                                <x-icon name="o-folder" class="w-3 h-3" />
+                                                <span class="opacity-60">{{ __('Path') }}:</span>
+                                                <span class="font-mono font-medium">{{ $backup->path }}</span>
+                                            </span>
+                                        @endif
+                                    </div>
+                                </div>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        {{-- Side: Connection / SSH / Agent --}}
+        <div class="flex flex-col gap-4 lg:basis-1/3 lg:w-1/3">
+            {{-- Connection --}}
+            <div class="card card-border bg-base-100 shadow-sm overflow-hidden">
+                <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
+                    <x-icon :name="$server->database_type->icon()" class="w-4 h-4" />
+                    <h2 class="text-sm font-semibold">{{ __('Connection') }}</h2>
+                </div>
+                <ul class="list">
+                    @if($isSqlite)
+                        <li class="list-row">
+                            <x-icon name="o-document" class="w-4 h-4 opacity-60" />
+                            <div>
+                                <div class="text-xs uppercase font-semibold opacity-60">{{ __('Database files') }}</div>
+                                <div class="text-sm font-mono break-all">
+                                    @foreach($server->resolveDatabaseNames() as $path)
+                                        <div>{{ $path }}</div>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </li>
+                    @else
+                        <li class="list-row">
+                            <x-icon name="o-wifi" class="w-4 h-4 opacity-60" />
+                            <div>
+                                <div class="text-xs uppercase font-semibold opacity-60">{{ __('Host / Port') }}</div>
+                                <div class="text-sm font-mono">{{ $server->host }}<span class="opacity-50">:{{ $server->port }}</span></div>
+                            </div>
+                        </li>
+                        @if($server->username)
+                            <li class="list-row">
+                                <x-icon name="o-key" class="w-4 h-4 opacity-60" />
+                                <div>
+                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('Username') }}</div>
+                                    <div class="text-sm font-mono">{{ $server->username }}</div>
+                                </div>
+                            </li>
+                        @endif
+                        <li class="list-row">
+                            <x-icon name="o-lock-closed" class="w-4 h-4 opacity-60" />
+                            <div>
+                                <div class="text-xs uppercase font-semibold opacity-60">{{ __('Password') }}</div>
+                                <div class="text-sm font-mono tracking-widest opacity-60">{{ $server->password ? '••••••••' : '—' }}</div>
+                            </div>
+                        </li>
+                        @if($server->database_type === DatabaseType::MYSQL)
+                            <li class="list-row">
+                                <x-icon name="o-shield-check" class="w-4 h-4 opacity-60" />
+                                <div>
+                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('SSL') }}</div>
+                                    <div class="text-xs font-medium {{ $sslEnabled ? 'text-success' : 'opacity-60' }}">
+                                        {{ $sslEnabled ? __('Enabled') : __('Disabled') }}
+                                    </div>
+                                </div>
+                            </li>
+                        @endif
+                        @if($authSource)
+                            <li class="list-row">
+                                <x-icon name="o-identification" class="w-4 h-4 opacity-60" />
+                                <div>
+                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('Authentication DB') }}</div>
+                                    <div class="text-sm font-mono">{{ $authSource }}</div>
+                                </div>
+                            </li>
+                        @endif
+                        @if($dumpFlags)
+                            <li class="list-row">
+                                <x-icon name="o-command-line" class="w-4 h-4 opacity-60" />
+                                <div>
+                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('Dump flags') }}</div>
+                                    <div class="text-xs font-mono break-all">{{ $dumpFlags }}</div>
+                                </div>
+                            </li>
+                        @endif
+                    @endif
+                </ul>
+            </div>
+
+            {{-- SSH --}}
+            @if($sshConfig)
+                <div class="card card-border bg-base-100 shadow-sm overflow-hidden">
+                    <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
+                        <x-icon name="o-shield-check" class="w-4 h-4 text-warning" />
+                        <h2 class="text-sm font-semibold">{{ __('SSH Tunnel') }}</h2>
+                    </div>
+                    <div class="p-4">
+                        <div role="alert" class="alert alert-warning alert-soft">
+                            <x-icon name="o-server" class="w-4 h-4" />
+                            <code class="font-mono text-sm break-all">{{ $sshConfig->username }}@{{ $sshConfig->host }}:{{ $sshConfig->port }}</code>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            {{-- Agent --}}
+            @if($agent)
+                @php
+                    $online = $agent->isOnline();
+                    $neverConnected = $agent->last_heartbeat_at === null;
+                @endphp
+                <div class="card card-border bg-base-100 shadow-sm overflow-hidden">
+                    <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
+                        <x-icon name="o-cpu-chip" class="w-4 h-4 opacity-60" />
+                        <h2 class="text-sm font-semibold">{{ __('Agent') }}</h2>
+                    </div>
+                    <div class="p-4 space-y-3">
+                        <div class="flex items-center justify-between gap-2">
+                            <span class="text-sm font-medium truncate">{{ $agent->name }}</span>
+                            <span class="badge {{ $neverConnected ? 'badge-ghost' : ($online ? 'badge-success' : 'badge-error') }} badge-soft gap-1.5">
+                                @if(! $neverConnected)
+                                    <span class="status {{ $online ? 'status-success animate-pulse' : 'status-error' }}"></span>
+                                @endif
+                                {{ $neverConnected ? __('Never connected') : ($online ? __('Online') : __('Offline')) }}
+                            </span>
+                        </div>
+                        @if($agent->last_heartbeat_at)
+                            <p class="text-xs opacity-60">
+                                {{ __('Last heartbeat :time', ['time' => $agent->last_heartbeat_at->diffForHumans()]) }}
+                            </p>
+                        @endif
+                    </div>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    {{-- ── Notifications ── --}}
+    <div class="card card-border bg-base-100 shadow-sm overflow-hidden mt-6">
+        <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
+            <x-icon name="o-bell" class="w-4 h-4 opacity-60" />
+            <h2 class="text-sm font-semibold">{{ __('Notifications') }}</h2>
+        </div>
+        <div class="p-4">
+            @php
+                $alertClass = $notifNoChannels ? 'alert-warning' : ($triggerMeta['alert'] ?: '');
+                $alertIcon = $notifNoChannels ? 'o-exclamation-triangle' : $triggerMeta['icon'];
+            @endphp
+            <div role="alert" class="alert {{ $alertClass }} alert-soft">
+                <x-icon :name="$alertIcon" class="w-4 h-4 shrink-0" />
+                <span class="text-sm">
+                    @if($notifDisabled)
+                        {{ __('Notifications are disabled for this server.') }}
+                    @elseif($notifNoChannels)
+                        @if($selection === NotificationChannelSelection::All)
+                            {{ __('Trigger is set to') }}
+                            <strong>{{ $trigger->label() }}</strong>
+                            {{ __('but no notification channels are configured.') }}
+                        @else
+                            {{ __('Trigger is set to') }}
+                            <strong>{{ $trigger->label() }}</strong>
+                            {{ __('but no channels are selected.') }}
+                        @endif
+                    @else
+                        {{ __('Sends notifications on') }}
+                        <strong>{{ $triggerMeta['summary'] }}</strong>
+                        {{ __('to') }}
+                        <strong>
+                            @if($selection === NotificationChannelSelection::All)
+                                {{ trans_choice('{1} all :count channel|[2,*] all :count channels', $channelCount, ['count' => $channelCount]) }}
+                            @else
+                                {{ trans_choice('{1} :count channel|[2,*] :count channels', $channelCount, ['count' => $channelCount]) }}
+                            @endif
+                        </strong>.
+                    @endif
+                </span>
+            </div>
+
+            @if(! $notifDisabled && $activeChannels->isNotEmpty())
+                <div class="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                    @foreach($activeChannels as $channel)
+                        <div class="card card-border bg-base-100">
+                            <div class="card-body p-3 flex-row items-center gap-3">
+                                <div class="avatar avatar-placeholder shrink-0">
+                                    <div class="bg-info/10 text-info rounded-box w-8 h-8">
+                                        <x-icon :name="$channel->type->icon()" class="w-4 h-4" />
+                                    </div>
+                                </div>
+                                <div class="min-w-0 flex-1">
+                                    <p class="truncate text-sm font-medium">{{ $channel->name }}</p>
+                                    <p class="text-xs opacity-60">{{ $channel->type->label() }}</p>
+                                </div>
+                            </div>
+                        </div>
+                    @endforeach
+                </div>
+            @endif
+        </div>
+    </div>
+
+    {{-- ── Latest Jobs ── --}}
+    <div class="mt-6">
+        <livewire:dashboard.latest-jobs :serverId="$server->id" :key="'jobs-' . $server->id" />
+    </div>
+
+    {{-- DELETE CONFIRMATION MODAL --}}
+    <x-delete-confirmation-modal :title="__('Delete Database Server')"
+                                 :message="__('Are you sure you want to delete this database server? This action cannot be undone.')"
+                                 onConfirm="delete"
+                                 :showKeepFiles="$deleteSnapshotCount > 0"
+                                 :snapshotCount="$deleteSnapshotCount" />
+
+    {{-- RESTORE MODAL --}}
+    <livewire:restore.modal />
+
+    {{-- REDIS RESTORE INFO MODAL --}}
+    <x-modal wire:model="showRedisRestoreModal" :title="__('Restore Redis / Valkey Snapshot')" class="backdrop-blur">
+        <div class="space-y-4">
+            <x-alert class="alert-info" icon="o-information-circle">
+                <div>
+                    <span class="font-bold">{{ __('Manual Restore Required') }}</span>
+                    <p class="text-sm mt-1">
+                        {{ __('Automated restore is not supported for Redis/Valkey. RDB snapshots must be restored manually.') }}
+                    </p>
+                </div>
+            </x-alert>
+
+            <div class="p-4 border rounded-lg bg-base-200 border-base-300 space-y-3">
+                <div class="text-sm font-semibold">{{ __('How to Restore an RDB Snapshot') }}</div>
+                <ol class="list-decimal list-inside text-sm space-y-2 opacity-80">
+                    <li>{{ __('Download the snapshot archive (.rdb.gz) from your storage volume.') }}</li>
+                    <li>{{ __('Extract the RDB file from the archive (e.g., gunzip snapshot.rdb.gz).') }}</li>
+                    <li>{{ __('Stop the Redis/Valkey server.') }}</li>
+                    <li>{{ __('Copy the RDB file to the Redis data directory, replacing dump.rdb.') }}</li>
+                    <li>{{ __('Set correct file permissions (e.g., chown redis:redis dump.rdb).') }}</li>
+                    <li>{{ __('Restart the Redis/Valkey server.') }}</li>
+                </ol>
+            </div>
+
+            <a href="{{ route('snapshots.index', ['serverFilter' => $server->id]) }}"
+               class="btn btn-sm btn-outline gap-2" wire:navigate>
+                <x-icon name="o-arrow-down-tray" class="w-4 h-4" />
+                {{ __('View Backup Snapshots') }}
+            </a>
+        </div>
+
+        <x-slot:actions>
+            <x-button label="{{ __('Close') }}" @click="$wire.showRedisRestoreModal = false" />
+        </x-slot:actions>
+    </x-modal>
+</div>

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -1,8 +1,10 @@
 <div>
     @php
+        use App\Enums\DatabaseSelectionMode;
         use App\Enums\DatabaseType;
         use App\Enums\NotificationChannelSelection;
         use App\Enums\NotificationTrigger;
+        use App\Livewire\Forms\BackupForm;
 
         $sshConfig = $server->sshConfig;
         $agent = $server->agent;
@@ -18,34 +20,10 @@
         $notifNoChannels = ! $notifDisabled && $channelCount === 0;
 
         $triggerMeta = [
-            'all' => [
-                'icon' => 'o-bell-alert',
-                'figure' => 'text-success',
-                'status' => 'status-success',
-                'alert' => 'alert-success',
-                'summary' => __('all events'),
-            ],
-            'success' => [
-                'icon' => 'o-check-circle',
-                'figure' => 'text-info',
-                'status' => 'status-info',
-                'alert' => 'alert-info',
-                'summary' => __('successful backups'),
-            ],
-            'failure' => [
-                'icon' => 'o-exclamation-triangle',
-                'figure' => 'text-warning',
-                'status' => 'status-warning',
-                'alert' => 'alert-warning',
-                'summary' => __('failures'),
-            ],
-            'none' => [
-                'icon' => 'o-bell-slash',
-                'figure' => 'text-base-content/40',
-                'status' => '',
-                'alert' => '',
-                'summary' => __('no events'),
-            ],
+            'all' => ['icon' => 'o-bell-alert', 'figure' => 'text-success', 'status' => 'status-success'],
+            'success' => ['icon' => 'o-check-circle', 'figure' => 'text-info', 'status' => 'status-info'],
+            'failure' => ['icon' => 'o-exclamation-triangle', 'figure' => 'text-warning', 'status' => 'status-warning'],
+            'none' => ['icon' => 'o-bell-slash', 'figure' => 'text-base-content/40', 'status' => ''],
         ][$trigger->value];
     @endphp
 
@@ -71,16 +49,11 @@
                                 {{ $server->database_type->label() }}
                             </span>
 
-                            <span class="badge badge-outline gap-1.5">
-                                <x-icon name="o-wifi" class="w-3.5 h-3.5 opacity-60" />
-                                <code class="font-mono">{{ $server->getConnectionLabel() }}</code>
-                            </span>
-
                             @if($sshConfig)
                                 <span class="badge badge-warning badge-soft gap-1.5">
                                     <x-icon name="o-shield-check" class="w-3.5 h-3.5" />
-                                    {{ __('SSH tunnel via') }}
-                                    <code class="font-mono">{{ $sshConfig->host }}</code>
+                                    {{ __('SSH tunnel') }}
+                                    <code class="font-mono">{{ $sshConfig->username . '@' . $sshConfig->host . ':' . $sshConfig->port }}</code>
                                 </span>
                             @endif
 
@@ -90,6 +63,18 @@
                                     <x-icon :name="$online ? 'o-signal' : 'o-signal-slash'" class="w-3.5 h-3.5" />
                                     {{ __('Agent') }}: {{ $agent->name }}
                                     <span class="status {{ $online ? 'status-success animate-pulse' : 'status-error' }}"></span>
+                                </span>
+                            @endif
+
+                            @if($server->backups_enabled)
+                                <span class="badge badge-success badge-soft gap-1.5">
+                                    <x-icon name="o-check-circle" class="w-3.5 h-3.5" />
+                                    {{ trans_choice('{0} Backups enabled (no config)|{1} Backups enabled (:count config)|[2,*] Backups enabled (:count configs)', $server->backups->count(), ['count' => $server->backups->count()]) }}
+                                </span>
+                            @else
+                                <span class="badge badge-warning badge-soft gap-1.5">
+                                    <x-icon name="o-no-symbol" class="w-3.5 h-3.5" />
+                                    {{ __('Backups disabled') }}
                                 </span>
                             @endif
                         </div>
@@ -149,17 +134,6 @@
         </a>
 
         <div class="stat">
-            <div class="stat-figure {{ $server->backups_enabled ? 'text-success' : 'text-base-content/40' }}">
-                <x-icon name="o-server-stack" class="w-8 h-8" />
-            </div>
-            <div class="stat-title">{{ __('Backup configs') }}</div>
-            <div class="stat-value font-mono">{{ $server->backups->count() }}</div>
-            <div class="stat-desc {{ $server->backups_enabled ? 'text-success' : '' }}">
-                {{ $server->backups_enabled ? __('Enabled') : __('Disabled') }}
-            </div>
-        </div>
-
-        <div class="stat">
             <div class="stat-figure {{ $triggerMeta['figure'] }}">
                 <x-icon :name="$triggerMeta['icon']" class="w-8 h-8" />
             </div>
@@ -170,11 +144,25 @@
                 @endif
                 {{ $trigger->label() }}
             </div>
-            <div class="stat-desc {{ $notifNoChannels ? 'text-warning' : '' }}">
+            <div class="stat-desc mt-1">
                 @if($notifDisabled)
-                    {{ __('No alerts') }}
+                    <span class="opacity-60">{{ __('No alerts') }}</span>
+                @elseif($notifNoChannels)
+                    <span class="text-warning inline-flex items-center gap-1">
+                        <x-icon name="o-exclamation-triangle" class="w-3.5 h-3.5" />
+                        {{ $selection === NotificationChannelSelection::All
+                            ? __('No channels configured')
+                            : __('No channels selected') }}
+                    </span>
                 @else
-                    {{ trans_choice('{0} no channels|{1} :count channel|[2,*] :count channels', $channelCount, ['count' => $channelCount]) }}
+                    <div class="flex flex-wrap gap-1">
+                        @foreach($activeChannels as $channel)
+                            <span class="badge badge-ghost badge-sm gap-1" title="{{ $channel->type->label() }}">
+                                <x-icon :name="$channel->type->icon()" class="w-3 h-3" />
+                                <span class="normal-case">{{ $channel->name }}</span>
+                            </span>
+                        @endforeach
+                    </div>
                 @endif
             </div>
         </div>
@@ -219,43 +207,76 @@
                     @else
                         <div class="flex flex-col gap-3">
                             @foreach($server->backups as $backup)
-                                @php $label = $backup->getDisplayLabel(false); @endphp
-                                <div class="rounded-box border border-base-200 bg-base-200/40 p-3 sm:p-4 space-y-3">
-                                    <div class="flex flex-wrap items-center gap-2">
-                                        <span class="badge badge-primary badge-soft gap-1.5">
-                                            <x-icon name="o-clock" class="w-3.5 h-3.5" />
-                                            {{ $label['schedule'] }}
-                                        </span>
-                                        <x-icon name="o-arrow-right" class="w-3.5 h-3.5 shrink-0 opacity-40" />
-                                        <span class="badge badge-ghost gap-1.5">
-                                            <x-volume-type-icon :type="$backup->volume->type" class="w-3.5 h-3.5" />
-                                            {{ $label['volume'] }}
-                                        </span>
-                                    </div>
+                                @php
+                                    $entry = $backup->toArray();
+                                    $summaryWhat = BackupForm::selectionSummary($entry, $server->database_type);
+                                    $summaryWhere = $backup->volume?->name;
+                                    $summaryWhen = $backup->backupSchedule
+                                        ? \App\Support\Formatters::cronTranslation($backup->backupSchedule->expression).' ('.$backup->backupSchedule->name.')'
+                                        : null;
+                                    $summaryKeep = BackupForm::retentionSummary($entry);
 
-                                    <div class="flex flex-wrap items-center gap-2">
-                                        @if($label['databases'])
-                                            <span class="badge badge-ghost badge-sm gap-1">
-                                                <x-icon name="o-circle-stack" class="w-3 h-3" />
-                                                <span class="opacity-60">{{ __('Databases') }}:</span>
-                                                <span class="font-medium">{{ $label['databases'] }}</span>
-                                            </span>
+                                    $mode = $backup->database_selection_mode;
+                                    $isSqliteServer = $server->database_type === DatabaseType::SQLITE;
+                                    $databaseNames = is_array($backup->database_names) ? array_values(array_filter($backup->database_names)) : [];
+                                    $showNamesList = ($isSqliteServer && $databaseNames !== [])
+                                        || ($mode === DatabaseSelectionMode::Selected && $databaseNames !== []);
+                                @endphp
+                                <div class="rounded-lg border border-primary/20 bg-primary/5 px-4 py-3.5">
+                                    <dl class="grid gap-y-2 gap-x-4 text-sm" style="grid-template-columns: auto 1fr;">
+                                        @if($summaryWhat || $showNamesList)
+                                            <dt class="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-base-content/50">
+                                                <x-icon name="o-circle-stack" class="w-3.5 h-3.5" />
+                                                {{ __('What') }}
+                                            </dt>
+                                            <dd class="font-semibold text-base-content">
+                                                @if($showNamesList)
+                                                    <div class="flex flex-wrap items-center gap-1.5">
+                                                        @foreach($databaseNames as $name)
+                                                            <span class="badge badge-ghost badge-sm font-mono normal-case">
+                                                                <x-icon :name="$isSqliteServer ? 'o-document' : 'o-circle-stack'" class="w-3 h-3 opacity-60 mr-1" />
+                                                                {{ $name }}
+                                                            </span>
+                                                        @endforeach
+                                                    </div>
+                                                @elseif($mode === DatabaseSelectionMode::Pattern && ! empty($backup->database_include_pattern))
+                                                    <span class="inline-flex items-center gap-1.5">
+                                                        {{ __('Databases matching') }}
+                                                        <code class="font-mono text-xs px-1.5 py-0.5 rounded bg-base-200">/{{ $backup->database_include_pattern }}/i</code>
+                                                    </span>
+                                                @else
+                                                    {{ $summaryWhat }}
+                                                @endif
+                                            </dd>
                                         @endif
-                                        @if($label['retention'])
-                                            <span class="badge badge-info badge-soft badge-sm gap-1">
-                                                <x-icon name="o-archive-box" class="w-3 h-3" />
-                                                <span class="opacity-70">{{ __('Retention') }}:</span>
-                                                <span class="font-medium">{{ $label['retention'] }}</span>
-                                            </span>
+
+                                        @if($summaryWhere)
+                                            <dt class="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-base-content/50">
+                                                <x-icon name="o-server-stack" class="w-3.5 h-3.5" />
+                                                {{ __('Where') }}
+                                            </dt>
+                                            <dd class="font-semibold text-base-content inline-flex items-center gap-1.5">
+                                                @if($backup->volume)
+                                                    <x-volume-type-icon :type="$backup->volume->type" class="w-3.5 h-3.5 opacity-70" />
+                                                @endif
+                                                <span>{{ $summaryWhere }}@if($backup->path)<span class="text-base-content/50 font-normal font-mono text-xs"> / {{ $backup->path }}</span>@endif</span>
+                                            </dd>
                                         @endif
-                                        @if($backup->path)
-                                            <span class="badge badge-ghost badge-sm gap-1">
-                                                <x-icon name="o-folder" class="w-3 h-3" />
-                                                <span class="opacity-60">{{ __('Path') }}:</span>
-                                                <span class="font-mono font-medium">{{ $backup->path }}</span>
-                                            </span>
+
+                                        @if($summaryWhen)
+                                            <dt class="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-base-content/50">
+                                                <x-icon name="o-clock" class="w-3.5 h-3.5" />
+                                                {{ __('When') }}
+                                            </dt>
+                                            <dd class="font-semibold text-base-content">{{ $summaryWhen }}</dd>
                                         @endif
-                                    </div>
+
+                                        <dt class="flex items-center gap-1.5 text-xs font-medium uppercase tracking-wide text-base-content/50">
+                                            <x-icon name="o-archive-box" class="w-3.5 h-3.5" />
+                                            {{ __('Keep') }}
+                                        </dt>
+                                        <dd class="font-semibold text-base-content">{{ $summaryKeep }}</dd>
+                                    </dl>
                                 </div>
                             @endforeach
                         </div>
@@ -342,22 +363,6 @@
                 </ul>
             </div>
 
-            {{-- SSH --}}
-            @if($sshConfig)
-                <div class="card card-border bg-base-100 shadow-sm overflow-hidden">
-                    <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
-                        <x-icon name="o-shield-check" class="w-4 h-4 text-warning" />
-                        <h2 class="text-sm font-semibold">{{ __('SSH Tunnel') }}</h2>
-                    </div>
-                    <div class="p-4">
-                        <div role="alert" class="alert alert-warning alert-soft">
-                            <x-icon name="o-server" class="w-4 h-4" />
-                            <code class="font-mono text-sm break-all">{{ $sshConfig->username }}@{{ $sshConfig->host }}:{{ $sshConfig->port }}</code>
-                        </div>
-                    </div>
-                </div>
-            @endif
-
             {{-- Agent --}}
             @if($agent)
                 @php
@@ -385,69 +390,6 @@
                             </p>
                         @endif
                     </div>
-                </div>
-            @endif
-        </div>
-    </div>
-
-    {{-- ── Notifications ── --}}
-    <div class="card card-border bg-base-100 shadow-sm overflow-hidden mt-6">
-        <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
-            <x-icon name="o-bell" class="w-4 h-4 opacity-60" />
-            <h2 class="text-sm font-semibold">{{ __('Notifications') }}</h2>
-        </div>
-        <div class="p-4">
-            @php
-                $alertClass = $notifNoChannels ? 'alert-warning' : ($triggerMeta['alert'] ?: '');
-                $alertIcon = $notifNoChannels ? 'o-exclamation-triangle' : $triggerMeta['icon'];
-            @endphp
-            <div role="alert" class="alert {{ $alertClass }} alert-soft">
-                <x-icon :name="$alertIcon" class="w-4 h-4 shrink-0" />
-                <span class="text-sm">
-                    @if($notifDisabled)
-                        {{ __('Notifications are disabled for this server.') }}
-                    @elseif($notifNoChannels)
-                        @if($selection === NotificationChannelSelection::All)
-                            {{ __('Trigger is set to') }}
-                            <strong>{{ $trigger->label() }}</strong>
-                            {{ __('but no notification channels are configured.') }}
-                        @else
-                            {{ __('Trigger is set to') }}
-                            <strong>{{ $trigger->label() }}</strong>
-                            {{ __('but no channels are selected.') }}
-                        @endif
-                    @else
-                        {{ __('Sends notifications on') }}
-                        <strong>{{ $triggerMeta['summary'] }}</strong>
-                        {{ __('to') }}
-                        <strong>
-                            @if($selection === NotificationChannelSelection::All)
-                                {{ trans_choice('{1} all :count channel|[2,*] all :count channels', $channelCount, ['count' => $channelCount]) }}
-                            @else
-                                {{ trans_choice('{1} :count channel|[2,*] :count channels', $channelCount, ['count' => $channelCount]) }}
-                            @endif
-                        </strong>.
-                    @endif
-                </span>
-            </div>
-
-            @if(! $notifDisabled && $activeChannels->isNotEmpty())
-                <div class="mt-4 grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                    @foreach($activeChannels as $channel)
-                        <div class="card card-border bg-base-100">
-                            <div class="card-body p-3 flex-row items-center gap-3">
-                                <div class="avatar avatar-placeholder shrink-0">
-                                    <div class="bg-info/10 text-info rounded-box w-8 h-8">
-                                        <x-icon :name="$channel->type->icon()" class="w-4 h-4" />
-                                    </div>
-                                </div>
-                                <div class="min-w-0 flex-1">
-                                    <p class="truncate text-sm font-medium">{{ $channel->name }}</p>
-                                    <p class="text-xs opacity-60">{{ $channel->type->label() }}</p>
-                                </div>
-                            </div>
-                        </div>
-                    @endforeach
                 </div>
             @endif
         </div>

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -66,7 +66,10 @@
                                         <x-icon name="o-arrow-top-right-on-square" class="w-3.5 h-3.5" />
                                     </a>
                                 </div>
-                                <div class="text-xs text-base-content/60 truncate">{{ $snapshot->databaseServer?->name ?? '?' }}</div>
+                                <a href="{{ route('database-servers.show', $snapshot->databaseServer) }}" wire:navigate
+                                   class="text-xs text-base-content/60 hover:text-primary hover:underline truncate block">
+                                    {{ $snapshot->databaseServer->name }}
+                                </a>
                             </div>
                         @else
                             <span class="text-sm text-base-content/50 italic">{{ __('(snapshot deleted)') }}</span>
@@ -81,7 +84,10 @@
                             <x-icon :name="$snapshot?->database_type?->icon() ?? 'o-server'" class="w-5 h-5 shrink-0" />
                             <div class="min-w-0">
                                 <div class="table-cell-primary truncate">{{ $restore->schema_name }}</div>
-                                <div class="text-xs text-base-content/60 truncate">{{ $target->name }}</div>
+                                <a href="{{ route('database-servers.show', $target) }}" wire:navigate
+                                   class="text-xs text-base-content/60 hover:text-primary hover:underline truncate block">
+                                    {{ $target->name }}
+                                </a>
                             </div>
                         @else
                             <span class="text-sm text-base-content/50 italic">{{ __('(target deleted)') }}</span>

--- a/resources/views/livewire/restore/modal.blade.php
+++ b/resources/views/livewire/restore/modal.blade.php
@@ -17,7 +17,7 @@
                 <div class="flex flex-wrap items-center gap-2">
                     <span class="text-xs opacity-60">{{ __('Snapshot:') }}</span>
                     <x-badge
-                        :value="($this->selectedSnapshot->databaseServer?->name ?? '?') . ' · ' . $this->selectedSnapshot->database_name . ' (' . $this->selectedSnapshot->database_type->label() . ')'"
+                        :value="$this->selectedSnapshot->databaseServer->name . ' · ' . $this->selectedSnapshot->database_name . ' (' . $this->selectedSnapshot->database_type->label() . ')'"
                         class="badge-secondary"
                     />
                 </div>
@@ -98,7 +98,7 @@
                                                 <div class="text-xs">
                                                     <span class="opacity-50">{{ __('Server:') }}</span>
                                                     <span
-                                                        class="opacity-70">{{ $snapshot->databaseServer?->name }}</span>
+                                                        class="opacity-70">{{ $snapshot->databaseServer->name }}</span>
                                                 </div>
                                             </div>
                                             <div class="text-right space-y-0.5">
@@ -252,7 +252,7 @@
                             <div class="text-sm font-semibold mb-2">{{ __('Restore Summary') }}</div>
                             <div class="text-sm opacity-70 space-y-1">
                                 <div><strong>{{ __('Source:') }}</strong>
-                                    {{ $this->selectedSnapshot->databaseServer?->name }} &bull; {{ $this->selectedSnapshot->database_name }}
+                                    {{ $this->selectedSnapshot->databaseServer->name }} &bull; {{ $this->selectedSnapshot->database_name }}
                                 </div>
                                 <div>
                                     <strong>{{ __('Snapshot:') }}</strong> {{ \App\Support\Formatters::humanDate($this->selectedSnapshot->created_at) }}

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -47,7 +47,10 @@
                     <div class="min-w-0">
                         <div class="flex items-center gap-2 flex-wrap">
                             <span class="table-cell-primary truncate">{{ $snapshot->database_name }}</span>
-                            <span class="text-sm text-base-content/60 truncate">{{ $snapshot->databaseServer?->name ?? __('(unknown)') }}</span>
+                            <a href="{{ route('database-servers.show', $snapshot->databaseServer) }}" wire:navigate
+                               class="text-sm text-base-content/60 hover:text-primary hover:underline truncate">
+                                {{ $snapshot->databaseServer->name }}
+                            </a>
                         </div>
                         <div class="flex items-center gap-2 mt-1 flex-wrap">
                             <x-id-popover :id="$snapshot->id" />

--- a/resources/views/partials/job-logs-modal.blade.php
+++ b/resources/views/partials/job-logs-modal.blade.php
@@ -9,8 +9,8 @@
                 // differs from the user's current organization. The relations
                 // were loaded with withoutGlobalScopes so the data is present
                 // even when scoped queries would normally exclude it.
-                $jobOrgId = $snapshot?->databaseServer?->organization_id
-                    ?? $this->selectedJob->restore?->targetServer?->organization_id;
+                $jobOrgId = $snapshot?->databaseServer->organization_id
+                    ?? $this->selectedJob->restore?->targetServer->organization_id;
                 $currentOrgId = app(\App\Services\CurrentOrganization::class)->id();
                 $crossOrg = ($jobOrgId && $jobOrgId !== $currentOrgId)
                     ? \App\Models\Organization::find($jobOrgId)
@@ -41,9 +41,9 @@
                             </div>
                             <div class="font-semibold truncate">
                                 @if($this->selectedJob->snapshot)
-                                    {{ $this->selectedJob->snapshot->databaseServer?->name ?? '?' }} / {{ $this->selectedJob->snapshot->database_name }}
+                                    {{ $this->selectedJob->snapshot->databaseServer->name }} / {{ $this->selectedJob->snapshot->database_name }}
                                 @elseif($this->selectedJob->restore)
-                                    {{ $this->selectedJob->restore->targetServer?->name ?? '?' }} / {{ $this->selectedJob->restore->schema_name }}
+                                    {{ $this->selectedJob->restore->targetServer->name }} / {{ $this->selectedJob->restore->schema_name }}
                                 @endif
                             </div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,6 +86,8 @@ Route::middleware(['auth'])->group(function () {
     // Database Servers
     Route::livewire('database-servers/create', \App\Livewire\DatabaseServer\Create::class)
         ->name('database-servers.create');
+    Route::livewire('database-servers/{server}', \App\Livewire\DatabaseServer\Show::class)
+        ->name('database-servers.show');
     Route::livewire('database-servers/{server}/edit', \App\Livewire\DatabaseServer\Edit::class)
         ->name('database-servers.edit');
 

--- a/tests/Feature/Dashboard/LatestJobsTest.php
+++ b/tests/Feature/Dashboard/LatestJobsTest.php
@@ -77,3 +77,26 @@ test('latest jobs can open and close logs modal', function () {
         ->assertSet('showLogsModal', false)
         ->assertSet('selectedJobId', null);
 });
+
+test('latest jobs scopes to a single server when serverId is set', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $serverA = DatabaseServer::factory()->create([
+        'name' => 'Server Alpha',
+        'database_names' => ['alpha_db'],
+    ]);
+    $serverB = DatabaseServer::factory()->create([
+        'name' => 'Server Bravo',
+        'database_names' => ['bravo_db'],
+    ]);
+
+    $factory->createSnapshots($serverA->backups->first(), 'manual', $user->id)[0]->job->markCompleted();
+    $factory->createSnapshots($serverB->backups->first(), 'manual', $user->id)[0]->job->markCompleted();
+
+    Livewire::withoutLazyLoading()
+        ->actingAs($user)
+        ->test(LatestJobs::class, ['serverId' => $serverA->id])
+        ->assertSee('Server Alpha')
+        ->assertDontSee('Server Bravo');
+});

--- a/tests/Feature/DatabaseServer/ShowTest.php
+++ b/tests/Feature/DatabaseServer/ShowTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Livewire\DatabaseServer\Show;
+use App\Models\Backup;
+use App\Models\DatabaseServer;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('show page renders server name, host and connection details', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->withoutBackups()->create([
+        'name' => 'Prod MySQL',
+        'host' => 'db.example.com',
+        'port' => 3307,
+        'username' => 'dbuser',
+    ]);
+    Backup::factory()->for($server)->selected(['app'])->create();
+
+    Livewire::actingAs($user)
+        ->test(Show::class, ['server' => $server])
+        ->assertSee('Prod MySQL')
+        ->assertSee('db.example.com')
+        ->assertSee('3307')
+        ->assertSee('dbuser');
+});
+
+test('show page never exposes the password', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->withoutBackups()->create([
+        'password' => 'super-secret-password',
+    ]);
+
+    Livewire::actingAs($user)
+        ->test(Show::class, ['server' => $server])
+        ->assertDontSee('super-secret-password')
+        ->assertSee('••••••••');
+});
+
+test('show page lists backup configurations', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->withoutBackups()->create();
+    Backup::factory()->for($server)->selected(['my_app_db'])->create();
+
+    Livewire::actingAs($user)
+        ->test(Show::class, ['server' => $server])
+        ->assertSee('my_app_db');
+});

--- a/tests/Feature/DatabaseServer/ShowTest.php
+++ b/tests/Feature/DatabaseServer/ShowTest.php
@@ -45,3 +45,24 @@ test('show page lists backup configurations', function () {
         ->test(Show::class, ['server' => $server])
         ->assertSee('my_app_db');
 });
+
+test('delete removes the database server', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->withoutBackups()->create();
+
+    Livewire::actingAs($user)
+        ->test(Show::class, ['server' => $server])
+        ->call('delete');
+
+    $this->assertDatabaseMissing('database_servers', ['id' => $server->id]);
+});
+
+test('confirmRestore on a Redis server opens the redis info modal', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->redis()->create();
+
+    Livewire::actingAs($user)
+        ->test(Show::class, ['server' => $server])
+        ->call('confirmRestore')
+        ->assertSet('showRedisRestoreModal', true);
+});


### PR DESCRIPTION
## Summary

Closes #317. Adds a read-only **View** page for each database server and moves row actions into a floating 3-dot dropdown on the index.

- **New `Show` page** (`/database-servers/{server}`) — hero header with policy-gated actions (Backup, Restore, Edit, Delete), 4-tile stat strip (snapshots/restores/backup configs/notifications), two-column body for Backup Configurations + Connection/SSH/Agent, Notifications section, and a server-scoped Latest Jobs panel (reuses the dashboard component via a new `$serverId` prop).
- **Row actions dropdown** — replaced the inline action buttons on the index with a teleported floating dropdown (`<x-floating-dropdown>`, Alpine `x-teleport`/`x-anchor`) so the menu escapes the table overflow.
- **Drill-down links** — server names are now clickable on the Snapshots index, Restores index, and the dashboard's Latest Jobs (intentionally suppressed when Latest Jobs is embedded inside the Show page).
- **Refactor** — extracted the duplicated `runBackupAll` loop+toast into an `App\Traits\RunsServerBackups` trait used by both `Index` and `Show`.
- **Cleanup** — dropped redundant null-safety on `snapshot→databaseServer` accesses across notifications, dashboard tiles, restore modal, and job-logs modal (the relation is NOT NULL with `cascadeOnDelete`, so the fallbacks were never reachable).

## Test plan

- [x] `make test` — 1001 tests, 2906 assertions pass
- [x] `make phpstan` — clean
- [x] `make lint-fix` (Pint) — clean
- [x] CodeRabbit `--agent` review — 0 findings
- [x] Manual: Show page renders for MySQL server (hero, stats with hover effect on Snapshots/Restores, sections, Latest Jobs)
- [x] Manual: floating dropdown opens on last row without clipping or scrollbar; closes on outside-click
- [x] Manual: dashboard Latest Jobs server names link to the Show page; on the Show page's embedded Latest Jobs they remain plain text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Database Server page with connection details, backup configs, job history, restore/delete flows, and server-scoped links.
  * Server-scoped filtering for Latest Jobs.
  * Consolidated “Run all backups” action with a single aggregated result notification.
  * Floating per-server action dropdown and x-cloak CSS to prevent UI flash.

* **Bug Fixes**
  * Improved notification/server-name rendering to avoid unknown-name fallbacks.

* **Tests**
  * Added feature tests for the Database Server page and latest-jobs server filter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->