### PR TITLE
ci: split tests and Codecov upload to protect CODECOV_TOKEN

### DIFF
--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -17,6 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download coverage artifact
+        # Producer uses `if-no-files-found: ignore`, so the artifact may be
+        # absent when tests crashed before generating any reports. Continue
+        # so the downstream `hashFiles` gates can no-op cleanly.
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: coverage-reports
@@ -37,7 +41,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: coverage
           files: coverage.xml
-          skip_validation: true
           override_commit: ${{ github.event.workflow_run.head_sha }}
           override_branch: ${{ github.event.workflow_run.head_branch }}
           override_pr: ${{ steps.pr.outputs.number }}
@@ -49,7 +52,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
           files: junit.xml
-          skip_validation: true
           override_commit: ${{ github.event.workflow_run.head_sha }}
           override_branch: ${{ github.event.workflow_run.head_branch }}
           override_pr: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -1,0 +1,55 @@
+name: coverage-upload
+
+on:
+  workflow_run:
+    workflows: [tests]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read   # needed to download artifacts from the triggering run
+
+jobs:
+  upload:
+    # Run even on test failure so junit results still reach Codecov.
+    # Skip only when the run was cancelled or skipped.
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' && github.event.workflow_run.conclusion != 'skipped' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-reports
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          if [ -f pr-number.txt ]; then
+            echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload coverage to Codecov
+        if: hashFiles('coverage.xml') != ''
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: coverage
+          files: coverage.xml
+          skip_validation: true
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}
+          override_pr: ${{ steps.pr.outputs.number }}
+
+      - name: Upload test results to Codecov
+        if: hashFiles('junit.xml') != ''
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
+          files: junit.xml
+          skip_validation: true
+          override_commit: ${{ github.event.workflow_run.head_sha }}
+          override_branch: ${{ github.event.workflow_run.head_branch }}
+          override_pr: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,8 +3,7 @@ name: tests
 on:
   push:
     branches: [main]
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
 
 permissions:
   contents: read
@@ -98,8 +97,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
@@ -122,17 +119,18 @@ jobs:
       - name: Run Tests
         run: php artisan test --parallel --coverage-clover=coverage.xml --log-junit junit.xml
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          report_type: coverage
-          files: coverage.xml
-          skip_validation: true
+      - name: Save PR metadata
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
 
-      - name: Upload test results to Codecov
-        uses: codecov/codecov-action@v6
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          report_type: test_results
-          skip_validation: true
+          name: coverage-reports
+          path: |
+            coverage.xml
+            junit.xml
+            pr-number.txt
+          retention-days: 1
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- The previous workflow combined `pull_request_target` with a checkout of the PR head SHA, which executed untrusted fork code in a secrets-bearing context — a classic pwn-request pattern that exposed `CODECOV_TOKEN` (and any future secret) to malicious PRs.
- Splits CI into two workflows: `tests.yml` runs on `pull_request` with no secrets and uploads `coverage.xml` / `junit.xml` as an artifact; `coverage-upload.yml` is triggered via `workflow_run`, downloads the artifact in base-repo context, and uploads to Codecov with the token.
- Side effect (improvement): test results now also upload on test failure, which the previous single-job flow silently skipped.

## Test plan

- [ ] Open this PR — confirm `tests` workflow runs and succeeds.
- [ ] After tests complete, confirm `coverage-upload` workflow triggers via `workflow_run` and uploads to Codecov.
- [ ] Verify Codecov report on the PR shows the correct commit / branch / PR number (relies on `override_commit` / `override_branch` / `override_pr` in `coverage-upload.yml`).
- [ ] After merging, confirm `workflow_run` keeps working on subsequent PRs (workflow_run triggers only fire from the default branch's copy of the file).
- [ ] If a required status check is configured for the old single `tests` job name, update branch protection rules accordingly.

## Notes

- Drops the explicit `ref: ${{ github.event.pull_request.head.sha || github.sha }}` checkout — the default `actions/checkout@v6` behavior under `pull_request` already checks out the PR merge ref correctly.
- `types: [opened, synchronize, reopened]` filter dropped because those are the defaults for `pull_request`.
- Fork PRs still trigger the workflow (first-time contributors still need maintainer approval, as before).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD Updates**
  * Added a post-test workflow to aggregate and upload coverage and test reports after successful test runs.
  * Modified test workflow to save coverage, test results, and PR metadata as build artifacts with short retention.
  * Adjusted pull-request triggers and checkout behavior to standard PR handling and more reliable CI context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->