### PR TITLE
fix: GFS retention keeps newest snapshot per week/month, not oldest

### DIFF
--- a/app/Services/Backup/SnapshotCleanupService.php
+++ b/app/Services/Backup/SnapshotCleanupService.php
@@ -147,7 +147,7 @@ class SnapshotCleanupService
 
             $snapshotInPeriod = $snapshots
                 ->filter(fn (Snapshot $s) => $s->created_at->between($periodStart, $periodEnd))
-                ->sortBy('created_at')
+                ->sortByDesc('created_at')
                 ->first();
 
             if ($snapshotInPeriod) {

--- a/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
+++ b/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
@@ -71,8 +71,6 @@ test('dry-run mode does not delete snapshots', function () {
 });
 
 test('GFS retention combines daily, weekly, and monthly tiers', function () {
-    // Fixed mid-month Saturday avoids day3 landing on a month boundary,
-    // which would cause the monthly tier to keep it as the oldest in the month.
     $this->travelTo(\Carbon\Carbon::create(2026, 6, 20, 12, 0));
 
     $server = DatabaseServer::factory()->create();
@@ -84,21 +82,28 @@ test('GFS retention combines daily, weekly, and monthly tiers', function () {
         'gfs_keep_monthly' => 2,
     ]);
 
+    // Daily tier keeps the 2 most recent regardless of period.
     $day1 = createSnapshot($server, 'completed', now()->subDays(1));
     $day2 = createSnapshot($server, 'completed', now()->subDays(2));
     $day3 = createSnapshot($server, 'completed', now()->subDays(3));
-    $thisWeekOldest = createSnapshot($server, 'completed', now()->startOfWeek());
-    $lastWeek = createSnapshot($server, 'completed', now()->subWeek()->startOfWeek()->addDay());
-    $lastMonth = createSnapshot($server, 'completed', now()->subMonth()->startOfMonth()->addDay());
+
+    // Last week has two snapshots — only the newest one should be kept by the weekly tier.
+    $lastWeekMid = createSnapshot($server, 'completed', now()->subWeek()->startOfWeek()->addDay());
+    $lastWeekNewest = createSnapshot($server, 'completed', now()->subWeek()->endOfWeek()->subHour());
+
+    // Last month has two snapshots — only the newest one should be kept by the monthly tier.
+    $lastMonthMid = createSnapshot($server, 'completed', now()->subMonth()->startOfMonth()->addDay());
+    $lastMonthNewest = createSnapshot($server, 'completed', now()->subMonth()->endOfMonth()->subHour());
 
     app(SnapshotCleanupService::class)->run();
 
     expect(Snapshot::find($day1->id))->not->toBeNull()
         ->and(Snapshot::find($day2->id))->not->toBeNull()
         ->and(Snapshot::find($day3->id))->toBeNull()
-        ->and(Snapshot::find($thisWeekOldest->id))->not->toBeNull()
-        ->and(Snapshot::find($lastWeek->id))->not->toBeNull()
-        ->and(Snapshot::find($lastMonth->id))->not->toBeNull();
+        ->and(Snapshot::find($lastWeekMid->id))->toBeNull()
+        ->and(Snapshot::find($lastWeekNewest->id))->not->toBeNull()
+        ->and(Snapshot::find($lastMonthMid->id))->toBeNull()
+        ->and(Snapshot::find($lastMonthNewest->id))->not->toBeNull();
 });
 
 test('GFS retention applies per database_name', function () {


### PR DESCRIPTION
## Summary

The GFS weekly/monthly tiers were picking the **oldest** snapshot in each period (Monday morning for weekly, 1st-of-month for monthly). Switched to **newest** per period to match standard GFS implementations (Veeam, restic, Borg, rsnapshot) and the "Keep last N weekly/monthly snapshots" UI copy.

### Why this matters

With the old behavior, "last month's backup" meant May 1 instead of May 31 — losing up to ~29 days of recency on the monthly tier when a user restores from it. The weekly tier had the same issue at a smaller scale (~6 days). After this change, each tier preserves the freshest snapshot of its period, which is what users expect.

### Change

One-line implementation change in `selectSnapshotsForPeriod`:

```diff
- ->sortBy('created_at')
+ ->sortByDesc('created_at')
```

The daily tier was already newest-first (uses `take(N)` on a desc-ordered query) — only the weekly/monthly tier selection was inverted.

### Test

Rewrote the combined-tier test to assert the new semantics with two snapshots per past period (mid + end), confirming only the newest is kept.

## Test plan

- [x] `make test-filter FILTER=SnapshotCleanupService` — 6 passed
- [x] `make test` — 1111 passed, 0 failed
- [x] `make lint-fix` — clean
- [x] `make phpstan` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected snapshot retention behavior during backup cleanup to prioritize keeping the newest snapshot within weekly and monthly retention periods, ensuring the most recent backups are preserved.

* **Tests**
  * Updated retention policy tests to verify the snapshot selection correctly keeps the most recent backup in each weekly and monthly window.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->