### PR TITLE
docs: add docusaurus-plugin-llms for llmstxt.org output

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@
 <p align="center">
   <a href="https://databasement-demo.crty.dev/"><strong>Live Demo</strong></a> ·
   <a href="https://david-crty.github.io/databasement/">Documentation</a> ·
-  <a href="https://github.com/David-Crty/databasement/issues">Report Bug or Request Feature</a> ·
+  <a href="https://david-crty.github.io/databasement/llms.txt">llms.txt</a> ·
+  <a href="https://github.com/David-Crty/databasement/issues">Report Bug or Request Feature</a>
 </p>
 
 ---
@@ -106,6 +107,10 @@ Databasement can be managed programmatically through its **REST API** and **MCP 
 ## Documentation
 
 Full documentation is available at [david-crty.github.io/databasement](https://david-crty.github.io/databasement/).
+
+For LLMs and AI assistants, the documentation is also published in the [llmstxt.org](https://llmstxt.org/) format:
+- [llms.txt](https://david-crty.github.io/databasement/llms.txt) — index of all documentation pages
+- [llms-full.txt](https://david-crty.github.io/databasement/llms-full.txt) — full documentation content in a single file
 
 ## Issues & Feature Requests
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -3,6 +3,7 @@ import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const version = process.env.DOCS_VERSION;
+const isLocalBuild = process.env.DOCS_LOCAL === 'true';
 
 const config: Config = {
     title: 'Databasement',
@@ -11,9 +12,46 @@ const config: Config = {
 
     plugins: [
         require.resolve('docusaurus-lunr-search'),
+        [
+            'docusaurus-plugin-llms',
+            {
+                title: 'Databasement Documentation',
+                description: 'Simple and powerful database backup management — self-hosting and user documentation for Databasement.',
+                generateLLMsTxt: true,
+                generateLLMsFullTxt: true,
+                generateMarkdownFiles: true,
+                preserveDirectoryStructure: false,
+                excludeImports: true,
+                removeDuplicateHeadings: true,
+                ignoreFiles: [
+                    'index.md',
+                ],
+                includeOrder: [
+                    'self-hosting/intro.md',
+                    'self-hosting/docker-compose.md',
+                    'self-hosting/docker.md',
+                    'self-hosting/kubernetes-helm.md',
+                    'self-hosting/native-ubuntu.md',
+                    'self-hosting/configuration/**',
+                    'self-hosting/versioning.md',
+                    'user-guide/intro.md',
+                    'user-guide/database-servers.md',
+                    'user-guide/volumes.md',
+                    'user-guide/backups.md',
+                    'user-guide/snapshots.md',
+                    'user-guide/organizations.md',
+                    'user-guide/permissions.md',
+                    'user-guide/api.md',
+                    'user-guide/mcp.md',
+                    'contributing/**',
+                ],
+                includeUnmatchedLast: true,
+                ...(version ? {version} : {}),
+            },
+        ],
     ],
 
-    url: 'https://david-crty.github.io',
+    url: isLocalBuild ? 'http://localhost:3000' : 'https://david-crty.github.io',
     baseUrl: '/databasement/',
 
     organizationName: 'David-Crty',
@@ -78,6 +116,12 @@ const config: Config = {
                     position: 'right' as const,
                     value: `<span class="badge badge--secondary">v${version}</span>`,
                 }] : []),
+                {
+                    href: 'pathname:///llms.txt',
+                    label: 'llms.txt',
+                    position: 'right',
+                    title: 'LLM-friendly documentation index (llmstxt.org)',
+                },
                 {
                     href: 'https://github.com/David-Crty/databasement',
                     label: 'GitHub',

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -21,6 +21,7 @@
         "@docusaurus/module-type-aliases": "^3.8.1",
         "@docusaurus/tsconfig": "^3.8.1",
         "@docusaurus/types": "^3.8.1",
+        "docusaurus-plugin-llms": "^0.4.0",
         "typescript": "~5.8.3"
       },
       "engines": {
@@ -8108,6 +8109,54 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.4.0.tgz",
+      "integrity": "sha512-jYlj2HJ5+gu7oJZuJ83Hk8KlB65YlZZ/7UpHXiL7Qr+qpNBkVocmt2Molc6F3HNr5RqcfhWD/98CvgyNztg/ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rachfop"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/docusaurus-plugin-llms/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/dom-converter": {
@@ -19335,6 +19384,22 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "build:local": "DOCS_LOCAL=true docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -28,6 +29,7 @@
     "@docusaurus/module-type-aliases": "^3.8.1",
     "@docusaurus/tsconfig": "^3.8.1",
     "@docusaurus/types": "^3.8.1",
+    "docusaurus-plugin-llms": "^0.4.0",
     "typescript": "~5.8.3"
   },
   "browserslist": {


### PR DESCRIPTION
## Summary

Adds [docusaurus-plugin-llms](https://github.com/rachfop/docusaurus-plugin-llms) so the docs site exposes its content in the [llmstxt.org](https://llmstxt.org/) format for AI assistants.

The build now emits:
- `llms.txt` — index of all 20 doc pages with descriptions
- `llms-full.txt` — full doc content in a single file
- Per-page `.md` files matching the served URL paths

## Config choices

- `preserveDirectoryStructure: false` — docs use `routeBasePath: '/'`, so emitted `.md` files must sit at `build/self-hosting/...` (not `build/docs/...`) to match the served URLs.
- `includeOrder` set to mirror the navbar reading flow (self-hosting → user-guide → contributing) instead of alphabetic.
- `ignoreFiles: ['index.md']` — skips the root landing page.
- `excludeImports` + `removeDuplicateHeadings` — cleaner output for LLM consumption.
- New `DOCS_LOCAL=true` env (via `npm run build:local`) swaps the site URL to `http://localhost:3000` so links resolve to the local preview server.

## UI touches

- Navbar link to `llms.txt` (uses `pathname://` to bypass React routing).
- README header bar and Documentation section both link to the file.

## Note on dev mode

The plugin only implements the Docusaurus `postBuild` hook, so `npm run start` does not generate `llms.txt`. Use `npm run build:local && npm run serve` to preview locally.

## Test plan

- [x] `npm run build` succeeds; `build/llms.txt`, `build/llms-full.txt`, and 20 per-page `.md` files generated.
- [x] `npm run build:local && npm run serve` → `http://localhost:3000/databasement/llms.txt` returns 200 with localhost URLs.
- [x] `npm run build && npm run serve` → links point to the production GitHub Pages URL.
- [ ] Once deployed, verify the navbar link and README links resolve on the live site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documentation now available in llms.txt format (index and full content versions)
  * Added navigation links to access LLM-friendly documentation formats
  * Enabled local documentation builds for development

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->