### PR TITLE
fix: exclude failed snapshots from all snapshot counters

### DIFF
--- a/app/Livewire/DatabaseServer/Show.php
+++ b/app/Livewire/DatabaseServer/Show.php
@@ -50,7 +50,9 @@ class Show extends Component
         ]);
 
         $this->server = $server;
-        $this->snapshotsCount = $server->snapshots()->count();
+        $this->snapshotsCount = $server->snapshots()
+            ->whereHas('job', fn ($q) => $q->whereRaw('status = ?', ['completed']))
+            ->count();
         $this->restoresCount = Restore::where('target_server_id', $server->id)->count();
     }
 

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -56,7 +56,7 @@ class DatabaseServerQuery
 
         return DatabaseServer::query()
             ->with(['backups.volume', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])
-            ->withCount('snapshots')
+            ->withCount(['snapshots' => fn (Builder $q) => $q->whereHas('job', fn (Builder $q) => $q->whereRaw('status = ?', ['completed']))])
             ->addSelect([
                 'restores_count' => Restore::selectRaw('count(*)')
                     ->whereColumn('target_server_id', 'database_servers.id'),

--- a/database/factories/SnapshotFactory.php
+++ b/database/factories/SnapshotFactory.php
@@ -92,6 +92,26 @@ class SnapshotFactory extends Factory
     }
 
     /**
+     * Mark the snapshot's job as completed.
+     */
+    public function completed(): static
+    {
+        return $this->afterCreating(function (Snapshot $snapshot) {
+            $snapshot->job->update(['status' => 'completed']);
+        });
+    }
+
+    /**
+     * Mark the snapshot's job as failed.
+     */
+    public function failed(): static
+    {
+        return $this->afterCreating(function (Snapshot $snapshot) {
+            $snapshot->job->update(['status' => 'failed']);
+        });
+    }
+
+    /**
      * Set the snapshot file as missing.
      */
     public function fileMissing(): static

--- a/tests/Feature/DatabaseServer/ShowTest.php
+++ b/tests/Feature/DatabaseServer/ShowTest.php
@@ -4,6 +4,7 @@ use App\Livewire\DatabaseServer\Show;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\ScheduledRestore;
+use App\Models\Snapshot;
 use App\Models\User;
 use Livewire\Livewire;
 
@@ -71,6 +72,19 @@ test('delete cascades to scheduled restores referencing the server', function ()
 
     $this->assertDatabaseMissing('scheduled_restores', ['id' => $asSource->id]);
     $this->assertDatabaseMissing('scheduled_restores', ['id' => $asTarget->id]);
+});
+
+test('snapshot counter only includes completed snapshots', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->create();
+
+    Snapshot::factory()->forServer($server)->completed()->create();
+    Snapshot::factory()->forServer($server)->completed()->create();
+    Snapshot::factory()->forServer($server)->failed()->create();
+
+    Livewire::actingAs($user)
+        ->test(Show::class, ['server' => $server])
+        ->assertSet('snapshotsCount', 2);
 });
 
 test('confirmRestore on a Redis server opens the redis info modal', function () {


### PR DESCRIPTION
## Summary

- Snapshot records are created before the backup job runs (as tracking artifacts), so a failed backup still leaves a `Snapshot` row with `job.status = 'failed'`
- Both the **index page** and the **show page** counted these, inflating the total with attempts that produced no usable data file
- Fixed both counters to only count completed jobs 
- Added `completed()` and `failed()` factory states to `SnapshotFactory`
- Added a regression test in `ShowTest`

## Test plan

- [ ] Trigger a backup that fails — counter on both index and show page should not increment
- [ ] Trigger a successful backup — counter should increment on both pages

Closes #375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot count on database server pages now displays only completed snapshots, excluding in-progress or failed snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->