### PR TITLE
fix: surface pre-flight connection failures as failed snapshots

### DIFF
--- a/app/Services/Backup/BackupJobFactory.php
+++ b/app/Services/Backup/BackupJobFactory.php
@@ -12,6 +12,7 @@ use App\Models\DatabaseServer;
 use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Services\Backup\Databases\DatabaseProvider;
+use App\Services\NotificationService;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
@@ -54,20 +55,26 @@ class BackupJobFactory
             return $snapshots;
         }
 
-        // Agent-backed servers with all/pattern mode need a discovery phase —
-        // the web app can't reach the database, only the agent can list databases.
+        // Agent-backed servers defer discovery to the agent — the web app
+        // can't reach the database itself.
         if ($server->agent_id && in_array($backup->database_selection_mode, [DatabaseSelectionMode::All, DatabaseSelectionMode::Pattern], true)) {
             return [];
         }
 
-        $databases = match ($backup->database_selection_mode) {
-            DatabaseSelectionMode::All => $this->databaseProvider->listDatabasesForServer($server),
-            DatabaseSelectionMode::Pattern => DatabaseServer::filterDatabasesByPattern(
-                $this->databaseProvider->listDatabasesForServer($server),
-                $backup->database_include_pattern ?? ''
-            ),
-            default => $backup->database_names ?? [],
-        };
+        try {
+            $databases = match ($backup->database_selection_mode) {
+                DatabaseSelectionMode::All => $this->databaseProvider->listDatabasesForServer($server),
+                DatabaseSelectionMode::Pattern => DatabaseServer::filterDatabasesByPattern(
+                    $this->databaseProvider->listDatabasesForServer($server),
+                    $backup->database_include_pattern ?? '',
+                ),
+                default => $backup->database_names ?? [],
+            };
+        } catch (\Throwable $e) {
+            $this->recordPreflightFailure($backup, $method, $triggeredByUserId, $e);
+
+            return [];
+        }
 
         if (empty($databases)) {
             Log::warning("No databases found on server [{$server->name}] for backup [{$backup->id}].");
@@ -115,6 +122,41 @@ class BackupJobFactory
         $snapshot->load(['job', 'volume', 'databaseServer']);
 
         return $snapshot;
+    }
+
+    /**
+     * Record a pre-flight failure (e.g. database unreachable when listing
+     * databases for All/Pattern modes) as a failed snapshot so monitoring
+     * dashboards and notifications can pick it up.
+     *
+     * @param  'manual'|'scheduled'  $method
+     */
+    private function recordPreflightFailure(
+        Backup $backup,
+        string $method,
+        ?int $triggeredByUserId,
+        \Throwable $exception,
+    ): void {
+        $databaseName = match ($backup->database_selection_mode) {
+            DatabaseSelectionMode::All => '(all databases)',
+            DatabaseSelectionMode::Pattern => $backup->database_include_pattern ?: '(pattern)',
+            default => '(preflight)',
+        };
+
+        $snapshot = $this->createSnapshot($backup, $databaseName, $method, $triggeredByUserId);
+        $snapshot->job->log("Pre-flight failed: {$exception->getMessage()}", 'error', [
+            'exception' => get_class($exception),
+        ]);
+        $snapshot->job->markFailed($exception);
+
+        try {
+            app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
+        } catch (\Throwable $notificationException) {
+            Log::warning('Pre-flight failure notification failed', [
+                'snapshot_id' => $snapshot->id,
+                'error' => $notificationException->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/tests/Feature/Console/RunScheduledBackupsTest.php
+++ b/tests/Feature/Console/RunScheduledBackupsTest.php
@@ -132,12 +132,11 @@ test('server with no databases does not prevent other backups from running', fun
     expect($snapshot->database_name)->toBe('production_db');
 });
 
-test('server throwing exception when listing databases does not prevent other backups from running', function () {
+test('server unreachable during all/pattern listing produces a failed preflight snapshot', function () {
     Queue::fake();
 
     $schedule = dailySchedule();
 
-    // Server with selection_mode=all that will throw an exception
     $failingServer = DatabaseServer::factory()->create([
         'name' => 'Failing Server',
         'database_selection_mode' => 'all',
@@ -145,7 +144,6 @@ test('server throwing exception when listing databases does not prevent other ba
     ]);
     $failingServer->backups->first()->update(['backup_schedule_id' => $schedule->id]);
 
-    // Server with selection_mode=all that should still work (databases from mock provider)
     $normalServer = DatabaseServer::factory()->create([
         'name' => 'Normal Server',
         'database_selection_mode' => 'all',
@@ -166,21 +164,23 @@ test('server throwing exception when listing databases does not prevent other ba
             });
     });
 
-    Log::shouldReceive('error')
-        ->once()
-        ->withArgs(fn (string $msg, array $ctx) => str_starts_with($msg, 'Failed to dispatch backup job for server [Failing Server / ')
-            && $ctx === ['error' => 'Connection refused']);
-
     $this->artisan('backups:run', ['schedule' => $schedule->id])
         ->expectsOutputToContain('Dispatching 2 backup(s)')
-        ->expectsOutput('Completed with 1 failed server(s).')
+        ->expectsOutput('All backup jobs dispatched successfully.')
         ->assertExitCode(0);
 
-    // Only the normal server's backup should be dispatched
+    // Only the normal server's snapshots get dispatched to the queue.
     Queue::assertPushed(ProcessBackupJob::class, 2);
 
-    $snapshot = Snapshot::first();
-    expect($snapshot->database_name)->toBe('production_db');
+    $failingSnapshot = Snapshot::where('database_server_id', $failingServer->id)->first();
+    expect($failingSnapshot)->not->toBeNull()
+        ->and($failingSnapshot->database_name)->toBe('(all databases)')
+        ->and($failingSnapshot->method)->toBe('scheduled')
+        ->and($failingSnapshot->job->status)->toBe('failed')
+        ->and($failingSnapshot->job->error_message)->toBe('Connection refused');
+
+    expect(Snapshot::where('database_server_id', $normalServer->id)->pluck('database_name')->sort()->values()->all())
+        ->toBe(['other_db', 'production_db']);
 });
 
 test('dispatches agent jobs when server has agent', function () {
@@ -223,6 +223,10 @@ test('dispatches discovery job for agent server with all mode', function () {
         ->and($discoveryJob->database_server_id)->toBe($server->id)
         ->and($discoveryJob->snapshot_id)->toBeNull()
         ->and($discoveryJob->payload['type'])->toBe('discover');
+
+    // Agent servers must defer discovery to the agent — the web app must not
+    // attempt a direct connection, so no pre-flight failure snapshot.
+    expect(Snapshot::where('database_server_id', $server->id)->count())->toBe(0);
 });
 
 test('skips duplicate discovery job when one is already in-flight', function () {


### PR DESCRIPTION
## Summary

- When a scheduled backup in `All` / `Pattern` mode could not reach the server (host down, backup user removed, etc.), `BackupJobFactory::createSnapshots()` let the listing exception propagate and `RunScheduledBackups` swallowed it with a log line. No `Snapshot` was created, so the dashboard, API and notification channels showed nothing — external monitors like Zabbix only saw the last successful run.
- `BackupJobFactory` now catches the failure from `listDatabasesForServer()`, creates one failed `Snapshot` with a representative `database_name` (`(all databases)` or the configured pattern), marks the `BackupJob` failed with the exception, and fires `NotificationService::notifyBackupFailed()`. Returns `[]` so nothing is dispatched to the queue.
- Agent-backed servers still defer discovery to the agent (early-return preserved) — they do not produce a pre-flight snapshot. Selected-mode behavior is unchanged: those snapshots were already created up-front and failed inside `ProcessBackupJob`.

Closes #345

## Test plan

- [x] `make test-filter FILTER=RunScheduledBackups` — updated `server unreachable during all/pattern listing produces a failed preflight snapshot` test asserts the failed snapshot is persisted with the connection error while sibling servers on the same schedule still run.
- [x] Added a regression assertion to `dispatches discovery job for agent server with all mode` confirming no pre-flight snapshot is created for agent servers.
- [x] `make phpstan` — clean.
- [x] `make lint-fix` — clean.
- [x] Full suite via pre-commit hook — 1044 passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling during backup database discovery to gracefully manage connection failures, record failed backups, and mark jobs as failed when preflight checks encounter issues.
  * Added notifications to alert users when backup discovery fails.

* **Tests**
  * Expanded test coverage for backup preflight failure scenarios and improved assertions for failure event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->