### PR TITLE
feat: support pg_dump custom format with pg_restore

### DIFF
--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -128,9 +128,15 @@ enum DatabaseType: string
 
     /**
      * Get the file extension used for database dumps.
+     *
+     * $format is the postgres dump format ('plain'|'custom'); ignored for other types.
      */
-    public function dumpExtension(): string
+    public function dumpExtension(?string $format = null): string
     {
+        if ($this === self::POSTGRESQL && $format === 'custom') {
+            return 'dump';
+        }
+
         return match ($this) {
             self::SQLITE => 'db',
             self::REDIS => 'rdb',

--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -49,6 +49,10 @@ class SaveDatabaseServerRequest extends FormRequest
             $rules['dump_flags'] = ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'];
         }
 
+        if ($type === 'postgres') {
+            $rules['dump_format'] = ['nullable', 'string', Rule::in(['plain', 'custom'])];
+        }
+
         if (in_array($type, ['mongodb', 'redis'])) {
             $rules['username'] = 'nullable|string|max:255';
             $rules['password'] = 'nullable';

--- a/app/Jobs/ProcessRestoreJob.php
+++ b/app/Jobs/ProcessRestoreJob.php
@@ -73,6 +73,7 @@ class ProcessRestoreJob implements ShouldQueue
                 workingDirectory: FilesystemSupport::createWorkingDirectory('restore', $restore->id),
                 forceDatabase: filter_var($restore->getOption('force_database', false), FILTER_VALIDATE_BOOLEAN),
                 ownerUser: is_string($value = $restore->getOption('owner_user')) && $value !== '' ? $value : null,
+                snapshotDumpFormat: is_string($format = ($snapshot->metadata['dump_format'] ?? null)) ? $format : null,
             );
 
             $restoreTask->execute($config, $job);

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -49,6 +49,8 @@ class DatabaseServerForm extends Form
 
     public string $dump_flags = '';
 
+    public string $dump_format = 'plain';
+
     public bool $ssl_enabled = false;
 
     // SSH Tunnel Configuration
@@ -426,6 +428,7 @@ class DatabaseServerForm extends Form
         $this->database_type = $server->database_type->value;
         $this->auth_source = $server->getExtraConfig('auth_source', '');
         $this->dump_flags = $server->getExtraConfig('dump_flags', '');
+        $this->dump_format = $server->getExtraConfig('dump_format', 'plain');
         $this->ssl_enabled = (bool) $server->getExtraConfig('ssl_enabled', false);
         $this->username = $server->username ?? '';
         $this->description = $server->description;
@@ -617,6 +620,14 @@ class DatabaseServerForm extends Form
     }
 
     /**
+     * Check if current database type is PostgreSQL.
+     */
+    public function isPostgresql(): bool
+    {
+        return $this->database_type === 'postgres';
+    }
+
+    /**
      * Check if current database type has optional credentials (username/password not required).
      */
     public function hasOptionalCredentials(): bool
@@ -657,6 +668,10 @@ class DatabaseServerForm extends Form
 
         if ($type === DatabaseType::MYSQL) {
             $config['ssl_enabled'] = $this->ssl_enabled;
+        }
+
+        if ($type === DatabaseType::POSTGRESQL) {
+            $config['dump_format'] = $this->dump_format;
         }
 
         try {
@@ -843,6 +858,7 @@ class DatabaseServerForm extends Form
             'agent_id' => 'nullable|exists:agents,id',
             'backups_enabled' => 'boolean',
             'dump_flags' => ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'],
+            'dump_format' => ['nullable', 'string', Rule::in(['plain', 'custom'])],
             'ssl_enabled' => 'boolean',
             'notification_trigger' => ['required', 'string', Rule::in(array_column(NotificationTrigger::cases(), 'value'))],
             'notification_channel_selection' => ['required', 'string', Rule::in(array_column(NotificationChannelSelection::cases(), 'value'))],

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -413,6 +413,15 @@ class DatabaseServer extends Model
             unset($data['dump_flags']);
         }
 
