### PR TITLE
fix: redirect back to origin page after editing a database server

### DIFF
--- a/app/Livewire/DatabaseServer/Edit.php
+++ b/app/Livewire/DatabaseServer/Edit.php
@@ -30,7 +30,7 @@ class Edit extends Component
         if (Gate::denies('update', $this->form->server)) {
             $this->warning(
                 title: __('Demo mode is enabled. Changes cannot be saved.'),
-                redirectTo: route('database-servers.index'),
+                redirectTo: url()->previous(route('database-servers.index')),
                 flashAs: 'demo_notice',
             );
 
@@ -40,7 +40,7 @@ class Edit extends Component
         if ($this->form->update()) {
             $this->success(
                 title: __('Database server updated successfully!'),
-                redirectTo: route('database-servers.index'),
+                redirectTo: url()->previous(route('database-servers.index')),
             );
         }
     }

--- a/app/Livewire/DatabaseServer/Edit.php
+++ b/app/Livewire/DatabaseServer/Edit.php
@@ -30,7 +30,7 @@ class Edit extends Component
         if (Gate::denies('update', $this->form->server)) {
             $this->warning(
                 title: __('Demo mode is enabled. Changes cannot be saved.'),
-                redirectTo: url()->previous(route('database-servers.index')),
+                redirectTo: $this->safeRedirectUrl(),
                 flashAs: 'demo_notice',
             );
 
@@ -40,9 +40,27 @@ class Edit extends Component
         if ($this->form->update()) {
             $this->success(
                 title: __('Database server updated successfully!'),
-                redirectTo: url()->previous(route('database-servers.index')),
+                redirectTo: $this->safeRedirectUrl(),
             );
         }
+    }
+
+    private function safeRedirectUrl(): string
+    {
+        $fallback = route('database-servers.index');
+        $previous = url()->previous($fallback);
+
+        // Reject external URLs to prevent open redirect.
+        if (parse_url($previous, PHP_URL_HOST) !== request()->getHost()) {
+            return $fallback;
+        }
+
+        // Don't redirect back to the edit page itself.
+        if ($previous === route('database-servers.edit', $this->form->server)) {
+            return $fallback;
+        }
+
+        return $previous;
     }
 
     public function addBackup(?string $defaultScheduleId = null): void

--- a/app/Livewire/DatabaseServer/Edit.php
+++ b/app/Livewire/DatabaseServer/Edit.php
@@ -59,8 +59,8 @@ class Edit extends Component
             return $fallback;
         }
 
