### PR TITLE
fix: address code review findings from #360

### DIFF
--- a/app/Jobs/ProcessBackupJob.php
+++ b/app/Jobs/ProcessBackupJob.php
@@ -115,7 +115,11 @@ class ProcessBackupJob implements ShouldQueue
      */
     public function failed(\Throwable $exception): void
     {
-        $snapshot = Snapshot::with(['databaseServer'])->findOrFail($this->snapshotId);
+        $snapshot = Snapshot::with(['databaseServer'])->find($this->snapshotId);
+        if ($snapshot === null) {
+            return;
+        }
+
         app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
     }
 }

--- a/app/Jobs/ProcessRestoreJob.php
+++ b/app/Jobs/ProcessRestoreJob.php
@@ -113,7 +113,11 @@ class ProcessRestoreJob implements ShouldQueue
      */
     public function failed(\Throwable $exception): void
     {
-        $restore = Restore::with(['targetServer', 'snapshot'])->findOrFail($this->restoreId);
+        $restore = Restore::with(['targetServer', 'snapshot'])->find($this->restoreId);
+        if ($restore === null) {
+            return;
+        }
+
         app(NotificationService::class)->notifyRestoreFailed($restore, $exception);
     }
 }

--- a/app/Services/Backup/BackupJobFactory.php
+++ b/app/Services/Backup/BackupJobFactory.php
@@ -13,6 +13,7 @@ use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Services\Backup\Databases\DatabaseProvider;
 use App\Services\NotificationService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\ValidationException;
 