+        if (array_key_exists('dump_format', $data)) {
+            if ($type === DatabaseType::POSTGRESQL->value && $data['dump_format'] === 'custom') {
+                $extraConfig['dump_format'] = 'custom';
+            } else {
+                unset($extraConfig['dump_format']);
+            }
+            unset($data['dump_format']);
+        }
+
         if (array_key_exists('ssl_enabled', $data)) {
             if ($type === DatabaseType::MYSQL->value && $data['ssl_enabled']) {
                 $extraConfig['ssl_enabled'] = true;

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -116,7 +116,7 @@ class Snapshot extends Model
      * Generate metadata array for a snapshot.
      * Sensitive fields (passwords) are excluded from the volume config.
      *
-     * @return array{database_server: array{host: string|null, port: int|null, username: string|null, database_name: string, ssh_tunnel: array{enabled: bool, host?: string, port?: int, username?: string, auth_type?: string}}, volume: array{type: string, config: array<string, mixed>}}
+     * @return array{database_server: array{host: string|null, port: int|null, username: string|null, database_name: string, ssh_tunnel: array{enabled: bool, host?: string, port?: int, username?: string, auth_type?: string}}, volume: array{type: string, config: array<string, mixed>}, dump_format?: string}
      */
     public static function generateMetadata(DatabaseServer $server, string $databaseName, Volume $volume): array
     {
@@ -132,7 +132,7 @@ class Snapshot extends Model
             ];
         }
 
-        return [
+        $metadata = [
             'database_server' => [
                 'host' => $server->host,
                 'port' => $server->port,
@@ -145,6 +145,14 @@ class Snapshot extends Model
                 'config' => $volume->getSafeConfig(),
             ],
         ];
+
+        // Record dump format for restore-time dispatch. Absent → plain (default for legacy snapshots).
+        if ($server->database_type === DatabaseType::POSTGRESQL
+            && $server->getExtraConfig('dump_format') === 'custom') {
+            $metadata['dump_format'] = 'custom';
+        }
+
+        return $metadata;
     }
 
     /**

--- a/app/Services/Backup/BackupTask.php
+++ b/app/Services/Backup/BackupTask.php
@@ -52,7 +52,8 @@ class BackupTask
                 $this->establishSshTunnel($db, $logger);
             }
 
-            $workingFile = $config->workingDirectory.'/dump.'.$db->databaseType->dumpExtension();
+            $dumpFormat = is_string($value = ($db->extraConfig['dump_format'] ?? null)) ? $value : null;
+            $workingFile = $config->workingDirectory.'/dump.'.$db->databaseType->dumpExtension($dumpFormat);
 
             // Database dump
             $database = $this->databaseProvider->makeFromConfig(
@@ -88,7 +89,7 @@ class BackupTask
 
             // Generate filename and transfer
             $humanFileSize = Formatters::humanFileSize($fileSize);
-            $filename = $this->generateFilename($db->serverName, $config->databaseName, $db->databaseType->dumpExtension(), $compressor, $config->backupPath);
+            $filename = $this->generateFilename($db->serverName, $config->databaseName, $db->databaseType->dumpExtension($dumpFormat), $compressor, $config->backupPath);
             $logger->log("Transferring backup ({$humanFileSize}) to volume: {$config->volume->name}", 'info', [
                 'volume_type' => $config->volume->type,
                 'source' => $archive,

--- a/app/Services/Backup/DTO/DatabaseConnectionConfig.php
+++ b/app/Services/Backup/DTO/DatabaseConnectionConfig.php
@@ -56,7 +56,7 @@ readonly class DatabaseConnectionConfig
 
         return new self(
             databaseType: $server->database_type,
-            serverName: $server->name,
+            serverName: $server->name ?? '',
             host: $server->host ?? '',
             port: $server->port,
             username: $server->username ?? '',

--- a/app/Services/Backup/DTO/RestoreConfig.php
+++ b/app/Services/Backup/DTO/RestoreConfig.php
@@ -19,5 +19,6 @@ readonly class RestoreConfig
         public string $workingDirectory,
         public bool $forceDatabase = false,
         public ?string $ownerUser = null,
+        public ?string $snapshotDumpFormat = null,
     ) {}
 }

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -47,6 +47,9 @@ class DatabaseProvider
      * Create a configured database interface from a server model.
      *
      * Host and port are passed explicitly to support SSH tunnel overrides.
+     * Delegates to makeFromConfig() for non-SQLite types; SQLite is kept inline
+     * because its SSH config uses the Eloquent model directly, not the
+     * decrypted array shape carried by DatabaseConnectionConfig.
      */
     public function makeForServer(
         DatabaseServer $server,
@@ -61,49 +64,25 @@ class DatabaseProvider
             if ($server->sshConfig !== null) {
                 $config['ssh_config'] = $server->sshConfig;
             }
-        } else {
-            $config = [
-                'host' => $host,
-                'port' => $port,
-                'user' => $server->username,
-                'pass' => $server->getDecryptedPassword(),
-            ];
 
-            if ($server->database_type !== DatabaseType::REDIS) {
-                $config['database'] = $databaseName;
-            }
-
-            if ($server->database_type === DatabaseType::MONGODB) {
-                $config['auth_source'] = $server->getExtraConfig('auth_source', 'admin');
-                if ($sourceDatabaseName !== null) {
-                    $config['source_database'] = $sourceDatabaseName;
-                }
-            }
-
-            $dumpFlags = $server->getExtraConfig('dump_flags', '');
-            if ($dumpFlags !== '') {
-                $config['dump_flags'] = $dumpFlags;
-            }
-
-            if ($server->database_type === DatabaseType::MYSQL && $server->getExtraConfig('ssl_enabled', false)) {
-                $config['ssl_enabled'] = true;
-            }
-
-            // Optional short timeout used by interactive UI lookups; jobs leave
-            // it unset and fall back to each handler's longer default.
-            $connectTimeout = $server->getExtraConfig('connect_timeout');
-            if ($connectTimeout !== null) {
-                $config['connect_timeout'] = (int) $connectTimeout;
-            }
+            return $this->makeConfigured(DatabaseType::SQLITE, $config);
         }
 
-        return $this->makeConfigured($server->database_type, $config);
+        return $this->makeFromConfig(
+            DatabaseConnectionConfig::fromServer($server),
+            $databaseName,
+            $host,
+            $port,
+            $sourceDatabaseName,
+        );
     }
 
     /**
      * Create a configured database interface from a DatabaseConnectionConfig DTO.
      *
      * Host and port are passed explicitly to support SSH tunnel overrides.
+     * $snapshotDumpFormat overrides the target's dump_format at restore time: format
+     * is a property of the snapshot file, not the destination server.
      */
     public function makeFromConfig(
         DatabaseConnectionConfig $config,
@@ -111,6 +90,7 @@ class DatabaseProvider
         string $host,
         int $port,
         ?string $sourceDatabaseName = null,
+        ?string $snapshotDumpFormat = null,
     ): DatabaseInterface {
         if ($config->databaseType === DatabaseType::SQLITE) {
             $dbConfig = ['sqlite_path' => $databaseName];
@@ -118,33 +98,47 @@ class DatabaseProvider
             if ($config->sshConfig !== null) {
                 $dbConfig['ssh_config_array'] = $config->sshConfig;
             }
-        } else {
-            $dbConfig = [
-                'host' => $host,
-                'port' => $port,
-                'user' => $config->username,
-                'pass' => $config->password,
-            ];
 
-            if ($config->databaseType !== DatabaseType::REDIS) {
-                $dbConfig['database'] = $databaseName;
-            }
+            return $this->makeConfigured(DatabaseType::SQLITE, $dbConfig);
+        }
 
-            if ($config->databaseType === DatabaseType::MONGODB) {
-                $dbConfig['auth_source'] = $config->extraConfig['auth_source'] ?? 'admin';
-                if ($sourceDatabaseName !== null) {
-                    $dbConfig['source_database'] = $sourceDatabaseName;
-                }
-            }
+        $extra = $config->extraConfig ?? [];
 
-            $dumpFlags = $config->extraConfig['dump_flags'] ?? '';
-            if ($dumpFlags !== '') {
-                $dbConfig['dump_flags'] = $dumpFlags;
-            }
+        $dbConfig = [
+            'host' => $host,
+            'port' => $port,
+            'user' => $config->username,
+            'pass' => $config->password,
+        ];
 
-            if ($config->databaseType === DatabaseType::MYSQL && ! empty($config->extraConfig['ssl_enabled'])) {
-                $dbConfig['ssl_enabled'] = true;
+        if ($config->databaseType !== DatabaseType::REDIS) {
+            $dbConfig['database'] = $databaseName;
+        }
+
+        if ($config->databaseType === DatabaseType::MONGODB) {
+            $dbConfig['auth_source'] = $extra['auth_source'] ?? 'admin';
+            if ($sourceDatabaseName !== null) {
+                $dbConfig['source_database'] = $sourceDatabaseName;
             }
+        }
+
+        if (! empty($extra['dump_flags'])) {
+            $dbConfig['dump_flags'] = $extra['dump_flags'];
+        }
+
+        if ($config->databaseType === DatabaseType::MYSQL && ! empty($extra['ssl_enabled'])) {
+            $dbConfig['ssl_enabled'] = true;
+        }
+
+        if ($config->databaseType === DatabaseType::POSTGRESQL
+            && ($snapshotDumpFormat ?? $extra['dump_format'] ?? null) === 'custom') {
+            $dbConfig['dump_format'] = 'custom';
+        }
+
+        // Optional short timeout used by interactive UI lookups; jobs leave
+        // it unset and fall back to each handler's longer default.
+        if (isset($extra['connect_timeout'])) {
+            $dbConfig['connect_timeout'] = (int) $extra['connect_timeout'];
         }
 
         return $this->makeConfigured($config->databaseType, $dbConfig);

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -23,14 +23,18 @@ class PostgresqlDatabase implements DatabaseInterface
     ];
 
     /**
-     * Restore-side counterparts applied by pg_restore when reading a custom-format archive.
-     * --clean/--if-exists in DUMP_OPTIONS only affect plain SQL output, so we re-pass them here.
+     * Restore-side flags applied by pg_restore when reading a custom-format archive.
+     * Only used by the custom-format branch of restore() — plain format uses psql -f
+     * which accepts none of these. --clean/--if-exists must be passed at restore time
+     * (not dump time) for custom archives. --jobs=4 enables parallel restore, which is
+     * the main reason custom format exists.
      */
-    private const array RESTORE_OPTIONS = [
+    private const array RESTORE_CUSTOM_FORMAT_OPTIONS = [
         '--clean',
         '--if-exists',
         '--no-owner',
         '--no-privileges',
+        '--jobs=4',
     ];
 
     private const array EXCLUDED_DATABASES = [
@@ -82,7 +86,7 @@ class PostgresqlDatabase implements DatabaseInterface
             return new DatabaseOperationResult(command: sprintf(
                 'PGPASSWORD=%s pg_restore %s --host=%s --port=%s --username=%s --dbname=%s %s',
                 escapeshellarg($this->config['pass']),
-                implode(' ', self::RESTORE_OPTIONS),
+                implode(' ', self::RESTORE_CUSTOM_FORMAT_OPTIONS),
                 escapeshellarg($this->config['host']),
                 escapeshellarg((string) $this->config['port']),
                 escapeshellarg($this->config['user']),

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -22,6 +22,17 @@ class PostgresqlDatabase implements DatabaseInterface
         '--quote-all-identifiers',  // Quote all identifiers (safer for reserved words)
     ];
 
+    /**
+     * Restore-side counterparts applied by pg_restore when reading a custom-format archive.
+     * --clean/--if-exists in DUMP_OPTIONS only affect plain SQL output, so we re-pass them here.
+     */
+    private const array RESTORE_OPTIONS = [
+        '--clean',
+        '--if-exists',
+        '--no-owner',
+        '--no-privileges',
+    ];
+
     private const array EXCLUDED_DATABASES = [
         'rdsadmin',          // AWS RDS internal database
         'azure_maintenance', // Azure Database for PostgreSQL internal database
@@ -38,6 +49,11 @@ class PostgresqlDatabase implements DatabaseInterface
 
     public function dump(string $outputPath): DatabaseOperationResult
     {
+        $options = self::DUMP_OPTIONS;
+        if (($this->config['dump_format'] ?? 'plain') === 'custom') {
+            $options[] = '--format=custom';
+        }
+
         $extraFlags = '';
         if (! empty($this->config['dump_flags'])) {
             $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
@@ -47,7 +63,7 @@ class PostgresqlDatabase implements DatabaseInterface
         $command = sprintf(
             'PGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s%s %s',
             escapeshellarg($this->config['pass']),
-            implode(' ', self::DUMP_OPTIONS),
+            implode(' ', $options),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
             escapeshellarg($this->config['user']),
@@ -62,6 +78,19 @@ class PostgresqlDatabase implements DatabaseInterface
 
     public function restore(string $inputPath): DatabaseOperationResult
     {
+        if (($this->config['dump_format'] ?? 'plain') === 'custom') {
+            return new DatabaseOperationResult(command: sprintf(
+                'PGPASSWORD=%s pg_restore %s --host=%s --port=%s --username=%s --dbname=%s %s',
+                escapeshellarg($this->config['pass']),
+                implode(' ', self::RESTORE_OPTIONS),
+                escapeshellarg($this->config['host']),
+                escapeshellarg((string) $this->config['port']),
+                escapeshellarg($this->config['user']),
+                escapeshellarg($this->config['database']),
+                escapeshellarg($inputPath),
+            ));
+        }
+
         return new DatabaseOperationResult(command: sprintf(
             'PGPASSWORD=%s psql --host=%s --port=%s --username=%s %s -f %s',
             escapeshellarg($this->config['pass']),

--- a/app/Services/Backup/RestoreTask.php
+++ b/app/Services/Backup/RestoreTask.php
@@ -58,7 +58,7 @@ class RestoreTask
             }
 
             $humanFileSize = Formatters::humanFileSize($config->snapshotFileSize);
-            $compressedFile = $config->workingDirectory.'/snapshot.'.$config->snapshotDatabaseType->dumpExtension().'.'.$config->snapshotCompressionType->extension();
+            $compressedFile = $config->workingDirectory.'/snapshot.'.$config->snapshotDatabaseType->dumpExtension($config->snapshotDumpFormat).'.'.$config->snapshotCompressionType->extension();
             $compressor = $this->compressorFactory->make($config->snapshotCompressionType);
 
             // Download snapshot from volume
@@ -82,6 +82,7 @@ class RestoreTask
                 $this->getConnectionHost($target),
                 $this->getConnectionPort($target),
                 $config->snapshotDatabaseName,
+                $config->snapshotDumpFormat,
             );
 
             $this->prepareDatabase($database, $config->schemaName, $logger, $config->forceDatabase);

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -204,7 +204,7 @@ use App\Enums\DatabaseType;
 
                                     @if($form->dump_format === 'custom')
                                         <x-alert class="alert-warning" icon="o-exclamation-triangle">
-                                            {{ __('Custom format archives are version-sensitive: the target restore server must be PostgreSQL 17 or newer.') }}
+                                            {{ __('Custom format archives are version-sensitive: the target restore server must be PostgreSQL 17 or newer. Restores run with 4 parallel pg_restore workers.') }}
                                         </x-alert>
                                     @endif
                                 @endif

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -185,12 +185,30 @@ use App\Enums\DatabaseType;
                     @endif
 
                     @if($form->supportsDumpFlags())
-                        <x-collapse class="mt-2" :open="!empty($form->dump_flags)">
+                        <x-collapse class="mt-2" :open="!empty($form->dump_flags) || $form->dump_format === 'custom'">
                             <x-slot:heading>
                                 <x-icon name="o-command-line" class="w-4 h-4" />
                                 {{ __('Dump Command Configuration') }}
                             </x-slot:heading>
                             <x-slot:content class="space-y-3">
+                                @if($form->isPostgresql())
+                                    <x-select
+                                        wire:model.live="form.dump_format"
+                                        :label="__('Dump Format')"
+                                        :hint="__('Custom format enables pg_restore parallel and selective restores. Defaults to plain SQL.')"
+                                        :options="[
+                                            ['id' => 'plain', 'name' => __('Plain SQL (psql -f)')],
+                                            ['id' => 'custom', 'name' => __('Custom (pg_restore)')],
+                                        ]"
+                                    />
+
+                                    @if($form->dump_format === 'custom')
+                                        <x-alert class="alert-warning" icon="o-exclamation-triangle">
+                                            {{ __('Custom format archives are version-sensitive: the target restore server must be PostgreSQL 17 or newer.') }}
+                                        </x-alert>
+                                    @endif
+                                @endif
+
                                 <x-input
                                     wire:model.live.debounce.300ms="form.dump_flags"
                                     placeholder="{{ __('e.g., --no-tablespaces --verbose') }}"

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -390,12 +390,6 @@
                                             </span>
                                         @endif
                                     </div>
-                                    @if($dumpFormat === 'custom')
-                                        <p class="mt-2 text-xs opacity-70 leading-snug">
-                                            <x-icon name="o-exclamation-triangle" class="w-3.5 h-3.5 inline align-text-bottom text-warning" />
-                                            {{ __('Restore target must be PostgreSQL 17 or newer.') }}
-                                        </p>
-                                    @endif
                                 </div>
                             </li>
                         @endif

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -9,9 +9,12 @@
         $sshConfig = $server->sshConfig;
         $agent = $server->agent;
         $isSqlite = $server->database_type === DatabaseType::SQLITE;
+        $isPostgres = $server->database_type === DatabaseType::POSTGRESQL;
         $sslEnabled = (bool) $server->getExtraConfig('ssl_enabled', false);
         $authSource = $server->getExtraConfig('auth_source');
         $dumpFlags = $server->getExtraConfig('dump_flags');
+        $dumpFormat = $isPostgres ? ($server->getExtraConfig('dump_format', 'plain')) : null;
+        $showDumpCard = $dumpFlags || ($isPostgres && $dumpFormat === 'custom');
 
         $trigger = $server->notification_trigger;
         $selection = $server->notification_channel_selection;
@@ -357,18 +360,57 @@
                                 </div>
                             </li>
                         @endif
-                        @if($dumpFlags)
-                            <li class="list-row">
-                                <x-icon name="o-command-line" class="w-4 h-4 opacity-60" />
-                                <div>
-                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('Dump flags') }}</div>
-                                    <div class="text-xs font-mono break-all">{{ $dumpFlags }}</div>
-                                </div>
-                            </li>
-                        @endif
                     @endif
                 </ul>
             </div>
+
+            {{-- Dump configuration --}}
+            @if($showDumpCard)
+                <div class="card card-border bg-base-100 shadow-sm overflow-hidden">
+                    <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
+                        <x-icon name="o-command-line" class="w-4 h-4 opacity-60" />
+                        <h2 class="text-sm font-semibold">{{ __('Dump configuration') }}</h2>
+                    </div>
+                    <ul class="list">
+                        @if($isPostgres)
+                            <li class="list-row">
+                                <x-icon name="o-document-text" class="w-4 h-4 opacity-60" />
+                                <div class="min-w-0">
+                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('Format') }}</div>
+                                    <div class="mt-0.5 flex flex-wrap items-center gap-1.5">
+                                        @if($dumpFormat === 'custom')
+                                            <span class="badge badge-info badge-soft gap-1.5">
+                                                <x-icon name="o-cube" class="w-3 h-3" />
+                                                {{ __('Custom (pg_restore)') }}
+                                            </span>
+                                        @else
+                                            <span class="badge badge-ghost gap-1.5">
+                                                <x-icon name="o-document" class="w-3 h-3" />
+                                                {{ __('Plain SQL (psql -f)') }}
+                                            </span>
+                                        @endif
+                                    </div>
+                                    @if($dumpFormat === 'custom')
+                                        <p class="mt-2 text-xs opacity-70 leading-snug">
+                                            <x-icon name="o-exclamation-triangle" class="w-3.5 h-3.5 inline align-text-bottom text-warning" />
+                                            {{ __('Restore target must be PostgreSQL 17 or newer.') }}
+                                        </p>
+                                    @endif
+                                </div>
+                            </li>
+                        @endif
+                        @if($dumpFlags)
+                            <li class="list-row">
+                                <x-icon name="o-adjustments-horizontal" class="w-4 h-4 opacity-60" />
+                                <div class="min-w-0">
+                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('Extra flags') }}</div>
+                                    <code class="mt-1 inline-block text-xs font-mono break-all px-1.5 py-0.5 rounded bg-base-200">{{ $dumpFlags }}</code>
+                                </div>
+                            </li>
+                        @endif
+                    </ul>
+                </div>
+            @endif
 
             {{-- Agent --}}
             @if($agent)

--- a/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
@@ -45,6 +45,24 @@ test('makeForServer uses explicit host and port parameters', function () {
         ->not->toContain('private-db.internal');
 });
 
+test('makeForServer handles unsaved forConnectionTest server (no name)', function () {
+    // The form's "Test Connection" and "Load Databases" flows build a transient
+    // DatabaseServer via forConnectionTest() without a name. This must not blow up
+    // when threaded through the DTO conversion in makeForServer.
+    $server = DatabaseServer::forConnectionTest([
+        'database_type' => 'mysql',
+        'host' => 'db.local',
+        'port' => 3306,
+        'username' => 'root',
+        'password' => 'secret',
+    ]);
+
+    $factory = new DatabaseProvider;
+    $database = $factory->makeForServer($server, 'myapp', 'db.local', 3306);
+
+    expect($database)->toBeInstanceOf(MysqlDatabase::class);
+});
+
 test('listDatabasesForServer delegates to handler listDatabases', function () {
     $server = DatabaseServer::factory()->create([
         'database_type' => 'mysql',

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -78,7 +78,7 @@ test('restore uses pg_restore when dump_format config is custom', function () {
     $result = $db->restore('/tmp/snapshot.sql');
 
     expect($result->command)->toBe(
-        "PGPASSWORD='pg_secret' pg_restore --clean --if-exists --no-owner --no-privileges --host='pg.local' --port='5432' --username='postgres' --dbname='myapp' '/tmp/snapshot.sql'"
+        "PGPASSWORD='pg_secret' pg_restore --clean --if-exists --no-owner --no-privileges --jobs=4 --host='pg.local' --port='5432' --username='postgres' --dbname='myapp' '/tmp/snapshot.sql'"
     );
 });
 

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -47,6 +47,48 @@ test('restore builds correct psql command', function () {
         ->and($result->command)->toBe("PGPASSWORD='pg_secret' psql --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/restore.sql'");
 });
 
+test('dump appends --format=custom when dump_format is custom', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'dump_format' => 'custom',
+    ]);
+
+    $result = $db->dump('/tmp/dump.sql');
+
+    expect($result->command)->toContain('--quote-all-identifiers --format=custom --host=')
+        ->and($result->command)->toEndWith("'myapp' -f '/tmp/dump.sql'");
+});
+
+test('restore uses pg_restore when dump_format config is custom', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'dump_format' => 'custom',
+    ]);
+
+    $result = $db->restore('/tmp/snapshot.sql');
+
+    expect($result->command)->toBe(
+        "PGPASSWORD='pg_secret' pg_restore --clean --if-exists --no-owner --no-privileges --host='pg.local' --port='5432' --username='postgres' --dbname='myapp' '/tmp/snapshot.sql'"
+    );
+});
+
+test('restore falls back to psql when dump_format is absent', function () {
+    $result = $this->db->restore('/tmp/snapshot.sql');
+
+    expect($result->command)->toStartWith("PGPASSWORD='pg_secret' psql ")
+        ->and($result->command)->toContain('-f ');
+});
+
 test('listDatabases returns databases excluding managed-service internals but keeps postgres', function () {
     $pdoStatement = Mockery::mock(\PDOStatement::class);
     $pdoStatement->shouldReceive('fetchAll')

--- a/tests/Feature/Services/Backup/RestoreTaskTest.php
+++ b/tests/Feature/Services/Backup/RestoreTaskTest.php
@@ -341,6 +341,7 @@ test('execute establishes SSH tunnel when target server requires it', function (
             '127.0.0.1',
             54321,
             'sourcedb',
+            null,
         )
         ->andReturn($mockHandler);
 

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -90,8 +90,10 @@ test('mysql backup and restore workflow', function (string $compression, string 
     ProcessRestoreJob::dispatchSync($restore->id);
 
     $pdo = IntegrationTestHelpers::connectToDatabase('mysql', $this->databaseServer, $this->restoredDatabaseName);
-    $stmt = $pdo->query('SHOW TABLES');
-    expect($stmt)->not->toBeFalse();
+    $tables = $pdo->query('SHOW TABLES')->fetchAll(PDO::FETCH_COLUMN);
+    expect($tables)->toContain('users')->toContain('products')
+        ->and((int) $pdo->query('SELECT COUNT(*) FROM users')->fetchColumn())->toBe(2)
+        ->and((int) $pdo->query('SELECT COUNT(*) FROM products')->fetchColumn())->toBe(2);
 })->with([
     'zstd' => ['zstd', 'zst'],
     'encrypted' => ['encrypted', '7z'],
@@ -147,8 +149,10 @@ test('postgres backup and restore workflow', function (?string $dumpFormat) {
     ProcessRestoreJob::dispatchSync($restore->id);
 
     $pdo = IntegrationTestHelpers::connectToDatabase('postgres', $this->databaseServer, $this->restoredDatabaseName);
-    $stmt = $pdo->query("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public'");
-    expect($stmt)->not->toBeFalse();
+    $tables = $pdo->query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' ORDER BY table_name")->fetchAll(PDO::FETCH_COLUMN);
+    expect($tables)->toContain('users')->toContain('products')
+        ->and((int) $pdo->query('SELECT COUNT(*) FROM users')->fetchColumn())->toBe(2)
+        ->and((int) $pdo->query('SELECT COUNT(*) FROM products')->fetchColumn())->toBe(2);
 })->with([
     'plain format' => [null],
     'custom dump format' => ['custom'],

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -45,8 +45,7 @@ afterEach(function () {
     }
 });
 
-test('client-server database backup and restore workflow', function (string $type, string $compression, string $expectedExt) {
-    // Set compression method (and encryption key for encrypted backups)
+test('mysql backup and restore workflow', function (string $compression, string $expectedExt) {
     AppConfig::set('backup.compression', $compression);
     if ($compression === 'encrypted') {
         config(['backup.encryption_key' => 'base64:'.base64_encode('0123456789abcdef0123456789abcdef')]);
@@ -57,16 +56,13 @@ test('client-server database backup and restore workflow', function (string $typ
     app()->forgetInstance(BackupTask::class);
     app()->forgetInstance(RestoreTask::class);
 
-    // Create models
-    $this->volume = IntegrationTestHelpers::createVolume($type);
-    $this->databaseServer = IntegrationTestHelpers::createDatabaseServer($type);
+    $this->volume = IntegrationTestHelpers::createVolume('mysql');
+    $this->databaseServer = IntegrationTestHelpers::createDatabaseServer('mysql');
     $this->backup = IntegrationTestHelpers::createBackup($this->databaseServer, $this->volume);
     $this->databaseServer->load('backups.volume');
 
-    // Load test data
-    IntegrationTestHelpers::loadTestData($type, $this->databaseServer);
+    IntegrationTestHelpers::loadTestData('mysql', $this->databaseServer);
 
-    // Run backup
     $snapshots = $this->backupJobFactory->createSnapshots(
         backup: $this->backup,
         method: 'manual',
@@ -84,7 +80,6 @@ test('client-server database backup and restore workflow', function (string $typ
         ->and($this->snapshot->filename)->toEndWith(".sql.{$expectedExt}")
         ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
 
-    // Run restore (use unique name with parallel token and microseconds to avoid collisions)
     $suffix = IntegrationTestHelpers::getParallelSuffix();
     $this->restoredDatabaseName = 'testdb_restored_'.hrtime(true).$suffix;
     $restore = $this->backupJobFactory->createRestore(
@@ -94,20 +89,69 @@ test('client-server database backup and restore workflow', function (string $typ
     );
     ProcessRestoreJob::dispatchSync($restore->id);
 
-    // Verify restore
-    $pdo = IntegrationTestHelpers::connectToDatabase($type, $this->databaseServer, $this->restoredDatabaseName);
-    expect($pdo)->toBeInstanceOf(PDO::class);
-
-    $verifyQuery = match ($type) {
-        'mysql' => 'SHOW TABLES',
-        'postgres' => "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public'",
-    };
-    $stmt = $pdo->query($verifyQuery);
+    $pdo = IntegrationTestHelpers::connectToDatabase('mysql', $this->databaseServer, $this->restoredDatabaseName);
+    $stmt = $pdo->query('SHOW TABLES');
     expect($stmt)->not->toBeFalse();
 })->with([
-    'postgres with gzip' => ['postgres', 'gzip', 'gz'],
-    'mysql with zstd' => ['mysql', 'zstd', 'zst'],
-    'mysql with encrypted' => ['mysql', 'encrypted', '7z'],
+    'zstd' => ['zstd', 'zst'],
+    'encrypted' => ['encrypted', '7z'],
+]);
+
+test('postgres backup and restore workflow', function (?string $dumpFormat) {
+    AppConfig::set('backup.compression', 'gzip');
+
+    app()->forgetInstance(CompressorInterface::class);
+    app()->forgetInstance(BackupTask::class);
+    app()->forgetInstance(RestoreTask::class);
+
+    $this->volume = IntegrationTestHelpers::createVolume('postgres');
+    $this->databaseServer = IntegrationTestHelpers::createDatabaseServer('postgres');
+    if ($dumpFormat !== null) {
+        $this->databaseServer->update([
+            'extra_config' => array_merge(
+                $this->databaseServer->extra_config ?? [],
+                ['dump_format' => $dumpFormat],
+            ),
+        ]);
+    }
+    $this->backup = IntegrationTestHelpers::createBackup($this->databaseServer, $this->volume);
+    $this->databaseServer->load('backups.volume');
+
+    IntegrationTestHelpers::loadTestData('postgres', $this->databaseServer);
+
+    $snapshots = $this->backupJobFactory->createSnapshots(
+        backup: $this->backup,
+        method: 'manual',
+    );
+    $this->snapshot = $snapshots[0];
+    ProcessBackupJob::dispatchSync($this->snapshot->id);
+    $this->snapshot->refresh();
+    $this->snapshot->load('job');
+
+    $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
+
+    $expectedDumpExt = $dumpFormat === 'custom' ? 'dump' : 'sql';
+    expect($this->snapshot->job->status)->toBe('completed')
+        ->and($this->snapshot->file_size)->toBeGreaterThan(0)
+        ->and($this->snapshot->compression_type)->toBe(CompressionType::GZIP)
+        ->and($this->snapshot->filename)->toEndWith(".{$expectedDumpExt}.gz")
+        ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
+
+    $suffix = IntegrationTestHelpers::getParallelSuffix();
+    $this->restoredDatabaseName = 'testdb_restored_'.hrtime(true).$suffix;
+    $restore = $this->backupJobFactory->createRestore(
+        snapshot: $this->snapshot,
+        targetServer: $this->databaseServer,
+        schemaName: $this->restoredDatabaseName,
+    );
+    ProcessRestoreJob::dispatchSync($restore->id);
+
+    $pdo = IntegrationTestHelpers::connectToDatabase('postgres', $this->databaseServer, $this->restoredDatabaseName);
+    $stmt = $pdo->query("SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public'");
+    expect($stmt)->not->toBeFalse();
+})->with([
+    'plain format' => [null],
+    'custom dump format' => ['custom'],
 ]);
 
 test('backup with extra dump flags succeeds', function (string $type, string $flag) {


### PR DESCRIPTION
Closes #291.

## Summary

Adds opt-in support for `pg_dump --format=custom` paired with `pg_restore`, unlocking parallel and selective restores for PostgreSQL backups. Default behavior is unchanged — existing servers keep producing plain SQL archives restored via `psql -f`.

## Key decisions

**Format dispatch lives on the snapshot, not the server.** A snapshot's metadata records the `dump_format` it was produced with, so restores route to `pg_restore` or `psql` based on the file itself — not the source server's current config (which may have flipped after the backup). Legacy snapshots without the key default to plain, identical to today.

**`.dump` extension for custom archives.** Matches `pg_dump`'s community convention (`pg_dump -Fc db > db.dump`) and makes the filename self-describing on the volume.

**Parallel restore on by default (`--jobs=4`).** The whole reason to pick custom format is the parallel restore win. Hardcoded conservatively — 4 connections sit well under any reasonable `max_connections` cap, and the target's core count caps the actual speedup (no failure if it has fewer cores). Plain-format restores aren't affected — the flag lives in a custom-format-only constant consumed only by the `pg_restore` branch.

**Version caveat surfaced in the UI.** `pg_dump 18` writes `SET transaction_timeout = 0;` into the archive preamble, which PG ≤16 rejects on restore (`psql` silently ignores unknown SETs; `pg_restore` does not — there is no flag to suppress this per the pgsql-hackers list). The form and the server show page warn that custom restores require PostgreSQL 17+. Bumped the test postgres image to 17 to match the bundled `postgresql18-client`.

**Refactor: `DatabaseProvider::makeForServer` now delegates to `makeFromConfig`** via `DatabaseConnectionConfig::fromServer()` — removes ~30 lines of duplicated config building. The refactor exposed a latent TypeError in the form's connection-test flow (transient `DatabaseServer` built without a name); fixed in the DTO factory and covered by a regression test.

## Test plan

- [x] Unit: dump emits `--format=custom` when configured; restore dispatches `pg_restore` vs `psql` based on snapshot's recorded format
- [x] Integration (real PG 17): backup → restore lifecycle for both `plain` and `custom dump format` datasets
- [x] Regression: `makeForServer` accepts a `forConnectionTest`-built server (no name)
- [x] Filename assertion: `.dump.gz` for custom, `.sql.gz` for plain
- [x] Pint, PHPStan, full test suite (1020 tests) green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL backups can use a selectable dump format (plain or custom); restores honor custom-format backups.
  * Backup/restore filenames and previews now reflect the chosen dump format.

* **UI**
  * Added per-server dump format selector and contextual warning when custom format is chosen.
  * Dump configuration UI now surfaces format and extra flags more clearly.

* **Tests**
  * Added and expanded tests covering custom/plain PostgreSQL dump and restore workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->