### PR TITLE
feat: optional PostgreSQL ownership and privilege backup

### DIFF
--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -48,6 +48,7 @@ class SaveDatabaseServerRequest extends FormRequest
 
         if ($type === 'postgres') {
             $rules['dump_format'] = ['nullable', 'string', Rule::in(['plain', 'custom'])];
+            $rules['dump_privileges'] = 'boolean';
         }
 
         if (in_array($type, ['mongodb', 'redis'])) {

--- a/app/Jobs/ProcessRestoreJob.php
+++ b/app/Jobs/ProcessRestoreJob.php
@@ -74,6 +74,7 @@ class ProcessRestoreJob implements ShouldQueue
                 forceDatabase: filter_var($restore->getOption('force_database', false), FILTER_VALIDATE_BOOLEAN),
                 ownerUser: is_string($value = $restore->getOption('owner_user')) && $value !== '' ? $value : null,
                 snapshotDumpFormat: is_string($format = ($snapshot->metadata['dump_format'] ?? null)) ? $format : null,
+                snapshotDumpPrivileges: (bool) ($snapshot->metadata['dump_privileges'] ?? false),
             );
 
             $restoreTask->execute($config, $job);

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -50,6 +50,15 @@ class DatabaseServerForm extends Form
 
     public string $dump_format = 'plain';
 
+    public bool $dump_privileges = false;
+
+    /**
+     * Whether the dump config collapse starts open. Snapshot taken when the
+     * form loads — intentionally not derived from live fields so the collapse
+     * doesn't close while the user toggles options.
+     */
+    public bool $dump_config_open = false;
+
     public bool $ssl_enabled = false;
 
     // SSH Tunnel Configuration
@@ -395,6 +404,8 @@ class DatabaseServerForm extends Form
         $this->auth_source = $server->getExtraConfig('auth_source', '');
         $this->dump_flags = $server->getExtraConfig('dump_flags', '');
         $this->dump_format = $server->getExtraConfig('dump_format', 'plain');
+        $this->dump_privileges = (bool) $server->getExtraConfig('dump_privileges', false);
+        $this->dump_config_open = ! empty($this->dump_flags) || $this->dump_format === 'custom' || $this->dump_privileges;
         $this->ssl_enabled = (bool) $server->getExtraConfig('ssl_enabled', false);
         $this->username = $server->username ?? '';
         $this->description = $server->description;
@@ -656,6 +667,7 @@ class DatabaseServerForm extends Form
 
         if ($type === DatabaseType::POSTGRESQL) {
             $config['dump_format'] = $this->dump_format;
+            $config['dump_privileges'] = $this->dump_privileges;
         }
 
         try {
@@ -808,6 +820,7 @@ class DatabaseServerForm extends Form
             'backups_enabled' => 'boolean',
             'dump_flags' => ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'],
             'dump_format' => ['nullable', 'string', Rule::in(['plain', 'custom'])],
+            'dump_privileges' => 'boolean',
             'ssl_enabled' => 'boolean',
             'notification_trigger' => ['required', 'string', Rule::in(array_column(NotificationTrigger::cases(), 'value'))],
             'notification_channel_selection' => ['required', 'string', Rule::in(array_column(NotificationChannelSelection::cases(), 'value'))],

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -379,6 +379,15 @@ class DatabaseServer extends Model
             unset($data['dump_format']);
         }
 
