### PR TITLE
fix: prevent edit form from locking on unreachable database hosts

### DIFF
--- a/app/Livewire/DatabaseServer/Edit.php
+++ b/app/Livewire/DatabaseServer/Edit.php
@@ -87,7 +87,7 @@ class Edit extends Component
 
     public function loadDatabases(): void
     {
-        if (! $this->form->isSqlite() && ! $this->form->isRedis()) {
+        if (! $this->form->isSqlite() && ! $this->form->isRedis() && ! $this->form->hasAgent()) {
             $this->form->loadAvailableDatabases();
         }
     }

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -23,6 +23,13 @@ use Livewire\Form;
 
 class DatabaseServerForm extends Form
 {
+    /**
+     * Connection timeout (seconds) for interactive form lookups like
+     * "load available databases". Kept short so an unreachable host does not
+     * lock the form for PHP's full max_execution_time.
+     */
+    private const int FORM_CONNECT_TIMEOUT_SECONDS = 5;
+
     public ?DatabaseServer $server = null;
 
     public string $name = '';
@@ -181,6 +188,12 @@ class DatabaseServerForm extends Form
         }
 
         if ($this->server === null || $this->isSqlite() || $this->isRedis()) {
+            return;
+        }
+
+        // Agent-backed servers are not reachable from this app; the agent does
+        // its own discovery. Don't try (and stall) a direct PDO connection.
+        if ($this->hasAgent()) {
             return;
         }
 
@@ -1239,7 +1252,11 @@ class DatabaseServerForm extends Form
     }
 
     /**
-     * Load available databases from the server for selection
+     * Load available databases from the server for selection.
+     *
+     * Uses a short connection timeout so an unreachable host (e.g. fake/seeded
+     * data, dead network) doesn't lock the edit form for PHP's full
+     * max_execution_time.
      */
     public function loadAvailableDatabases(): void
     {
@@ -1252,6 +1269,9 @@ class DatabaseServerForm extends Form
             // Build SSH config if enabled
             $sshConfig = $this->ssh_enabled ? $this->buildSshConfigForTest() : null;
 
+            $extraConfig = $this->buildExtraConfigForTest() ?? [];
+            $extraConfig['connect_timeout'] = self::FORM_CONNECT_TIMEOUT_SECONDS;
+
             // Create a temporary DatabaseServer object for the service
             $tempServer = DatabaseServer::forConnectionTest([
                 'host' => $this->host,
@@ -1259,7 +1279,7 @@ class DatabaseServerForm extends Form
                 'database_type' => $this->database_type,
                 'username' => $this->username,
                 'password' => $password,
-                'extra_config' => $this->buildExtraConfigForTest(),
+                'extra_config' => $extraConfig,
             ], $sshConfig);
 
             $databases = app(DatabaseProvider::class)->listDatabasesForServer($tempServer);

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -88,6 +88,13 @@ class DatabaseProvider
             if ($server->database_type === DatabaseType::MYSQL && $server->getExtraConfig('ssl_enabled', false)) {
                 $config['ssl_enabled'] = true;
             }
+
+            // Optional short timeout used by interactive UI lookups; jobs leave
+            // it unset and fall back to each handler's longer default.
+            $connectTimeout = $server->getExtraConfig('connect_timeout');
+            if ($connectTimeout !== null) {
+                $config['connect_timeout'] = (int) $connectTimeout;
+            }
         }
 
         return $this->makeConfigured($server->database_type, $config);

--- a/app/Services/Backup/Databases/MongodbDatabase.php
+++ b/app/Services/Backup/Databases/MongodbDatabase.php
@@ -215,9 +215,11 @@ class MongodbDatabase implements DatabaseInterface
             $this->authSource(),
         );
 
+        $timeoutMs = (int) ($this->config['connect_timeout'] ?? 10) * 1000;
+
         return new Manager($uri, [
-            'connectTimeoutMS' => 10000,
-            'serverSelectionTimeoutMS' => 10000,
+            'connectTimeoutMS' => $timeoutMs,
+            'serverSelectionTimeoutMS' => $timeoutMs,
         ]);
     }
 }

--- a/app/Services/Backup/Databases/MssqlDatabase.php
+++ b/app/Services/Backup/Databases/MssqlDatabase.php
@@ -175,9 +175,12 @@ class MssqlDatabase implements DatabaseInterface
 
     protected function createPdoForDatabase(string $database): \PDO
     {
+        $loginTimeout = (int) ($this->config['connect_timeout'] ?? 10);
+
         $dsn = sprintf(
-            'sqlsrv:Server=%s;TrustServerCertificate=true;Encrypt=true;LoginTimeout=10%s',
+            'sqlsrv:Server=%s;TrustServerCertificate=true;Encrypt=true;LoginTimeout=%d%s',
             $this->buildServerName(),
+            $loginTimeout,
             $database !== '' ? ';Database='.$database : '',
         );
 

--- a/app/Services/Backup/Databases/MysqlDatabase.php
+++ b/app/Services/Backup/Databases/MysqlDatabase.php
@@ -180,7 +180,7 @@ class MysqlDatabase implements DatabaseInterface
 
         $options = [
             \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-            \PDO::ATTR_TIMEOUT => 30,
+            \PDO::ATTR_TIMEOUT => (int) ($this->config['connect_timeout'] ?? 30),
         ];
 
         if (! empty($this->config['ssl_enabled'])) {

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -216,9 +216,12 @@ class PostgresqlDatabase implements DatabaseInterface
     {
         $dsn = sprintf('pgsql:host=%s;port=%d;dbname=%s', $this->config['host'], $this->config['port'], $database);
 
+        $timeout = (int) ($this->config['connect_timeout'] ?? 30);
+        $dsn .= ';connect_timeout='.$timeout;
+
         return new \PDO($dsn, $this->config['user'], $this->config['pass'], [
             \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-            \PDO::ATTR_TIMEOUT => 30,
+            \PDO::ATTR_TIMEOUT => $timeout,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- When opening an existing server's edit form and changing the backup *selection mode*, the form auto-loads the available database list via PDO. Against an unreachable host the PDO connect used a 30s timeout that raced with PHP's `max_execution_time`, surfacing as an **uncatchable** `Symfony\Component\ErrorHandler\Error\FatalError` and locking the Livewire form for the full 30s.
- Plumb a `connect_timeout` config value through `DatabaseServer::forConnectionTest` → `DatabaseProvider::makeForServer` → each PDO/Mongo handler. The edit form passes **5s** so PDO fails fast and the existing `try/catch` in `loadAvailableDatabases` actually fires. Jobs leave it unset and keep the previous defaults (30s for MySQL/Postgres, 10s for MongoDB/MSSQL).
- Short-circuit `onBackupSelectionModeChanged` / `Edit::loadDatabases` when the server is agent-backed — the agent owns its own discovery and the app cannot reach the DB directly, so even the 5s wait was wasted.

## Test plan
- [x] `make lint-fix` (Pint)
- [x] `make phpstan`
- [x] `make test` (998 passed, 2899 assertions)
- [x] Manual: open `/database-servers/<unreachable-host>/edit`, toggle backup selection mode → form unlocks within ~5s instead of timing out the request.
- [x] Manual: open an agent-backed server's edit page, toggle backup selection mode → no PDO attempt is made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Database connections now support configurable timeout settings across MySQL, PostgreSQL, MongoDB, and MSSQL.
  * Database server edit form uses optimized timeouts when discovering available databases, reducing form blocking.
  * Agent-backed database servers now skip direct database discovery for improved responsiveness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->