### PR TITLE
fix: render health/debug timestamps in display timezone

### DIFF
--- a/app/Http/Controllers/Web/HealthCheckController.php
+++ b/app/Http/Controllers/Web/HealthCheckController.php
@@ -40,6 +40,7 @@ class HealthCheckController extends Controller
         $isTrustedProxy = $request->isFromTrustedProxy();
 
         $dbTimezone = $this->getDatabaseTimezone();
+        $displayTimezone = config('app.display_timezone');
 
         $response = [
             'ip_address' => $ipAddress,
@@ -48,7 +49,7 @@ class HealthCheckController extends Controller
             'hostname' => $hostname,
             'timestamp' => Carbon::now()->timestamp,
             'date_time_utc' => Carbon::now('UTC')->toDateTimeString(),
-            'date_time_app' => Carbon::now()->toDateTimeString(),
+            'date_time_app' => Carbon::now()->setTimezone($displayTimezone)->toDateTimeString(),
             'timezone' => $dbTimezone,
             'secure' => $secure,
             'is_trusted_proxy' => $isTrustedProxy,
@@ -59,6 +60,7 @@ class HealthCheckController extends Controller
             $response['app_url'] = config('app.url');
             $response['app_env'] = app()->environment();
             $response['app_timezone'] = config('app.timezone');
+            $response['app_display_timezone'] = $displayTimezone;
             $response['app_force_https'] = config('app.force_https');
             $response['session_secure'] = config('session.secure');
             $response['trusted_proxies'] = config('app.trusted_proxies');

--- a/tests/Feature/HealthCheckTest.php
+++ b/tests/Feature/HealthCheckTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Carbon;
+
 test('health check returns success', function () {
     $response = $this->getJson(route('health.up'));
 
@@ -23,4 +25,21 @@ test('health debug returns application info', function () {
             'secure',
             'is_trusted_proxy',
         ]);
+});
+
+test('health debug renders date_time_app in display timezone and exposes it in debug mode', function () {
+    config(['app.timezone' => 'UTC']);
+    config(['app.display_timezone' => 'Asia/Tokyo']);
+    config(['app.debug' => true]);
+
+    Carbon::setTestNow(Carbon::parse('2026-05-27 00:00:00', 'UTC'));
+
+    $response = $this->getJson(route('health.debug'));
+
+    $response->assertOk()
+        ->assertJsonPath('date_time_utc', '2026-05-27 00:00:00')
+        ->assertJsonPath('date_time_app', '2026-05-27 09:00:00')
+        ->assertJsonPath('app_display_timezone', 'Asia/Tokyo');
+
+    Carbon::setTestNow();
 });

--- a/tests/Feature/HealthCheckTest.php
+++ b/tests/Feature/HealthCheckTest.php
@@ -34,12 +34,14 @@ test('health debug renders date_time_app in display timezone and exposes it in d
 
     Carbon::setTestNow(Carbon::parse('2026-05-27 00:00:00', 'UTC'));
 
-    $response = $this->getJson(route('health.debug'));
+    try {
+        $response = $this->getJson(route('health.debug'));
 
-    $response->assertOk()
-        ->assertJsonPath('date_time_utc', '2026-05-27 00:00:00')
-        ->assertJsonPath('date_time_app', '2026-05-27 09:00:00')
-        ->assertJsonPath('app_display_timezone', 'Asia/Tokyo');
-
-    Carbon::setTestNow();
+        $response->assertOk()
+            ->assertJsonPath('date_time_utc', '2026-05-27 00:00:00')
+            ->assertJsonPath('date_time_app', '2026-05-27 09:00:00')
+            ->assertJsonPath('app_display_timezone', 'Asia/Tokyo');
+    } finally {
+        Carbon::setTestNow();
+    }
 });


### PR DESCRIPTION
## Summary
- `/health/debug` was still rendering `date_time_app` in UTC after #335/#336, because `config('app.timezone')` is UTC and timestamps are now displayed via `app.display_timezone`.
- Render `date_time_app` using the display timezone and expose `app_display_timezone` alongside `app_timezone` in debug mode.

Reported by @cba-tony in https://github.com/David-Crty/databasement/issues/337#issuecomment-4538951165.

Refs #337

## Test plan
- [x] `make test-filter FILTER=HealthCheckTest` — new test pins `now()` to UTC and asserts `date_time_app` reflects `Asia/Tokyo` and `app_display_timezone` is present
- [x] Manual: visit `/health/debug` with `APP_DISPLAY_TIMEZONE` set and confirm `date_time_app` matches the configured zone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Health check debug endpoint now renders application time using the configured display timezone and exposes that display timezone in debug output.

* **Tests**
  * Added test coverage verifying display-timezone rendering and exposure in the health check debug endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->