+        if (array_key_exists('dump_privileges', $data)) {
+            if ($type === DatabaseType::POSTGRESQL->value && $data['dump_privileges']) {
+                $extraConfig['dump_privileges'] = true;
+            } else {
+                unset($extraConfig['dump_privileges']);
+            }
+            unset($data['dump_privileges']);
+        }
+
         if (array_key_exists('ssl_enabled', $data)) {
             if ($type === DatabaseType::MYSQL->value && $data['ssl_enabled']) {
                 $extraConfig['ssl_enabled'] = true;

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -64,7 +64,7 @@ class Snapshot extends Model
      * Generate metadata array for a snapshot.
      * Sensitive fields (passwords) are excluded from the volume config.
      *
-     * @return array{database_server: array{host: string|null, port: int|null, username: string|null, database_name: string, ssh_tunnel: array{enabled: bool, host?: string, port?: int, username?: string, auth_type?: string}}, volume: array{type: string, config: array<string, mixed>}, dump_format?: string}
+     * @return array{database_server: array{host: string|null, port: int|null, username: string|null, database_name: string, ssh_tunnel: array{enabled: bool, host?: string, port?: int, username?: string, auth_type?: string}}, volume: array{type: string, config: array<string, mixed>}, dump_format?: string, dump_privileges?: bool}
      */
     public static function generateMetadata(DatabaseServer $server, string $databaseName, Volume $volume): array
     {
@@ -98,6 +98,13 @@ class Snapshot extends Model
         if ($server->database_type === DatabaseType::POSTGRESQL
             && $server->getExtraConfig('dump_format') === 'custom') {
             $metadata['dump_format'] = 'custom';
+        }
+
+        // Record whether ownership/privilege information was preserved in the dump.
+        // Absent → stripped via --no-owner/--no-privileges (default for legacy snapshots).
+        if ($server->database_type === DatabaseType::POSTGRESQL
+            && (bool) $server->getExtraConfig('dump_privileges')) {
+            $metadata['dump_privileges'] = true;
         }
 
         return $metadata;

--- a/app/Services/Backup/DTO/RestoreConfig.php
+++ b/app/Services/Backup/DTO/RestoreConfig.php
@@ -20,5 +20,6 @@ readonly class RestoreConfig
         public bool $forceDatabase = false,
         public ?string $ownerUser = null,
         public ?string $snapshotDumpFormat = null,
+        public bool $snapshotDumpPrivileges = false,
     ) {}
 }

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -82,8 +82,9 @@ class DatabaseProvider
      * Create a configured database interface from a DatabaseConnectionConfig DTO.
      *
      * Host and port are passed explicitly to support SSH tunnel overrides.
-     * $snapshotDumpFormat overrides the target's dump_format at restore time: format
-     * is a property of the snapshot file, not the destination server.
+     * $snapshotDumpFormat and $snapshotDumpPrivileges override the target's
+     * extra_config at restore time: both are properties of the snapshot file,
+     * not the destination server.
      */
     public function makeFromConfig(
         DatabaseConnectionConfig $config,
@@ -92,6 +93,7 @@ class DatabaseProvider
         int $port,
         ?string $sourceDatabaseName = null,
         ?string $snapshotDumpFormat = null,
+        ?bool $snapshotDumpPrivileges = null,
     ): DatabaseInterface {
         if ($config->databaseType === DatabaseType::SQLITE) {
             return $this->makeConfigured(DatabaseType::SQLITE, $this->sqliteConfig($databaseName, $config->sshConfig));
@@ -112,6 +114,11 @@ class DatabaseProvider
         if ($config->databaseType === DatabaseType::POSTGRESQL
             && ($snapshotDumpFormat ?? $extra['dump_format'] ?? null) === 'custom') {
             $dbConfig['dump_format'] = 'custom';
+        }
+
+        if ($config->databaseType === DatabaseType::POSTGRESQL
+            && ($snapshotDumpPrivileges ?? ! empty($extra['dump_privileges']))) {
+            $dbConfig['dump_privileges'] = true;
         }
 
         // Optional short timeout used by interactive UI lookups; jobs leave

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -37,6 +37,15 @@ class PostgresqlDatabase implements DatabaseInterface
         '--jobs=4',
     ];
 
+    /**
+     * Dropped from dump/restore options when the server is configured to
+     * preserve ownership and privilege information (dump_privileges).
+     */
+    private const array PORTABILITY_OPTIONS = [
+        '--no-owner',
+        '--no-privileges',
+    ];
+
     private const array EXCLUDED_DATABASES = [
         'rdsadmin',          // AWS RDS internal database
         'azure_maintenance', // Azure Database for PostgreSQL internal database
@@ -53,7 +62,7 @@ class PostgresqlDatabase implements DatabaseInterface
 
     public function dump(string $outputPath): DatabaseOperationResult
     {
-        $options = self::DUMP_OPTIONS;
+        $options = $this->withPrivilegeOptions(self::DUMP_OPTIONS);
         if (($this->config['dump_format'] ?? 'plain') === 'custom') {
             $options[] = '--format=custom';
         }
@@ -86,7 +95,7 @@ class PostgresqlDatabase implements DatabaseInterface
             return new DatabaseOperationResult(command: sprintf(
                 'PGPASSWORD=%s pg_restore %s --host=%s --port=%s --username=%s --dbname=%s %s',
                 escapeshellarg($this->config['pass']),
-                implode(' ', self::RESTORE_CUSTOM_FORMAT_OPTIONS),
+                implode(' ', $this->withPrivilegeOptions(self::RESTORE_CUSTOM_FORMAT_OPTIONS)),
                 escapeshellarg($this->config['host']),
                 escapeshellarg((string) $this->config['port']),
                 escapeshellarg($this->config['user']),
@@ -104,6 +113,22 @@ class PostgresqlDatabase implements DatabaseInterface
             escapeshellarg($this->config['database']),
             escapeshellarg($inputPath)
         ));
+    }
+
+    /**
+     * Strip the --no-owner/--no-privileges portability flags when the
+     * configuration asks to preserve ownership and privilege information.
+     *
+     * @param  array<string>  $options
+     * @return array<string>
+     */
+    private function withPrivilegeOptions(array $options): array
+    {
+        if (empty($this->config['dump_privileges'])) {
+            return $options;
+        }
+
+        return array_values(array_diff($options, self::PORTABILITY_OPTIONS));
     }
 
     public function prepareForRestore(string $schemaName, BackupLogger $logger, bool $forceDatabase = false): void

--- a/app/Services/Backup/RestoreTask.php
+++ b/app/Services/Backup/RestoreTask.php
@@ -83,6 +83,7 @@ class RestoreTask
                 $this->getConnectionPort($target),
                 $config->snapshotDatabaseName,
                 $config->snapshotDumpFormat,
+                $config->snapshotDumpPrivileges,
             );
 
             $this->prepareDatabase($database, $config->schemaName, $logger, $config->forceDatabase);

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -127,7 +127,7 @@ use App\Enums\DatabaseType;
                     @endif
 
                     @if($form->supportsDumpFlags())
-                        <x-collapse class="mt-2" :open="!empty($form->dump_flags) || $form->dump_format === 'custom'">
+                        <x-collapse class="mt-2" :open="$form->dump_config_open">
                             <x-slot:heading>
                                 <x-icon name="o-command-line" class="w-4 h-4" />
                                 {{ __('Dump Command Configuration') }}
@@ -149,6 +149,12 @@ use App\Enums\DatabaseType;
                                             {{ __('Custom format archives are version-sensitive: the target restore server must be PostgreSQL 17 or newer. Restores run with 4 parallel pg_restore workers.') }}
                                         </x-alert>
                                     @endif
+
+                                    <x-checkbox
+                                        wire:model.live="form.dump_privileges"
+                                        :label="__('Backup ownership and privilege information (less portable)')"
+                                        :hint="__('Keeps OWNER and GRANT/REVOKE statements in the dump instead of stripping them with --no-owner and --no-privileges. Every role referenced by the dump must exist on the restore target, otherwise the restore will report errors.')"
+                                    />
                                 @endif
 
                                 <x-input

--- a/resources/views/livewire/restore/_destination-step.blade.php
+++ b/resources/views/livewire/restore/_destination-step.blade.php
@@ -11,6 +11,9 @@
 
     Params:
       $targetLocked (bool) - when true the target is fixed; hide the select
+      $snapshotPreservesPrivileges (bool, optional) - when true the snapshot was
+          dumped with ownership/privilege information, so the post-restore
+          ownership transfer option is hidden (the dump itself sets owners)
 --}}
 @php
     $type = $this->targetServer?->database_type;