-        // Don't redirect back to the edit page itself.
-        if ($url === route('database-servers.edit', $this->form->server)) {
+        // Don't redirect back to the edit page itself (strip query string/fragment before comparing).
+        if (strtok($url, '?#') === route('database-servers.edit', $this->form->server)) {
             return $fallback;
         }
 

--- a/app/Livewire/DatabaseServer/Edit.php
+++ b/app/Livewire/DatabaseServer/Edit.php
@@ -18,11 +18,15 @@ class Edit extends Component
 
     public DatabaseServerForm $form;
 
+    public string $returnUrl = '';
+
     public function mount(DatabaseServer $server): void
     {
         $this->authorize('viewForm', $server);
 
         $this->form->setServer($server);
+
+        $this->returnUrl = $this->safeReturnUrl(url()->previous(route('database-servers.index')));
     }
 
     public function save(): void
@@ -30,7 +34,7 @@ class Edit extends Component
         if (Gate::denies('update', $this->form->server)) {
             $this->warning(
                 title: __('Demo mode is enabled. Changes cannot be saved.'),
-                redirectTo: $this->safeRedirectUrl(),
+                redirectTo: $this->safeReturnUrl($this->returnUrl),
                 flashAs: 'demo_notice',
             );
 
@@ -40,27 +44,27 @@ class Edit extends Component
         if ($this->form->update()) {
             $this->success(
                 title: __('Database server updated successfully!'),
-                redirectTo: $this->safeRedirectUrl(),
+                redirectTo: $this->safeReturnUrl($this->returnUrl),
             );
         }
     }
 
-    private function safeRedirectUrl(): string
+    private function safeReturnUrl(string $url): string
     {
         $fallback = route('database-servers.index');
-        $previous = url()->previous($fallback);
+        $appRoot = request()->getSchemeAndHttpHost();
 
-        // Reject external URLs to prevent open redirect.
-        if (parse_url($previous, PHP_URL_HOST) !== request()->getHost()) {
+        // Same-origin only (scheme + host + port).
+        if (! str_starts_with($url, $appRoot.'/') && $url !== $appRoot) {
             return $fallback;
         }
 
         // Don't redirect back to the edit page itself.
-        if ($previous === route('database-servers.edit', $this->form->server)) {
+        if ($url === route('database-servers.edit', $this->form->server)) {
             return $fallback;
         }
 
-        return $previous;
+        return $url;
     }
 
     public function addBackup(?string $defaultScheduleId = null): void

--- a/app/Livewire/DatabaseServer/Edit.php
+++ b/app/Livewire/DatabaseServer/Edit.php
@@ -8,6 +8,7 @@ use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Gate;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Title;
 use Livewire\Component;
 
@@ -18,6 +19,7 @@ class Edit extends Component
 
     public DatabaseServerForm $form;
 
+    #[Locked]
     public string $returnUrl = '';
 
     public function mount(DatabaseServer $server): void
@@ -34,7 +36,7 @@ class Edit extends Component
         if (Gate::denies('update', $this->form->server)) {
             $this->warning(
                 title: __('Demo mode is enabled. Changes cannot be saved.'),
-                redirectTo: $this->safeReturnUrl($this->returnUrl),
+                redirectTo: $this->returnUrl,
                 flashAs: 'demo_notice',
             );
 
@@ -44,7 +46,7 @@ class Edit extends Component
         if ($this->form->update()) {
             $this->success(
                 title: __('Database server updated successfully!'),
-                redirectTo: $this->safeReturnUrl($this->returnUrl),
+                redirectTo: $this->returnUrl,
             );
         }
     }

--- a/tests/Feature/DatabaseServer/EditTest.php
+++ b/tests/Feature/DatabaseServer/EditTest.php
@@ -250,6 +250,17 @@ test('falls back to index when return url is the edit page itself', function () 
         ->assertRedirect(route('database-servers.index'));
 });
 
+test('falls back to index when return url is the edit page with a query string', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['server' => $server])
+        ->set('returnUrl', route('database-servers.edit', $server).'?tab=backups')
+        ->call('save')
+        ->assertRedirect(route('database-servers.index'));
+});
+
 test('pattern mode filters available databases and auto-loads on switch', function () {
     $user = User::factory()->create();
     $server = DatabaseServer::factory()->create();

--- a/tests/Feature/DatabaseServer/EditTest.php
+++ b/tests/Feature/DatabaseServer/EditTest.php
@@ -221,45 +221,29 @@ test('redirects to show page when arriving from show page', function () {
     $server = DatabaseServer::factory()->create();
     $showUrl = route('database-servers.show', $server);
 
+    session()->setPreviousUrl($showUrl);
+
     Livewire::actingAs($user)
         ->test(Edit::class, ['server' => $server])
-        ->set('returnUrl', $showUrl)
         ->call('save')
         ->assertRedirect($showUrl);
 });
 
-test('falls back to index when return url is external', function () {
+test('falls back to index when the previous url is unsafe', function (Closure $previousUrl) {
     $user = User::factory()->create();
     $server = DatabaseServer::factory()->create();
 
-    Livewire::actingAs($user)
-        ->test(Edit::class, ['server' => $server])
-        ->set('returnUrl', 'https://evil.com/steal-tokens')
-        ->call('save')
-        ->assertRedirect(route('database-servers.index'));
-});
-
-test('falls back to index when return url is the edit page itself', function () {
-    $user = User::factory()->create();
-    $server = DatabaseServer::factory()->create();
+    session()->setPreviousUrl($previousUrl($server));
 
     Livewire::actingAs($user)
         ->test(Edit::class, ['server' => $server])
-        ->set('returnUrl', route('database-servers.edit', $server))
         ->call('save')
         ->assertRedirect(route('database-servers.index'));
-});
-
-test('falls back to index when return url is the edit page with a query string', function () {
-    $user = User::factory()->create();
-    $server = DatabaseServer::factory()->create();
-
-    Livewire::actingAs($user)
-        ->test(Edit::class, ['server' => $server])
-        ->set('returnUrl', route('database-servers.edit', $server).'?tab=backups')
-        ->call('save')
-        ->assertRedirect(route('database-servers.index'));
-});
+})->with([
+    'external host' => [fn ($server) => 'https://evil.com/steal-tokens'],
+    'edit page itself' => [fn ($server) => route('database-servers.edit', $server)],
+    'edit page with query string' => [fn ($server) => route('database-servers.edit', $server).'?tab=backups'],
+]);
 
 test('pattern mode filters available databases and auto-loads on switch', function () {
     $user = User::factory()->create();

--- a/tests/Feature/DatabaseServer/EditTest.php
+++ b/tests/Feature/DatabaseServer/EditTest.php
@@ -216,6 +216,40 @@ test('refreshVolumes can be called without error', function () {
         ->assertOk();
 });
 
+test('redirects to show page when arriving from show page', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->create();
+    $showUrl = route('database-servers.show', $server);
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['server' => $server])
+        ->set('returnUrl', $showUrl)
+        ->call('save')
+        ->assertRedirect($showUrl);
+});
+
+test('falls back to index when return url is external', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['server' => $server])
+        ->set('returnUrl', 'https://evil.com/steal-tokens')
+        ->call('save')
+        ->assertRedirect(route('database-servers.index'));
+});
+
+test('falls back to index when return url is the edit page itself', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Edit::class, ['server' => $server])
+        ->set('returnUrl', route('database-servers.edit', $server))
+        ->call('save')
+        ->assertRedirect(route('database-servers.index'));
+});
+
 test('pattern mode filters available databases and auto-loads on switch', function () {
     $user = User::factory()->create();
     $server = DatabaseServer::factory()->create();


### PR DESCRIPTION
## Summary

- After saving an edit, the user was always redirected to the index page — even when they arrived from the show page
- Replaced with `url()->previous(route('database-servers.index'))` so the user is returned to wherever they came from, with the index as a safe fallback

## Test plan

- [ ] Navigate to edit from the **index** page → saving redirects back to index
- [ ] Navigate to edit from the **show** page → saving redirects back to show
- [ ] Direct URL access to edit page → saving falls back to index


Closes #376

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “save” redirect behavior in the database server edit flow by returning users to a validated previous page when available.
  * Added protection against unsafe/external redirects and ensured same-origin-only navigation with a safe fallback to the database servers list.
  * Prevents redirecting back to the current edit page, including cases with query strings.
* **Tests**
  * Added feature test coverage for safe return behavior (including returning to a show page) and fallback behavior for unsafe previous URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->