### PR TITLE
Harden Docker image dependencies (mongo tools, sqlpackage arm64, jmespath)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4250,16 +4250,16 @@
         },
         {
             "name": "mtdowling/jmespath.php",
-            "version": "2.8.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmespath/jmespath.php.git",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
-                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/9c208ba27ae7d90853c288b3795d6702eb251d34",
+                "reference": "9c208ba27ae7d90853c288b3795d6702eb251d34",
                 "shasum": ""
             },
             "require": {
@@ -4268,7 +4268,7 @@
             },
             "require-dev": {
                 "composer/xdebug-handler": "^3.0.3",
-                "phpunit/phpunit": "^8.5.33"
+                "phpunit/phpunit": "^8.5.52"
             },
             "bin": [
                 "bin/jp.php"
@@ -4276,7 +4276,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.8-dev"
+                    "dev-master": "2.9-dev"
                 }
             },
             "autoload": {
@@ -4310,9 +4310,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmespath/jmespath.php/issues",
-                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.1"
             },
-            "time": "2024-09-04T18:46:31+00:00"
+            "time": "2026-06-11T10:43:56+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -52,8 +52,24 @@ RUN apk add --no-cache git \
         procps-ng \
         ncurses-libs
 
-# Install MongoDB tools (mongodump, mongorestore) from Alpine edge community repo
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community mongodb-tools
+# Install MongoDB tools — only mongodump + mongorestore, the binaries the app
+# uses. From MongoDB's official archive (newer than Alpine's edge package); the
+# glibc builds run on Alpine via the gcompat layer, like the Firebird binaries.
+# Refresh from https://www.mongodb.com/try/download/database-tools when bumping.
+ARG MONGODB_TOOLS_VERSION=100.17.0
+ARG TARGETARCH
+RUN case "${TARGETARCH}" in \
+        amd64) MONGO_ARCH=x86_64 ;; \
+        arm64) MONGO_ARCH=arm64 ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL -o /tmp/mtools.tgz \
+        "https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-${MONGO_ARCH}-${MONGODB_TOOLS_VERSION}.tgz" \
+    && tar xzf /tmp/mtools.tgz -C /tmp \
+    && cp /tmp/mongodb-database-tools-*/bin/mongodump \
+          /tmp/mongodb-database-tools-*/bin/mongorestore /usr/local/bin/ \
+    && chmod +x /usr/local/bin/mongodump /usr/local/bin/mongorestore \
+    && rm -rf /tmp/mtools.tgz /tmp/mongodb-database-tools-*
 
 # Install .NET 8 ASP.NET runtime (required by sqlpackage). Pulled from edge/community
 # because Alpine stable repos lag behind the .NET LTS Microsoft supports for musl.


### PR DESCRIPTION
## Summary

Reduces vulnerabilities and fixes a multi-arch packaging bug in the Docker image, surfaced by a Snyk scan of `davidcrty/databasement:latest`.

### MongoDB tools
- Switch from Alpine edge's `mongodb-tools` package (pinned to `100.14.1-r3`, built against an old `golang.org/x/net`) to MongoDB's **official `100.17.0`** archive, which links the patched `golang.org/x/net v0.47.0`.
- **Install only `mongodump` + `mongorestore`** — the only mongo binaries the app uses (verified across app/tests/scripts/CI). The 6 unused binaries (`mongoimport`, `mongoexport`, `mongostat`, `mongotop`, `mongofiles`, `bsondump`) are no longer in the image.
- `TARGETARCH`-aware for both `linux/amd64` and `linux/arm64`. The official builds are glibc (no musl target exists) and run on Alpine via the existing `gcompat`/`libc6-compat` layer — the same approach already used for the Firebird binaries.

Net effect: all 16 mongo-tools findings (8 critical + 8 high) clear — 12 from removing the unused binaries, 4 from the patched `x/net`.

### sqlpackage — arm64 fix
- Previously the install hardcoded the **self-contained x64** zip, but CI builds `linux/arm64` too — so arm64 images shipped a non-functional x86 `sqlpackage` (silent: the build step never executes the binary).
- Microsoft ships **no arm64 build** of sqlpackage — only the x64 self-contained zip. Their supported arm64 path is the **framework-dependent `dotnet tool`**, which runs on whatever arch's .NET runtime is present.
- Build that tool in a multi-arch `mcr.microsoft.com/dotnet/sdk:8.0-alpine` stage and `COPY` it into the final image (keeps the ~750 MB SDK out of the runtime image). It runs on the `aspnetcore8-runtime` already installed, on both amd64 and arm64.

### Composer
- Bump `mtdowling/jmespath.php` `2.8.0 → 2.9.1` (transitive via `aws/aws-sdk-php`, already within its `^2.8.0` constraint).

## Testing
Built the amd64 image locally, recreated the app container on it, and ran the integration suite against live service containers:
- **MongoDB**: only `mongodump`/`mongorestore` (100.17.0) present; `mongodb backup and restore workflow` passes — real dump → restore under Alpine/musl, exercising the network path.
- **sqlpackage**: reports `170.3.93.6`, framework-dependent runtimeconfig; `mssql backup and restore workflow` passes (full backup + restore).
- arm64 runtime not exercised locally (amd64 host); both tools use their documented arch-agnostic mechanisms and CI's QEMU multi-arch build covers them.