### PR TITLE
test: standardize Volume creation via factory in tests

### DIFF
--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -98,12 +98,7 @@ test('can create database server with backups disabled', function () {
 
 test('can create database server with retention policy', function (array $config) {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     $component = Livewire::actingAs($user)
         ->test(Create::class)
@@ -137,12 +132,7 @@ test('can create database server with retention policy', function (array $config
 
 test('cannot create database server with GFS retention when all tiers are empty', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'GFS Validation Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'GFS Validation Test Volume']);
 
     Livewire::actingAs($user)
         ->test(Create::class)
@@ -280,12 +270,7 @@ test('can add and remove SQLite database paths', function () {
 
 test('can create database server with dump flags', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     Livewire::actingAs($user)
         ->test(Create::class)
@@ -312,12 +297,7 @@ test('can create database server with dump flags', function () {
 
 test('can create mysql database server with ssl_enabled', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     Livewire::actingAs($user)
         ->test(Create::class)
@@ -342,7 +322,7 @@ test('can create mysql database server with ssl_enabled', function () {
 
 test('local volume options reflect use_agent state', function (bool $useAgent, bool $expectedDisabled) {
     $user = User::factory()->create();
-    $localVolume = Volume::create(['name' => 'Local Vol', 'type' => 'local', 'config' => ['path' => '/backups'], 'organization_id' => \App\Models\Organization::first()->id]);
+    $localVolume = Volume::factory()->local()->create(['name' => 'Local Vol']);
 
     $component = Livewire::actingAs($user)
         ->test(Create::class)
@@ -357,9 +337,12 @@ test('local volume options reflect use_agent state', function (bool $useAgent, b
     'enabled when use_agent is false' => [false, false],
 ]);
 
-test('toggling use_agent clears local volume but keeps remote volume', function (string $volumeType, array $volumeConfig, string $expectedVolumeId) {
+test('toggling use_agent clears local volume but keeps remote volume', function (string $volumeType, string $expectedVolumeId) {
     $user = User::factory()->create();
-    $volume = Volume::create(['name' => 'Test Vol', 'type' => $volumeType, 'config' => $volumeConfig, 'organization_id' => \App\Models\Organization::first()->id]);
+    $volume = match ($volumeType) {
+        's3' => Volume::factory()->s3()->create(['name' => 'Test Vol']),
+        default => Volume::factory()->local()->create(['name' => 'Test Vol']),
+    };
 
     $expected = $expectedVolumeId === 'keep' ? $volume->id : '';
 
@@ -369,14 +352,14 @@ test('toggling use_agent clears local volume but keeps remote volume', function 
         ->set('form.use_agent', true)
         ->assertSet('form.backups.0.volume_id', $expected);
 })->with([
-    'clears local volume' => ['local', ['path' => '/backups'], 'clear'],
-    'keeps s3 volume' => ['s3', ['bucket' => 'test'], 'keep'],
+    'clears local volume' => ['local', 'clear'],
+    'keeps s3 volume' => ['s3', 'keep'],
 ]);
 
 test('cannot create agent-backed server with local volume', function () {
     $user = User::factory()->create();
     $agent = Agent::factory()->create();
-    $localVolume = Volume::create(['name' => 'Local Vol', 'type' => 'local', 'config' => ['path' => '/backups'], 'organization_id' => \App\Models\Organization::first()->id]);
+    $localVolume = Volume::factory()->local()->create(['name' => 'Local Vol']);
 
     Livewire::actingAs($user)
         ->test(Create::class)
@@ -398,12 +381,7 @@ test('cannot create agent-backed server with local volume', function () {
 
 test('backup summary is incomplete until volume and schedule are set, then renders the full plan', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Prod Backups',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Prod Backups']);
 
     $component = Livewire::actingAs($user)
         ->test(Create::class)
@@ -475,12 +453,7 @@ test('retention summary text adapts to each retention policy', function () {
 
 test('backup summary reports incomplete when retention settings are blank', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Prod Backups',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Prod Backups']);
 
     $component = Livewire::actingAs($user)
         ->test(Create::class)
@@ -516,18 +489,8 @@ test('backup summary reports incomplete when retention settings are blank', func
 
 test('can create a server with multiple backup configurations', function () {
     $user = User::factory()->create();
-    $volume1 = Volume::create([
-        'name' => 'Primary Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups/primary'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
-    $volume2 = Volume::create([
-        'name' => 'Secondary Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups/secondary'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume1 = Volume::factory()->local()->create(['name' => 'Primary Volume']);
+    $volume2 = Volume::factory()->local()->create(['name' => 'Secondary Volume']);
     $daily = dailySchedule();
     $weekly = weeklySchedule();
 

--- a/tests/Feature/DatabaseServer/EditTest.php
+++ b/tests/Feature/DatabaseServer/EditTest.php
@@ -12,12 +12,7 @@ use Livewire\Livewire;
 
 test('can edit database server', function (array $config) {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
     $schedule = dailySchedule();
 
     $serverData = [
@@ -99,12 +94,7 @@ test('can edit database server', function (array $config) {
 
 test('can change retention policy', function (array $config) {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
     $schedule = dailySchedule();
 
     $server = DatabaseServer::create([

--- a/tests/Feature/DatabaseServer/SshTunnelTest.php
+++ b/tests/Feature/DatabaseServer/SshTunnelTest.php
@@ -13,12 +13,7 @@ uses(RefreshDatabase::class);
 
 test('can create database server with SSH tunnel (password auth)', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     Livewire::actingAs($user)
         ->test(Create::class)
@@ -62,12 +57,7 @@ test('can create database server with SSH tunnel (password auth)', function () {
 
 test('can create database server with SSH tunnel (key auth)', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     $privateKey = "-----BEGIN OPENSSH PRIVATE KEY-----\ntest_key_content\n-----END OPENSSH PRIVATE KEY-----";
 
@@ -106,12 +96,7 @@ test('can create database server with SSH tunnel (key auth)', function () {
 
 test('can create database server using existing SSH config', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     // Create existing SSH config
     $existingSshConfig = DatabaseServerSshConfig::factory()->create([
@@ -188,12 +173,7 @@ test('SSH section is shown for SQLite with SFTP label', function () {
 
 test('can create SQLite server with SSH config for remote access', function () {
     $user = User::factory()->create();
-    $volume = Volume::create([
-        'name' => 'Test Volume',
-        'type' => 'local',
-        'config' => ['path' => '/var/backups'],
-        'organization_id' => \App\Models\Organization::first()->id,
-    ]);
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     Livewire::actingAs($user)
         ->test(Create::class)

--- a/tests/Feature/Services/Backup/LocalVolumeStorageTest.php
+++ b/tests/Feature/Services/Backup/LocalVolumeStorageTest.php
@@ -35,11 +35,9 @@ test('getForVolume supports both root and path config keys for local filesystem'
     $tempDir = $volume->config['path'];
 
     // Test with 'root' key (from config/backup.php style)
-    $volumeWithRoot = Volume::create([
+    $volumeWithRoot = Volume::factory()->local()->create([
         'name' => 'Volume with root key',
-        'type' => 'local',
         'config' => ['root' => $tempDir],
-        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $filesystem = $this->filesystemProvider->getForVolume($volumeWithRoot);
@@ -48,11 +46,9 @@ test('getForVolume supports both root and path config keys for local filesystem'
     expect(file_exists($tempDir.'/root-test.txt'))->toBeTrue();
 
     // Test with 'path' key (from Volume database style)
-    $volumeWithPath = Volume::create([
+    $volumeWithPath = Volume::factory()->local()->create([
         'name' => 'Volume with path key',
-        'type' => 'local',
         'config' => ['path' => $tempDir],
-        'organization_id' => \App\Models\Organization::first()->id,
     ]);
 
     $filesystem2 = $this->filesystemProvider->getForVolume($volumeWithPath);

--- a/tests/Feature/Volume/VolumeTest.php
+++ b/tests/Feature/Volume/VolumeTest.php
@@ -200,17 +200,13 @@ describe('volume editing', function () {
 describe('volume listing', function () {
     test('displays volumes in index', function () {
         $user = User::factory()->create();
-        Volume::create([
+        Volume::factory()->local()->create([
             'name' => 'Local Volume',
-            'type' => 'local',
             'config' => ['path' => '/var/backups'],
-            'organization_id' => \App\Models\Organization::first()->id,
         ]);
-        Volume::create([
+        Volume::factory()->s3()->create([
             'name' => 'S3 Volume',
-            'type' => 's3',
             'config' => ['bucket' => 'my-bucket', 'prefix' => ''],
-            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         Livewire::actingAs($user)
@@ -223,18 +219,8 @@ describe('volume listing', function () {
 
     test('can search volumes', function () {
         $user = User::factory()->create();
-        Volume::create([
-            'name' => 'Production Volume',
-            'type' => 'local',
-            'config' => ['path' => '/var/backups'],
-            'organization_id' => \App\Models\Organization::first()->id,
-        ]);
-        Volume::create([
-            'name' => 'Development Volume',
-            'type' => 's3',
-            'config' => ['bucket' => 'dev-bucket', 'prefix' => ''],
-            'organization_id' => \App\Models\Organization::first()->id,
-        ]);
+        Volume::factory()->local()->create(['name' => 'Production Volume']);
+        Volume::factory()->s3()->create(['name' => 'Development Volume']);
 
         Livewire::actingAs($user)
             ->test(Index::class)
@@ -247,12 +233,7 @@ describe('volume listing', function () {
 describe('volume deletion', function () {
     test('can delete volume', function () {
         $user = User::factory()->create();
-        $volume = Volume::create([
-            'name' => 'Volume to Delete',
-            'type' => 'local',
-            'config' => ['path' => '/var/backups'],
-            'organization_id' => \App\Models\Organization::first()->id,
-        ]);
+        $volume = Volume::factory()->local()->create(['name' => 'Volume to Delete']);
 
         Livewire::actingAs($user)
             ->test(Index::class)
@@ -401,12 +382,7 @@ describe('volume immutability', function () {
 
     test('can edit volume without snapshots', function () {
         $user = User::factory()->create();
-        $volume = Volume::create([
-            'name' => 'Empty Volume',
-            'type' => 'local',
-            'config' => ['path' => '/var/backups'],
-            'organization_id' => \App\Models\Organization::first()->id,
-        ]);
+        $volume = Volume::factory()->local()->create(['name' => 'Empty Volume']);
 
         // Verify volume has no snapshots
         expect($volume->hasSnapshots())->toBeFalse();
@@ -439,9 +415,8 @@ describe('connection testing', function () {
         $user = User::factory()->create();
 
         // Create SFTP volume with encrypted password
-        $volume = Volume::create([
+        $volume = Volume::factory()->sftp()->create([
             'name' => 'Test SFTP Volume',
-            'type' => 'sftp',
             'config' => [
                 'host' => 'localhost',
                 'port' => 22,
@@ -449,7 +424,6 @@ describe('connection testing', function () {
                 'password' => Crypt::encryptString('secret-password'),
                 'root' => '/uploads',
             ],
-            'organization_id' => \App\Models\Organization::first()->id,
         ]);
 
         // Mock the FilesystemProvider to verify the volume receives merged password

--- a/tests/Support/IntegrationTestHelpers.php
+++ b/tests/Support/IntegrationTestHelpers.php
@@ -111,11 +111,9 @@ class IntegrationTestHelpers
             mkdir($storageDir, 0755, true);
         }
 
-        return Volume::create([
+        return Volume::factory()->local()->create([
             'name' => "Integration Test Volume ({$type})",
-            'type' => 'local',
             'config' => ['root' => $storageDir],
-            'organization_id' => \App\Models\Organization::first()->id,
         ]);
     }
 
@@ -126,9 +124,8 @@ class IntegrationTestHelpers
     {
         $ssh = self::getSshConfig();
 
-        return Volume::create([
+        return Volume::factory()->sftp()->create([
             'name' => 'Integration Test SFTP Volume',
-            'type' => 'sftp',
             'config' => [
                 'host' => $ssh['host'],
                 'port' => $ssh['port'],
@@ -137,7 +134,6 @@ class IntegrationTestHelpers
                 'root' => '/config/backups',
                 'timeout' => 10,
             ],
-            'organization_id' => \App\Models\Organization::first()->id,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- Replace direct `Volume::create([...])` calls in tests with `Volume::factory()->local()->create(...)` (or `->s3()`/`->sftp()` where appropriate) so volume setup is consistent across the test suite.
- Covers `DatabaseServer/CreateTest.php`, `DatabaseServer/EditTest.php`, `DatabaseServer/SshTunnelTest.php`, `Services/Backup/LocalVolumeStorageTest.php`, `Volume/VolumeTest.php`, and `Support/IntegrationTestHelpers.php`.
- Drops the unused `\$volumeConfig` dataset column on `toggling use_agent clears local volume but keeps remote volume`; type is now mapped to the matching factory state.

The first commit addresses a CodeRabbit/review comment that specifically called out `CreateTest.php`; the second commit extends the same standardization to the remaining test files where the mixed pattern existed.

## Test plan
- [x] `make test` — 1044 passed, 3009 assertions
- [x] Pint clean (`vendor/bin/pint --dirty`)
- [x] PHPStan clean (pre-commit ran full analysis)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures to use factory-based Volume creation patterns across multiple test suites, improving test consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/David-Crty/databasement/pull/358?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->