@@ -43,12 +46,18 @@
     @endif
 
     @if($type === DatabaseType::POSTGRESQL)
-        <x-input
-            wire:model="ownerUser"
-            :label="__('Transfer database ownership to user after restore')"
-            :placeholder="__('PostgreSQL username (leave empty to skip)')"
-            :hint="__('Transfers ownership of the database and all its objects (tables, sequences, functions, schemas) to this user. Useful when the restore user differs from the application user.')"
-        />
+        @if($snapshotPreservesPrivileges ?? false)
+            <x-alert class="alert-info" icon="o-information-circle">
+                {{ __('This snapshot includes ownership and privilege information; original owners and grants will be applied by the restore itself.') }}
+            </x-alert>
+        @else
+            <x-input
+                wire:model="ownerUser"
+                :label="__('Transfer database ownership to user after restore')"
+                :placeholder="__('PostgreSQL username (leave empty to skip)')"
+                :hint="__('Transfers ownership of the database and all its objects (tables, sequences, functions, schemas) to this user. Useful when the restore user differs from the application user.')"
+            />
+        @endif
     @endif
 
     @if(in_array($type, [DatabaseType::MYSQL, DatabaseType::POSTGRESQL], true))

--- a/resources/views/livewire/restore/modal.blade.php
+++ b/resources/views/livewire/restore/modal.blade.php
@@ -144,6 +144,7 @@
                 <div class="space-y-4">
                     @include('livewire.restore._destination-step', [
                         'targetLocked' => $mode->targetServerLocked(),
+                        'snapshotPreservesPrivileges' => (bool) ($snapshot?->metadata['dump_privileges'] ?? false),
                     ])
 
                     @if($snapshot)