@@ -93,25 +94,28 @@ class BackupJobFactory
         ?int $triggeredByUserId = null
     ): Snapshot {
         $server = $backup->databaseServer;
-        $job = BackupJob::create(['status' => 'pending']);
         $volume = $backup->volume;
 
-        $snapshot = Snapshot::create([
-            'backup_job_id' => $job->id,
-            'database_server_id' => $server->id,
-            'backup_id' => $backup->id,
-            'volume_id' => $volume->id,
-            'filename' => '',
-            'file_size' => 0,
-            'checksum' => null,
-            'started_at' => now(),
-            'database_name' => $databaseName,
-            'database_type' => $server->database_type,
-            'compression_type' => CompressionType::from(AppConfig::get('backup.compression')),
-            'method' => $method,
-            'metadata' => Snapshot::generateMetadata($server, $databaseName, $volume),
-            'triggered_by_user_id' => $triggeredByUserId,
-        ]);
+        $snapshot = DB::transaction(function () use ($backup, $server, $volume, $databaseName, $method, $triggeredByUserId) {
+            $job = BackupJob::create(['status' => 'pending']);
+
+            return Snapshot::create([
+                'backup_job_id' => $job->id,
+                'database_server_id' => $server->id,
+                'backup_id' => $backup->id,
+                'volume_id' => $volume->id,
+                'filename' => '',
+                'file_size' => 0,
+                'checksum' => null,
+                'started_at' => now(),
+                'database_name' => $databaseName,
+                'database_type' => $server->database_type,
+                'compression_type' => CompressionType::from(AppConfig::get('backup.compression')),
+                'method' => $method,
+                'metadata' => Snapshot::generateMetadata($server, $databaseName, $volume),
+                'triggered_by_user_id' => $triggeredByUserId,
+            ]);
+        });
 
         $snapshot->load(['job', 'volume', 'databaseServer']);
 
@@ -168,6 +172,13 @@ class BackupJobFactory
         array $options = [],
         ?string $scheduledRestoreId = null,
     ): Restore {
+        $snapshot->loadMissing('job');
+        if ($snapshot->job->status !== 'completed' || $snapshot->filename === '') {
+            throw ValidationException::withMessages([
+                'snapshot_id' => 'Snapshot is not completed and cannot be restored.',
+            ]);
+        }
+
         if ($snapshot->database_type !== $targetServer->database_type) {
             throw ValidationException::withMessages([
                 'snapshot_id' => 'Snapshot database type does not match the target server.',
@@ -180,17 +191,19 @@ class BackupJobFactory
             ]);
         }
 
-        $job = BackupJob::create(['status' => 'pending']);
+        $restore = DB::transaction(function () use ($snapshot, $targetServer, $schemaName, $options, $triggeredByUserId, $scheduledRestoreId) {
+            $job = BackupJob::create(['status' => 'pending']);
 
-        $restore = Restore::create([
-            'backup_job_id' => $job->id,
-            'snapshot_id' => $snapshot->id,
-            'target_server_id' => $targetServer->id,
-            'schema_name' => $schemaName,
-            'options' => $options ?: null,
-            'triggered_by_user_id' => $triggeredByUserId,
-            'scheduled_restore_id' => $scheduledRestoreId,
-        ]);
+            return Restore::create([
+                'backup_job_id' => $job->id,
+                'snapshot_id' => $snapshot->id,
+                'target_server_id' => $targetServer->id,
+                'schema_name' => $schemaName,
+                'options' => $options ?: null,
+                'triggered_by_user_id' => $triggeredByUserId,
+                'scheduled_restore_id' => $scheduledRestoreId,
+            ]);
+        });
 
         $restore->load(['job', 'snapshot.volume', 'snapshot.databaseServer', 'targetServer']);
 

--- a/app/Services/SshTunnelService.php
+++ b/app/Services/SshTunnelService.php
@@ -73,7 +73,13 @@ class SshTunnelService
 
         $this->tunnelProcess = $this->createTunnelProcess($command);
         $this->tunnelProcess->setTimeout(null);
-        $this->tunnelProcess->start();
+
+        try {
+            $this->tunnelProcess->start();
+        } catch (\Throwable $e) {
+            $this->close();
+            throw new SshTunnelException('Failed to start SSH tunnel process: '.$e->getMessage(), previous: $e);
+        }
 
         // Wait for tunnel to be established
         if (! $this->waitForTunnel()) {

--- a/tests/Feature/Jobs/ProcessRestoreJobTest.php
+++ b/tests/Feature/Jobs/ProcessRestoreJobTest.php
@@ -15,6 +15,7 @@ test('job is configured with correct queue and settings', function () {
     $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
     $factory = app(BackupJobFactory::class);
     $snapshot = $factory->createSnapshots($server->backups->first(), 'manual')[0];
+    $snapshot->update(['filename' => 'backup.sql.gz']);
     $snapshot->job->markCompleted();
 
     $restore = $factory->createRestore($snapshot, $server, 'restored_db');
@@ -124,6 +125,7 @@ test('job can be dispatched to queue', function () {
     $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
     $factory = app(BackupJobFactory::class);
     $snapshot = $factory->createSnapshots($server->backups->first(), 'manual')[0];
+    $snapshot->update(['filename' => 'backup.sql.gz']);
     $snapshot->job->markCompleted();
 
     $restore = $factory->createRestore($snapshot, $server, 'restored_db');
@@ -141,6 +143,7 @@ test('failed method sends notification', function () {
     $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
     $factory = app(BackupJobFactory::class);
     $snapshot = $factory->createSnapshots($server->backups->first(), 'manual')[0];
+    $snapshot->update(['filename' => 'backup.sql.gz']);
     $snapshot->job->markCompleted();
 
     $restore = $factory->createRestore($snapshot, $server, 'restored_db');


### PR DESCRIPTION
## Summary

Addresses the remaining actionable findings from the code review in #360. Combined with the agent removal (#365) and the GFS retention fix (#364), this covers everything actionable from that review.

Closes #360

### Changes

- **Validate snapshot state before creating a restore** (`BackupJobFactory::createRestore()`): restores can no longer be queued from pending/failed snapshots or snapshots without a backup file. Protects all call sites at once (REST API, MCP tool, scheduled restores, UI modal), which previously accepted any snapshot ID and failed later in the worker.
- **Resilient `failed()` handlers** (`ProcessBackupJob`, `ProcessRestoreJob`): switched `findOrFail` to `find` with an early return, so the failure-notification path no longer throws if the record was deleted before retries were exhausted.
- **Transactions in `BackupJobFactory`**: `BackupJob` + `Snapshot`/`Restore` creation are now atomic, so a failed second insert can't leave orphan `backup_jobs` rows.
- **SSH temp-file cleanup on process start failure** (`SshTunnelService`): if the tunnel process fails to start, the temp key file and askpass script are now removed and the error is rethrown as `SshTunnelException`.

### Findings from #360 not addressed here (with reasons)

- *Scheduler timezone not applied*: false — Laravel natively reads `app.schedule_timezone` for all scheduled events.
- *Notification channels not org-scoped*: channels are instance-level configuration, manageable only by admins — by design.
- *Agent-related findings*: obsolete since the agent feature was removed in #365.
- *GFS retention*: already fixed in #364.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in backup and restore job processing to gracefully handle missing records without crashing
  * Enhanced database consistency through transactional operations during backup and restore creation
  * Added automatic resource cleanup and improved error reporting for SSH tunnel connection failures
  * Added validation to ensure restore operations have valid snapshot data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->