### PR TITLE
fix: store timestamps in UTC, render in display timezone (#335)

### DIFF
--- a/app/Livewire/Dashboard/JobsActivityChart.php
+++ b/app/Livewire/Dashboard/JobsActivityChart.php
@@ -18,11 +18,12 @@ class JobsActivityChart extends Component
     public function mount(): void
     {
         $days = 14;
-        $startDate = Carbon::now()->subDays($days - 1)->startOfDay();
+        $displayTz = config('app.display_timezone');
+        $startDate = Carbon::now($displayTz)->subDays($days - 1)->startOfDay();
 
         $jobs = BackupJob::forCurrentOrg()->where('created_at', '>=', $startDate)
             ->get()
-            ->groupBy(fn ($job) => $job->created_at->format('Y-m-d'));
+            ->groupBy(fn ($job) => $job->created_at->copy()->setTimezone($displayTz)->format('Y-m-d'));
 
         $labels = [];
         $completed = [];

--- a/app/Notifications/BackupFailedNotification.php
+++ b/app/Notifications/BackupFailedNotification.php
@@ -20,7 +20,7 @@ class BackupFailedNotification extends BaseFailedNotification
             body: 'A backup job has failed and requires your attention.',
             actionText: '🔗 View Job Details',
             actionUrl: route('snapshots.index', ['job' => $this->snapshot->backup_job_id]),
-            footerText: '🕐 '.now()->toDateTimeString(),
+            footerText: '🕐 '.\App\Support\Formatters::humanDate(now()),
             errorLabel: '❌ Error Details',
             fields: [
                 'Server' => $this->snapshot->databaseServer->name,

--- a/app/Notifications/BackupSuccessNotification.php
+++ b/app/Notifications/BackupSuccessNotification.php
@@ -17,7 +17,7 @@ class BackupSuccessNotification extends BaseSuccessNotification
             body: 'A backup job completed successfully.',
             actionText: '🔗 View Job Details',
             actionUrl: route('snapshots.index', ['job' => $this->snapshot->backup_job_id]),
-            footerText: '🕐 '.now()->toDateTimeString(),
+            footerText: '🕐 '.\App\Support\Formatters::humanDate(now()),
             fields: [
                 'Server' => $this->snapshot->databaseServer->name,
                 'Database' => $this->snapshot->database_name ?? 'Unknown',

--- a/app/Notifications/RestoreFailedNotification.php
+++ b/app/Notifications/RestoreFailedNotification.php
@@ -20,7 +20,7 @@ class RestoreFailedNotification extends BaseFailedNotification
             body: 'A restore job has failed and requires your attention.',
             actionText: '🔗 View Job Details',
             actionUrl: route('restores.index', ['job' => $this->restore->backup_job_id]),
-            footerText: '🕐 '.now()->toDateTimeString(),
+            footerText: '🕐 '.\App\Support\Formatters::humanDate(now()),
             errorLabel: '❌ Error Details',
             fields: [
                 'Target Server' => $this->restore->targetServer->name ?? 'Unknown',

--- a/app/Notifications/RestoreSuccessNotification.php
+++ b/app/Notifications/RestoreSuccessNotification.php
@@ -17,7 +17,7 @@ class RestoreSuccessNotification extends BaseSuccessNotification
             body: 'A restore job completed successfully.',
             actionText: '🔗 View Job Details',
             actionUrl: route('restores.index', ['job' => $this->restore->backup_job_id]),
-            footerText: '🕐 '.now()->toDateTimeString(),
+            footerText: '🕐 '.\App\Support\Formatters::humanDate(now()),
             fields: [
                 'Target Server' => $this->restore->targetServer->name ?? 'Unknown',
                 'Target Database' => $this->restore->schema_name ?? 'Unknown',

--- a/app/Notifications/SnapshotsMissingNotification.php
+++ b/app/Notifications/SnapshotsMissingNotification.php
@@ -26,7 +26,7 @@ class SnapshotsMissingNotification extends BaseFailedNotification
             body: "{$count} backup ".str('file')->plural($count).' could not be found on their storage volumes.',
             actionText: '🔗 View Missing Files',
             actionUrl: route('snapshots.index', ['fileMissing' => '1']),
-            footerText: '🕐 '.now()->toDateTimeString(),
+            footerText: '🕐 '.\App\Support\Formatters::humanDate(now()),
             errorLabel: '📁 Missing Files',
         );
     }

--- a/app/Services/Backup/BackupTask.php
+++ b/app/Services/Backup/BackupTask.php
@@ -133,7 +133,7 @@ class BackupTask
      */
     private function generateFilename(string $serverName, string $databaseName, string $baseExtension, CompressorInterface $compressor, string $backupPath): string
     {
-        $timestamp = now()->format('Y-m-d-His');
+        $timestamp = now()->setTimezone(config('app.display_timezone'))->format('Y-m-d-His');
         $sanitizedServerName = preg_replace('/[^a-zA-Z0-9-_]/', '-', $serverName) ?? $serverName;
         $sanitizedDbName = preg_replace('/[^a-zA-Z0-9-_]/', '-', $databaseName) ?? $databaseName;
         $compressionExtension = $compressor->getExtension();

--- a/app/Support/Formatters.php
+++ b/app/Support/Formatters.php
@@ -64,7 +64,9 @@ class Formatters
             $date = Carbon::parse($date);
         }
 
-        return $date->format('M j, Y, H:i');
+        return Carbon::instance($date)
+            ->setTimezone(config('app.display_timezone'))
+            ->format('M j, Y, H:i');
     }
 
     /**
@@ -97,7 +99,8 @@ class Formatters
      */
     public static function resolveDatePlaceholders(string $path, ?\DateTimeInterface $date = null): string
     {
-        $date ??= Carbon::now();
+        $date = Carbon::instance($date ?? Carbon::now())
+            ->setTimezone(config('app.display_timezone'));
 
         return str_replace(
             ['{year}', '{month}', '{day}'],

--- a/config/app.php
+++ b/config/app.php
@@ -74,15 +74,48 @@ return [
     | Application Timezone
     |--------------------------------------------------------------------------
     |
-    | Here you may specify the default timezone for your application, which
-    | will be used by the PHP date and date-time functions. The timezone
-    | is set to "UTC" by default as it is suitable for most use cases.
+    | All internal timestamps (database storage, scheduling math, log entries)
+    | are kept in UTC regardless of the host's TZ environment variable. This
+    | guarantees consistent comparisons between the web app and the worker
+    | container, which previously diverged when their system timezones did
+    | not match (see GitHub issue #335).
+    |
+    | The user-facing display timezone is configured separately via
+    | "display_timezone" below.
     |
     | See: https://www.php.net/manual/en/timezones.php
     |
     */
 
-    'timezone' => env('TZ', 'UTC'),
+    'timezone' => 'UTC',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Display Timezone
+    |--------------------------------------------------------------------------
+    |
+    | The timezone used when rendering datetimes in the UI, generating
+    | timestamps in backup filenames, and elsewhere in user-facing output.
+    | The container entrypoint also migrates a legacy TZ value into this
+    | variable before PHP boots, so existing deployments keep working.
+    | Storage stays UTC.
+    |
+    */
+
+    'display_timezone' => env('APP_DISPLAY_TIMEZONE', 'UTC'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Schedule Timezone
+    |--------------------------------------------------------------------------
+    |
+    | Timezone used by Laravel's scheduler to interpret cron expressions —
+    | including user-configured BackupSchedule expressions. Mirrors the
+    | display timezone so "0 2 * * *" fires at 02:00 local, not 02:00 UTC.
+    |
+    */
+
+    'schedule_timezone' => env('APP_DISPLAY_TIMEZONE', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/database.php
+++ b/config/database.php
@@ -64,6 +64,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
+            'timezone' => '+00:00',
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
@@ -84,6 +85,7 @@ return [
             'prefix_indexes' => true,
             'strict' => true,
             'engine' => null,
+            'timezone' => '+00:00',
             'options' => extension_loaded('pdo_mysql') ? array_filter([
                 PDO\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
@@ -102,6 +104,7 @@ return [
             'prefix_indexes' => true,
             'search_path' => 'public',
             'sslmode' => 'prefer',
+            'timezone' => 'UTC',
         ],
 
         'sqlsrv' => [

--- a/docker/php/scripts/docker-entrypoint.sh
+++ b/docker/php/scripts/docker-entrypoint.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
 set -e
 
+# Normalize timezone configuration before launching any child process:
+#   - APP_DISPLAY_TIMEZONE drives all user-facing display in the app.
+#   - For backwards compatibility, fall back to TZ if it was set the old way.
+#   - Then force the container's system TZ to UTC so libc-based output
+#     (mariadb-dump comments, log timestamps, etc.) matches storage, which
+#     Laravel always keeps in UTC (see config/app.php).
+if [ -z "${APP_DISPLAY_TIMEZONE:-}" ] && [ -n "${TZ:-}" ] && [ "${TZ}" != "UTC" ]; then
+    export APP_DISPLAY_TIMEZONE="${TZ}"
+fi
+export TZ=UTC
+
 exec "$@"

--- a/docs/docs/self-hosting/configuration/application.md
+++ b/docs/docs/self-hosting/configuration/application.md
@@ -131,6 +131,7 @@ Here's a complete `.env` file for a production deployment with MySQL:
 APP_DEBUG=false
 APP_URL=https://backup.yourdomain.com
 APP_KEY=base64:your-generated-key-here
+# APP_DISPLAY_TIMEZONE=UTC  # timezone for UI, backup filenames, and schedules
 
 # Database (for Databasement itself)
 DB_CONNECTION=mysql

--- a/docs/docs/self-hosting/configuration/application.md
+++ b/docs/docs/self-hosting/configuration/application.md
@@ -8,12 +8,12 @@ Core application settings including database, timezone, proxy configuration, and
 
 ## Application Settings
 
-| Variable    | Description                                      | Default                 |
-| ----------- | ------------------------------------------------ | ----------------------- |
-| `APP_KEY`   | Application encryption key (required)            | -                       |
-| `APP_URL`   | Full URL where the app is accessible             | `http://localhost:2226` |
-| `APP_DEBUG` | Enable debug mode (set to `false` in production) | `false`                 |
-| `TZ`        | Application timezone                             | `UTC`                   |
+| Variable                | Description                                      | Default                 |
+| ----------------------- | ------------------------------------------------ | ----------------------- |
+| `APP_KEY`               | Application encryption key (required)            | -                       |
+| `APP_URL`               | Full URL where the app is accessible             | `http://localhost:2226` |
+| `APP_DEBUG`             | Enable debug mode (set to `false` in production) | `false`                 |
+| `APP_DISPLAY_TIMEZONE`  | Timezone for UI, backup filenames, and crons     | `UTC`                   |
 
 
 ### Generating the Application Key
@@ -28,14 +28,15 @@ Copy the output (e.g., `base64:xxxx...`) and set it as `APP_KEY`.
 
 ### Timezone Configuration
 
-Set the `TZ` environment variable to configure the application timezone.
+Set `APP_DISPLAY_TIMEZONE` to display dates, backup filenames, and schedule times in your local timezone. A cron like `0 2 * * *` will then fire at 02:00 in that zone.
+
 ```bash
-TZ=America/New_York
-TZ=Europe/London
-TZ=Asia/Tokyo
+APP_DISPLAY_TIMEZONE=Europe/London
 ```
 
 See the [list of supported timezones](https://www.php.net/manual/en/timezones.php).
+
+Data is always stored in UTC internally. If you previously set `TZ`, it is migrated automatically — no action needed.
 
 ## Database Configuration
 

--- a/helm/databasement/templates/deployment.yaml
+++ b/helm/databasement/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
             {{ toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-c", "php artisan db:wait --allow-missing-db && php artisan migrate --force"]
+          args: ["sh", "-c", "php artisan db:wait --allow-missing-db && php artisan migrate --force"]
           env:
             {{ include "databasement.env" . | nindent 12 }}
           {{- with .Values.extraEnvFrom }}
@@ -98,7 +98,7 @@ spec:
             {{ toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-c", "{{ .Values.worker.command }}"]
+          args: ["sh", "-c", "{{ .Values.worker.command }}"]
           env:
             {{ include "databasement.env" . | nindent 12 }}
           {{- with .Values.extraEnvFrom }}
@@ -180,7 +180,7 @@ spec:
             {{ toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-c", "php artisan db:wait && {{ .Values.worker.command }}"]
+          args: ["sh", "-c", "php artisan db:wait && {{ .Values.worker.command }}"]
           env:
             {{ include "databasement.env" . | nindent 12 }}
           {{- with .Values.extraEnvFrom }}

--- a/helm/databasement/tests/__snapshot__/deployment_test.yaml.snap
+++ b/helm/databasement/tests/__snapshot__/deployment_test.yaml.snap
@@ -94,7 +94,7 @@ should render deployment with default values:
               volumeMounts:
                 - mountPath: /data
                   name: data
-            - command:
+            - args:
                 - sh
                 - -c
                 - php artisan db:wait --check-migrations && php artisan queue:work --queue=backups,default --max-jobs=1000
@@ -139,7 +139,7 @@ should render deployment with default values:
                 - mountPath: /data
                   name: data
           initContainers:
-            - command:
+            - args:
                 - sh
                 - -c
                 - php artisan db:wait --allow-missing-db && php artisan migrate --force
@@ -300,7 +300,7 @@ should render deployment with mysql database:
               volumeMounts:
                 - mountPath: /data
                   name: data
-            - command:
+            - args:
                 - sh
                 - -c
                 - php artisan db:wait --check-migrations && php artisan queue:work --queue=backups,default --max-jobs=1000
@@ -356,7 +356,7 @@ should render deployment with mysql database:
                 - mountPath: /data
                   name: data
           initContainers:
-            - command:
+            - args:
                 - sh
                 - -c
                 - php artisan db:wait --allow-missing-db && php artisan migrate --force

--- a/helm/databasement/tests/deployment_test.yaml
+++ b/helm/databasement/tests/deployment_test.yaml
@@ -84,7 +84,7 @@ tests:
           path: spec.template.spec.containers[1].name
           value: databasement-worker
       - equal:
-          path: spec.template.spec.containers[1].command
+          path: spec.template.spec.containers[1].args
           value: ["sh", "-c", "php artisan queue:work --queue=custom --tries=5"]
 
   - it: should apply worker resources in sidecar mode
@@ -162,7 +162,7 @@ tests:
     asserts:
       - documentIndex: 1
         equal:
-          path: spec.template.spec.containers[0].command
+          path: spec.template.spec.containers[0].args
           value: ["sh", "-c", "php artisan db:wait && php artisan queue:work --queue=custom --tries=5"]
 
   - it: should apply worker resources in separate deployment

--- a/resources/views/partials/job-logs-modal.blade.php
+++ b/resources/views/partials/job-logs-modal.blade.php
@@ -155,7 +155,8 @@
                     <div class="max-h-[60vh] overflow-y-auto divide-y divide-base-300">
                         @foreach($logs as $index => $log)
                             @php
-                                $timestamp = \Carbon\Carbon::parse($log['timestamp']);
+                                $timestamp = \Carbon\Carbon::parse($log['timestamp'])
+                                    ->setTimezone(config('app.display_timezone'));
                                 $isCommand = $log['type'] === 'command';
                                 $isRunning = $isCommand && ($log['status'] ?? null) === 'running';
 

--- a/tests/Feature/Support/FormattersTest.php
+++ b/tests/Feature/Support/FormattersTest.php
@@ -74,6 +74,15 @@ test('humanDate handles single digit days correctly', function () {
     expect(Formatters::humanDate($date))->toBe('Jan 5, 2025, 09:05');
 });
 
+test('humanDate renders in the configured display timezone', function () {
+    config(['app.display_timezone' => 'Asia/Tokyo']);
+
+    // 2025-12-19 16:44 UTC = 2025-12-20 01:44 Tokyo (UTC+9)
+    $date = \Carbon\Carbon::create(2025, 12, 19, 16, 44, 0, 'UTC');
+
+    expect(Formatters::humanDate($date))->toBe('Dec 20, 2025, 01:44');
+});
+
 test('resolveDatePlaceholders replaces year, month and day tokens zero-padded', function () {
     $date = \Carbon\Carbon::create(2026, 3, 5);
 
@@ -97,6 +106,17 @@ test('resolveDatePlaceholders replaces each placeholder globally', function () {
 
 test('resolveDatePlaceholders defaults to the current date when none is provided', function () {
     \Carbon\Carbon::setTestNow(\Carbon\Carbon::create(2026, 7, 8));
+
+    expect(Formatters::resolveDatePlaceholders('archive/{year}/{month}/{day}'))
+        ->toBe('archive/2026/07/08');
+
+    \Carbon\Carbon::setTestNow();
+});
+
+test('resolveDatePlaceholders uses display timezone for "now"', function () {
+    config(['app.display_timezone' => 'Asia/Tokyo']);
+    // 2026-07-07 23:00 UTC = 2026-07-08 08:00 Tokyo — day boundary differs.
+    \Carbon\Carbon::setTestNow(\Carbon\Carbon::create(2026, 7, 7, 23, 0, 0, 'UTC'));
 
     expect(Formatters::resolveDatePlaceholders('archive/{year}/{month}/{day}'))
         ->toBe('archive/2026/07/08');


### PR DESCRIPTION
## Summary

- Closes #335. Jobs were briefly flipping to **Failed** with absurd durations (e.g. 603m on a freshly started backup) because `app.timezone` was read from the system `TZ` env var. When the `app` and `worker` containers had different `TZ` values, the scheduler's `RecoverStuckJobsCommand` interpreted the worker-written `started_at` in its own timezone and saw the job as already past timeout.
- Storage is now always **UTC**: `config/app.php` hardcodes `app.timezone = UTC`, the DB connection timezone is forced to `+00:00`, and the container entrypoint exports `TZ=UTC` for system tools too. The `app` and `worker` containers no longer need to agree on `TZ`.
- A new `APP_DISPLAY_TIMEZONE` env var drives the user-facing layer: UI rendering (`Formatters::humanDate`, dashboard chart grouping, job-logs modal), backup filenames (`BackupTask::generateFilename`, `resolveDatePlaceholders`), notification footers, and the scheduler's interpretation of `BackupSchedule` cron expressions (`schedule_timezone`).
- Backwards compatible: if a user previously set `TZ`, the entrypoint migrates it to `APP_DISPLAY_TIMEZONE` before PHP boots, so existing deployments keep working with no change.

## Test plan

- [x] Self-hosted Docker deployment with `APP_DISPLAY_TIMEZONE` unset: timestamps in UI render as UTC, cron expressions interpreted as UTC.
- [x] Self-hosted Docker deployment with `APP_DISPLAY_TIMEZONE=Europe/Paris`: UI shows local time, `0 2 * * *` fires at 02:00 Paris time, backup filenames contain local timestamps.
- [x] Self-hosted Docker deployment with legacy `TZ=Europe/Paris` and `APP_DISPLAY_TIMEZONE` unset: entrypoint migration takes effect, behaves identically to setting `APP_DISPLAY_TIMEZONE` directly.
- [x] Trigger a long-running backup, confirm `RecoverStuckJobsCommand` does not mark it as failed before the configured timeout (the original #335 reproduction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable display timezone applied consistently to UI charts, notifications, job logs, and backup filenames; internal timestamps standardized to UTC.

* **Bug Fixes**
  * Fixed timezone handling so displayed dates/times respect the configured display timezone across the app.

* **Documentation**
  * Updated configuration guide to introduce APP_DISPLAY_TIMEZONE and migration guidance.

* **Tests**
  * Added tests ensuring date formatting and placeholder substitution use the configured display timezone.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->