### PR TITLE
ci: monitor latest Docker image with Snyk

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -168,3 +168,26 @@ jobs:
           echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "Base image: \`davidcrty/databasement-php:${{ needs.build-base-image.outputs.base_image_tag }}\`" >> $GITHUB_STEP_SUMMARY
+
+  snyk-monitor:
+    runs-on: ubuntu-latest
+    needs: build-app-image
+    # Only when the `latest` tag was (re)published, i.e. a push to the default branch.
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Snyk CLI
+        uses: snyk/actions/setup@master
+
+      - name: Monitor latest image in Snyk
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          snyk container monitor davidcrty/databasement:latest \
+            --file=Dockerfile \
+            --platform=linux/amd64 \
+            --project-name=databasement \
+            --project-tags=image=latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -178,6 +178,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Snyk CLI
         uses: snyk/actions/setup@master


### PR DESCRIPTION
## What

Adds a `snyk-monitor` job to `.github/workflows/docker.yml` that runs `snyk container monitor` on `davidcrty/databasement:latest`, posting a snapshot to the Snyk dashboard.

## When it runs

Only on pushes to `main` (`if: github.ref == 'refs/heads/main'`) — i.e. exactly when the `latest` tag is (re)published. Version tags (`v*`) don't update `latest`, so they don't trigger a scan. Runs after `build-app-image` so it scans the freshly-pushed image.

## Notes

- Uses `snyk container monitor` (dashboard snapshot), **not** `test` — it never fails the build.
- `--file=Dockerfile` lets Snyk attribute findings to base vs. app layers.
- Requires the `SNYK_TOKEN` secret (already configured, backed by an Org Collaborator service account).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated security monitoring for container images. On main branch builds, the application image is now scanned for vulnerabilities using Snyk and reported under a dedicated project with an `image=latest` tag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->