--- a/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
@@ -141,6 +141,47 @@ test('makeFromConfig passes ssl_enabled from extra_config for mysql', function (
         ->not->toContain('--skip_ssl');
 });
 
+test('makeFromConfig passes dump_privileges from extra_config for postgres', function () {
+    $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
+        databaseType: DatabaseType::POSTGRESQL,
+        serverName: 'PG Server',
+        host: 'pg.example.com',
+        port: 5432,
+        username: 'postgres',
+        password: 'secret',
+        extraConfig: ['dump_privileges' => true],
+    );
+
+    $database = (new DatabaseProvider)->makeFromConfig($config, 'myapp', 'pg.example.com', 5432);
+
+    expect($database->dump('/tmp/test.sql')->command)
+        ->not->toContain('--no-owner')
+        ->not->toContain('--no-privileges');
+});
+
+test('makeFromConfig snapshot dump_privileges overrides target extra_config at restore time', function () {
+    $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
+        databaseType: DatabaseType::POSTGRESQL,
+        serverName: 'PG Server',
+        host: 'pg.example.com',
+        port: 5432,
+        username: 'postgres',
+        password: 'secret',
+        extraConfig: ['dump_privileges' => true],
+    );
+
+    // Legacy snapshot dumped without privileges: target server setting must not apply
+    $database = (new DatabaseProvider)->makeFromConfig(
+        $config, 'myapp', 'pg.example.com', 5432,
+        snapshotDumpFormat: 'custom',
+        snapshotDumpPrivileges: false,
+    );
+
+    expect($database->restore('/tmp/snapshot.dump')->command)
+        ->toContain('--no-owner')
+        ->toContain('--no-privileges');
+});
+
 test('makeForServer passes sourceDatabaseName for mongodb restore', function () {
     $server = DatabaseServer::factory()->mongodb()->create();
 

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -82,6 +82,41 @@ test('restore uses pg_restore when dump_format config is custom', function () {
     );
 });
 
+test('dump keeps ownership and privileges when dump_privileges is enabled', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'dump_privileges' => true,
+    ]);
+
+    $result = $db->dump('/tmp/dump.sql');
+
+    expect($result->command)->toBe("PGPASSWORD='pg_secret' pg_dump --clean --if-exists --quote-all-identifiers --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/dump.sql'");
+});
+
+test('custom format restore keeps ownership and privileges when dump_privileges is enabled', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'dump_format' => 'custom',
+        'dump_privileges' => true,
+    ]);
+
+    $result = $db->restore('/tmp/snapshot.sql');
+
+    expect($result->command)->toBe(
+        "PGPASSWORD='pg_secret' pg_restore --clean --if-exists --jobs=4 --host='pg.local' --port='5432' --username='postgres' --dbname='myapp' '/tmp/snapshot.sql'"
+    );
+});
+
 test('restore falls back to psql when dump_format is absent', function () {
     $result = $this->db->restore('/tmp/snapshot.sql');
 

--- a/tests/Feature/Services/Backup/RestoreTaskTest.php
+++ b/tests/Feature/Services/Backup/RestoreTaskTest.php
@@ -342,6 +342,7 @@ test('execute establishes SSH tunnel when target server requires it', function (
             54321,
             'sourcedb',
             null,
+            false,
         )
         ->andReturn($mockHandler);
 


### PR DESCRIPTION
Closes #363

## What

Adds a per-server **"Backup ownership and privilege information (less portable)"** checkbox for PostgreSQL servers, defaulting to off. When enabled, the hardcoded `--no-owner` / `--no-privileges` flags are dropped from `pg_dump`, so OWNER and GRANT/REVOKE statements are preserved in the dump.

## How it affects restore

- The setting is recorded in the snapshot's metadata (`dump_privileges: true`), mirroring how `dump_format` is handled — it is a property of the snapshot file, not the destination server.
- For **custom-format** archives, `pg_restore` reads the snapshot metadata and drops `--no-owner --no-privileges` so the preserved owners/grants are actually applied. The snapshot value overrides the target server's own setting, so a legacy (privileges-stripped) snapshot restored onto a privileges-enabled server still gets the portable flags.
- **Plain-format** restores need no change: `psql -f` replays whatever SQL the dump contains.
- In the restore modal, when the selected snapshot preserved privileges, the "Transfer database ownership" field is replaced by an info alert — the dump itself sets owners, so a post-restore `REASSIGN OWNED` would be redundant or conflicting.

## Caveat (surfaced in the UI hint)

Dumps taken with this option are less portable: every role referenced by the dump must exist on the restore target, otherwise the restore reports errors. This is the trade-off the issue explicitly accepted.

## Changes

- `PostgresqlDatabase`: strips the portability flags from dump/restore options when `dump_privileges` is set
- `DatabaseProvider::makeFromConfig()`: new `$snapshotDumpPrivileges` override, same pattern as `$snapshotDumpFormat`
- `Snapshot::generateMetadata()` / `ProcessRestoreJob` / `RestoreConfig` / `RestoreTask`: plumb the flag from snapshot metadata to the handler
- `DatabaseServerForm` + `SaveDatabaseServerRequest` + `DatabaseServer::buildExtraConfig()`: validation and `extra_config` storage (UI + API)
- Server form: checkbox in the "Dump Command Configuration" collapse; the collapse open-state is now snapshotted at form load (`dump_config_open`) so toggling options no longer closes it
- Tests: dump/restore command assertions with the flag enabled, plus provider tests covering the snapshot-overrides-target behavior

## Tests

Full suite passes (1043 tests), PHPStan clean, Pint formatted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added "Include Privileges" option for PostgreSQL database backups to preserve ownership and permission statements
- Restore process now respects privilege preservation settings from snapshots and conditionally displays relevant destination configuration options

## Tests
- Added test coverage for dump privileges functionality in backup and restore operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->