### PR TITLE
feat: add OAUTH_ONLY_MODE to hide password login form

### DIFF
--- a/.env
+++ b/.env
@@ -65,6 +65,9 @@ LOG_CHANNEL=stderr
 # OAuth Configuration
 # ============================================
 
+# Hide the password login form and require OAuth/SSO sign-in (default: false)
+OAUTH_ONLY_MODE=false
+
 # Allow new users to register via OAuth (default: true)
 OAUTH_AUTO_CREATE_USERS=true
 

--- a/app/Livewire/Configuration/Authentication.php
+++ b/app/Livewire/Configuration/Authentication.php
@@ -28,6 +28,11 @@ class Authentication extends Component
     {
         return [
             [
+                'env' => 'OAUTH_ONLY_MODE',
+                'value' => config('oauth.only_mode') ? 'true' : 'false',
+                'description' => __('Hide the password login form and require OAuth/SSO sign-in.'),
+            ],
+            [
                 'env' => 'OAUTH_GOOGLE_ENABLED',
                 'value' => config('oauth.providers.google.enabled') ? 'true' : 'false',
                 'description' => __('Enable Google OAuth authentication.'),

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -41,6 +41,12 @@ class FortifyServiceProvider extends ServiceProvider
     private function configureAuthentication(): void
     {
         Fortify::authenticateUsing(function (Request $request) {
+            if (config('oauth.only_mode')) {
+                throw ValidationException::withMessages([
+                    Fortify::username() => [__('Password login is disabled. Please sign in with an OAuth provider.')],
+                ]);
+            }
+
             $user = User::where('email', $request->email)->first();
 
             if (! $user) {
@@ -93,8 +99,20 @@ class FortifyServiceProvider extends ServiceProvider
 
             return view('livewire.auth.confirm-password');
         });
-        Fortify::resetPasswordView(fn () => view('livewire.auth.reset-password'));
-        Fortify::requestPasswordResetLinkView(fn () => view('livewire.auth.forgot-password'));
+        Fortify::resetPasswordView(function () {
+            if (config('oauth.only_mode')) {
+                abort(404);
+            }
+
+            return view('livewire.auth.reset-password');
+        });
+        Fortify::requestPasswordResetLinkView(function () {
+            if (config('oauth.only_mode')) {
+                abort(404);
+            }
+
+            return view('livewire.auth.forgot-password');
+        });
 
         Fortify::registerView(function () {
             if (User::count() > 0) {

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -143,9 +143,9 @@ return [
     |
     */
 
-    'features' => [
+    'features' => array_values(array_filter([
         Features::registration(),
-        Features::resetPasswords(),
+        env('OAUTH_ONLY_MODE', false) ? null : Features::resetPasswords(),
         // Features::updateProfileInformation(),
         // Features::updatePasswords(),
         Features::twoFactorAuthentication([
@@ -153,6 +153,6 @@ return [
             'confirmPassword' => true,
             // 'window' => 0,
         ]),
-    ],
+    ])),
 
 ];

--- a/config/oauth.php
+++ b/config/oauth.php
@@ -3,6 +3,19 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | OAuth-Only Mode
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the password login form is hidden and password-based
+    | authentication is rejected — users must sign in via an OAuth provider.
+    | The first-user bootstrap registration still works so the instance can
+    | be initialized before connecting an identity provider.
+    |
+    */
+    'only_mode' => env('OAUTH_ONLY_MODE', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | OAuth Default Role
     |--------------------------------------------------------------------------
     |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       - app-data:/data
     ports:
       - "2226:2226"
-    extra_hosts:
-      - "dex-local:host-gateway"
     environment:
       TZ: UTC
       XDG_CONFIG_HOME: /tmp
@@ -201,6 +199,10 @@ services:
       - ./docker/dex/config.yaml:/etc/dex/config.yaml:ro
     ports:
       - "127.0.0.1:5556:5556"
+    networks:
+      default:
+        aliases:
+          - dex-local
     command: ["dex", "serve", "/etc/dex/config.yaml"]
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:5556/dex/.well-known/openid-configuration"]

--- a/docs/docs/self-hosting/configuration/sso.md
+++ b/docs/docs/self-hosting/configuration/sso.md
@@ -118,6 +118,25 @@ OAUTH_OIDC_BASE_URL=https://authentik.example.com/application/o/databasement/
 OAUTH_OIDC_LABEL=Authentik
 ```
 
+## OAuth-Only Mode
+
+To enforce OAuth/SSO as the only sign-in method, hide the password login form, and reject password authentication on the server:
+
+```env
+OAUTH_ONLY_MODE=true  # Default: false
+```
+
+When enabled:
+
+- The password fields are hidden on the login page; users only see OAuth provider buttons.
+- Password authentication is rejected even if a request bypasses the UI.
+- The "forgot password" and "reset password" routes return `404`.
+- First-user bootstrap registration (when no users exist yet) still works, so the instance can be initialized before connecting an identity provider.
+
+:::warning
+Make sure at least one OAuth provider is configured and working before enabling `OAUTH_ONLY_MODE` — otherwise no one will be able to sign in.
+:::
+
 ## User Creation Settings
 
 ### Auto-Create Users

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -1,11 +1,22 @@
+@php
+    $oauthOnlyMode = (bool) config('oauth.only_mode');
+    $oauthProviders = app(\App\Services\OAuthService::class)->getEnabledProviders();
+@endphp
+
 <x-layouts::auth>
     <div class="flex flex-col gap-6">
         <div class="flex w-full flex-col text-center">
             <h1 class="text-2xl font-bold">{{ __('Log in to your account') }}</h1>
-            <p class="text-sm opacity-70">{{ __('Enter your email and password below to log in') }}</p>
+            <p class="text-sm opacity-70">
+                @if ($oauthOnlyMode)
+                    {{ __('Sign in with your identity provider to continue') }}
+                @else
+                    {{ __('Enter your email and password below to log in') }}
+                @endif
+            </p>
         </div>
 
-        @if (config('app.demo_mode'))
+        @if (config('app.demo_mode') && ! $oauthOnlyMode)
             <x-alert class="alert-info" icon="o-information-circle">
                 {{ __('Demo mode: credentials are pre-filled. Just click Log in!') }}
             </x-alert>
@@ -23,54 +34,53 @@
             <x-alert class="alert-error" icon="o-exclamation-circle">{{ $message }}</x-alert>
         @enderror
 
-        <x-form method="POST" action="{{ route('login.store') }}" class="flex flex-col gap-6">
-            @csrf
+        @unless ($oauthOnlyMode)
+            <x-form method="POST" action="{{ route('login.store') }}" class="flex flex-col gap-6">
+                @csrf
 
-            <!-- Email Address -->
-            <x-input
-                name="email"
-                label="{{ __('Email address') }}"
-                type="email"
-                required
-                autofocus
-                autocomplete="email"
-                placeholder="email@example.com"
-                value="{{ config('app.demo_mode') ? config('app.demo_user_email') : old('email') }}"
-            />
-
-            <!-- Password -->
-            <div class="relative">
-                <x-password
-                    name="password"
-                    label="{{ __('Password') }}"
+                <!-- Email Address -->
+                <x-input
+                    name="email"
+                    label="{{ __('Email address') }}"
+                    type="email"
                     required
-                    autocomplete="current-password"
-                    placeholder="{{ __('Password') }}"
-                    value="{{ config('app.demo_mode') ? config('app.demo_user_password') : '' }}"
+                    autofocus
+                    autocomplete="email"
+                    placeholder="email@example.com"
+                    value="{{ config('app.demo_mode') ? config('app.demo_user_email') : old('email') }}"
                 />
 
-                @if (Route::has('password.request'))
-                    <a href="{{ route('password.request') }}" class="absolute top-0 text-sm end-0 link link-hover" wire:navigate>
-                        {{ __('Forgot your password?') }}
-                    </a>
-                @endif
-            </div>
+                <!-- Password -->
+                <div class="relative">
+                    <x-password
+                        name="password"
+                        label="{{ __('Password') }}"
+                        required
+                        autocomplete="current-password"
+                        placeholder="{{ __('Password') }}"
+                        value="{{ config('app.demo_mode') ? config('app.demo_user_password') : '' }}"
+                    />
 
-            <!-- Remember Me -->
-            <x-checkbox name="remember" label="{{ __('Remember me') }}" :checked="old('remember')" />
+                    @if (Route::has('password.request'))
+                        <a href="{{ route('password.request') }}" class="absolute top-0 text-sm end-0 link link-hover" wire:navigate>
+                            {{ __('Forgot your password?') }}
+                        </a>
+                    @endif
+                </div>
 
-            <div class="flex items-center justify-end">
-                <x-button type="submit" class="btn-primary w-full" label="{{ __('Log in') }}" data-test="login-button" />
-            </div>
-        </x-form>
+                <!-- Remember Me -->
+                <x-checkbox name="remember" label="{{ __('Remember me') }}" :checked="old('remember')" />
 
-        {{-- OAuth Providers Section --}}
-        @php
-            $oauthProviders = app(\App\Services\OAuthService::class)->getEnabledProviders();
-        @endphp
+                <div class="flex items-center justify-end">
+                    <x-button type="submit" class="btn-primary w-full" label="{{ __('Log in') }}" data-test="login-button" />
+                </div>
+            </x-form>
+        @endunless
 
         @if (count($oauthProviders) > 0)
-            <div class="divider">{{ __('or continue with') }}</div>
+            @unless ($oauthOnlyMode)
+                <div class="divider">{{ __('or continue with') }}</div>
+            @endunless
 
             <div class="flex flex-col gap-3">
                 @foreach ($oauthProviders as $key => $provider)
@@ -80,6 +90,10 @@
                     </a>
                 @endforeach
             </div>
+        @elseif ($oauthOnlyMode)
+            <x-alert class="alert-warning" icon="o-exclamation-triangle">
+                {{ __('OAuth-only mode is enabled but no OAuth providers are configured. Please contact your administrator.') }}
+            </x-alert>
         @endif
     </div>
 </x-layouts::auth>

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -149,6 +149,44 @@ test('user without organization is logged out with error', function () {
     $this->assertGuest();
 });
 
+test('oauth-only mode hides password form on login screen', function () {
+    User::factory()->create();
+    config()->set('oauth.only_mode', true);
+    config()->set('oauth.providers.github.enabled', true);
+    config()->set('oauth.providers.github.client_id', 'test');
+    config()->set('oauth.providers.github.client_secret', 'test');
+
+    $response = $this->get(route('login'));
+
+    $response->assertStatus(200);
+    $response->assertDontSee('name="password"', false);
+    $response->assertDontSee(route('login.store'));
+    $response->assertSeeText('Continue with GitHub');
+});
+
+test('oauth-only mode rejects password authentication even with valid credentials', function () {
+    $user = User::factory()->withoutTwoFactor()->create();
+    config()->set('oauth.only_mode', true);
+
+    $response = $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $response->assertSessionHasErrors([
+        'email' => 'Password login is disabled. Please sign in with an OAuth provider.',
+    ]);
+
+    $this->assertGuest();
+});
+
+test('oauth-only mode disables password reset routes', function () {
+    User::factory()->create();
+    config()->set('oauth.only_mode', true);
+
+    $this->get('/forgot-password')->assertNotFound();
+});
+
 test('users can logout', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Configuration/AuthenticationTest.php
+++ b/tests/Feature/Configuration/AuthenticationTest.php
@@ -11,6 +11,7 @@ test('authentication page displays SSO environment variables', function () {
     Livewire::actingAs($user)
         ->test(Authentication::class)
         ->assertSee('Configuration')
+        ->assertSee('OAUTH_ONLY_MODE')
         ->assertSee('OAUTH_GOOGLE_ENABLED')
         ->assertSee('OAUTH_GITHUB_ENABLED')
         ->assertSee('OAUTH_GITLAB_ENABLED')


### PR DESCRIPTION
## Summary

Closes #331.

Adds a new `OAUTH_ONLY_MODE` environment variable to enforce OAuth/SSO as the only sign-in method. When enabled:

- The password fields are hidden on the login page; only OAuth provider buttons are shown.
- Password authentication is rejected server-side (`Fortify::authenticateUsing`), so direct POSTs to `/login` also fail.
- The `forgot-password` and `reset-password` views return `404` and the password-reset feature is unregistered from Fortify.
- First-user bootstrap registration still works, so the instance can be initialized before connecting an IdP.

The variable is surfaced in **Configuration → Authentication** alongside the existing `OAUTH_*` settings, and documented in the SSO self-hosting guide.

The name `OAUTH_ONLY_MODE` was chosen over `DISABLE_LOCAL_LOGIN` / `HIDE_LOCAL_LOGIN_FORM` (suggested in the issue) because it's a positive boolean and lives naturally next to the other `OAUTH_*` vars.

## Test plan

- [x] Unit/feature tests pass (`make test` — 1023 passed)
- [x] PHPStan clean (`make phpstan`)
- [x] Pint clean (`make lint-fix`)
- [x] Manual: enable `OAUTH_ONLY_MODE=true`, confirm `/login` shows only the SSO button
- [x] Manual: with `OAUTH_ONLY_MODE=true`, POST to `/login` with valid creds is rejected with the disabled-login message
- [x] Manual: `/forgot-password` returns `404` when `OAUTH_ONLY_MODE=true`
- [ ] Manual: `OAUTH_ONLY_MODE=false` (default) preserves the current login experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth-only mode (env-configurable) to enforce OAuth/SSO sign-in and hide the password login UI; login screen adapts to show OAuth buttons or a warning if no providers are configured.

* **Bug Fixes**
  * Password-based logins are rejected and password reset endpoints are inaccessible when OAuth-only mode is enabled.

* **Documentation**
  * Added OAuth-only mode docs with guidance and warnings.

* **Tests**
  * Added feature tests covering OAuth-only UI and authentication behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->