### PR TITLE
docs: add dedicated SSH Tunnel page

### DIFF
--- a/docs/docs/user-guide/api.md
+++ b/docs/docs/user-guide/api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # REST API

--- a/docs/docs/user-guide/backups.md
+++ b/docs/docs/user-guide/backups.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Backups

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -351,13 +351,6 @@ Ensure your firewall allows connections:
 
 ## SSH Tunnel
 
-Connect to databases in private networks through a bastion/jump server. Enable this when the database isn't directly accessible from Databasement.
+Connect to databases that aren't directly reachable from Databasement — in private networks, behind a bastion/jump host, or on a remote Docker host whose database ports aren't exposed. Databasement opens the tunnel before each backup/restore and closes it afterward, with credentials encrypted at rest.
 
-| Field | Description |
-|-------|-------------|
-| SSH Host | Bastion server hostname or IP |
-| SSH Port | SSH port (default: 22) |
-| SSH Username | SSH user |
-| Auth Type | `Password` or `Private Key` (with optional passphrase) |
-
-Databasement establishes the tunnel before each backup/restore operation and closes it when complete. Sensitive credentials are encrypted at rest.
+See [SSH Tunnel](./ssh-tunnel.md) for configuration and for backing up databases on a remote host.

--- a/docs/docs/user-guide/mcp.md
+++ b/docs/docs/user-guide/mcp.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 ---
 
 # MCP Server

--- a/docs/docs/user-guide/organizations.md
+++ b/docs/docs/user-guide/organizations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 ---
 
 # Organizations

--- a/docs/docs/user-guide/permissions.md
+++ b/docs/docs/user-guide/permissions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 8
 ---
 
 # Permissions

--- a/docs/docs/user-guide/snapshots.md
+++ b/docs/docs/user-guide/snapshots.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Snapshots

--- a/docs/docs/user-guide/ssh-tunnel.md
+++ b/docs/docs/user-guide/ssh-tunnel.md
@@ -1,0 +1,56 @@
+---
+sidebar_position: 3
+---
+
+# SSH Tunnel
+
+Connect to databases that aren't directly reachable from Databasement: in private networks, behind a bastion/jump host, or on a remote Docker host whose database ports aren't published.
+
+:::info How it works
+Databasement runs `ssh -N -L <localPort>:<host>:<port>` before each backup or restore and closes it afterward, where `<host>` and `<port>` are the **Host** and **Port** set on the database server (resolved from the SSH server's side). SSH credentials are encrypted at rest.
+:::
+
+:::note No database tools needed on the SSH host
+The tunnel only forwards TCP. The dump and restore tools (`mariadb-dump`, `pg_dump`, `mongodump`, and so on) run inside the Databasement container and connect *through* the tunnel — the SSH host needs only `sshd` and network access to the database, not any database client installed.
+:::
+
+## Configuration
+
+Enable **SSH Tunnel** on the database server and point it at the SSH host:
+
+| Field | Description |
+|-------|-------------|
+| SSH Host | SSH server hostname or IP (bastion, jump host, or remote Docker host) |
+| SSH Port | SSH port (default: 22) |
+| SSH Username | SSH user |
+| Auth Type | `Password` or `Private Key` (with optional passphrase) |
+
+Databasement connects with `StrictHostKeyChecking=accept-new` (the host key is trusted on first connection). Keys and passphrases are never exposed in process arguments.
+
+## Backing up databases on a remote host
+
+When databases run in Docker containers on a remote machine with ports only on an internal network, the tunnel reuses the **same SSH access you already use to manage that host** — no separate agent or "SSH container" is needed, and the database stays private.
+
+Publish the database port to the host's loopback, so it's reachable from the host but not from the network:
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    ports:
+      - "127.0.0.1:5432:5432"
+```
+
+Set the database **Host** to `127.0.0.1` and **Port** to `5432`. Loopback is exactly where the tunnel terminates, so Databasement can reach the database while the network cannot.
+
+For same-host containers sharing a Docker network (no SSH), see [Docker Networking](./database-servers.md#docker-networking) instead.
+
+## Security
+
+:::info Hardening the SSH tunnel
+Disable password auth (`PasswordAuthentication no`) and use a dedicated, least-privilege key. Restrict it in `authorized_keys` to forwarding only:
+
+```
+restrict,permitopen="127.0.0.1:5432",no-pty,no-X11-forwarding ssh-ed25519 AAAA... databasement-tunnel
+```
+:::

--- a/docs/docs/user-guide/ssh-tunnel.md
+++ b/docs/docs/user-guide/ssh-tunnel.md
@@ -7,11 +7,11 @@ sidebar_position: 3
 Connect to databases that aren't directly reachable from Databasement: in private networks, behind a bastion/jump host, or on a remote Docker host whose database ports aren't published.
 
 :::info How it works
-Databasement runs `ssh -N -L <localPort>:<host>:<port>` before each backup or restore and closes it afterward, where `<host>` and `<port>` are the **Host** and **Port** set on the database server (resolved from the SSH server's side). SSH credentials are encrypted at rest.
+Databasement runs `ssh -N -L <localPort>:<host>:<port>` before each backup or restore and closes it afterward. SSH credentials are encrypted at rest.
 :::
 
 :::note No database tools needed on the SSH host
-The tunnel only forwards TCP. The dump and restore tools (`mariadb-dump`, `pg_dump`, `mongodump`, and so on) run inside the Databasement container and connect *through* the tunnel — the SSH host needs only `sshd` and network access to the database, not any database client installed.
+The dump and restore tools (`mariadb-dump`, `pg_dump`, `mongodump`, and so on) run inside the Databasement container and are NOT NEEDED on the SSH host.
 :::
 
 ## Configuration
@@ -25,11 +25,9 @@ Enable **SSH Tunnel** on the database server and point it at the SSH host:
 | SSH Username | SSH user |
 | Auth Type | `Password` or `Private Key` (with optional passphrase) |
 
-Databasement connects with `StrictHostKeyChecking=accept-new` (the host key is trusted on first connection). Keys and passphrases are never exposed in process arguments.
-
 ## Backing up databases on a remote host
 
-When databases run in Docker containers on a remote machine with ports only on an internal network, the tunnel reuses the **same SSH access you already use to manage that host** — no separate agent or "SSH container" is needed, and the database stays private.
+When databases run in Docker containers on a remote machine with ports only on an internal network, the tunnel reuses the **same SSH access you already use to manage that host** — no separate agent is needed, and the database stays private.
 
 Publish the database port to the host's loopback, so it's reachable from the host but not from the network:
 
@@ -43,14 +41,29 @@ services:
 
 Set the database **Host** to `127.0.0.1` and **Port** to `5432`. Loopback is exactly where the tunnel terminates, so Databasement can reach the database while the network cannot.
 
+### Optional: SSH server in the stack
+
+If the host doesn't expose SSH — or you'd rather not publish the database port at all — add a small SSH server to the database's network. Only the SSH port is published; Databasement reaches the database by its container name over the internal network.
+
+```yaml
+services:
+  db:
+    image: postgres:16
+    networks: [internal]
+
+  sshd:
+    image: lscr.io/linuxserver/openssh-server
+    environment:
+      USER_NAME: databasement
+      PUBLIC_KEY: "ssh-ed25519 AAAA... databasement-tunnel"
+    ports:
+      - "2222:2222"   # only SSH is published — not the database
+    networks: [internal]
+
+networks:
+  internal:
+```
+
+Point the SSH Tunnel at the host on port `2222`, then set the database **Host** to `db` and **Port** to `5432` — the service name resolves on the SSH container's network.
+
 For same-host containers sharing a Docker network (no SSH), see [Docker Networking](./database-servers.md#docker-networking) instead.
-
-## Security
-
-:::info Hardening the SSH tunnel
-Disable password auth (`PasswordAuthentication no`) and use a dedicated, least-privilege key. Restrict it in `authorized_keys` to forwarding only:
-
-```
-restrict,permitopen="127.0.0.1:5432",no-pty,no-X11-forwarding ssh-ed25519 AAAA... databasement-tunnel
-```
-:::

--- a/docs/docs/user-guide/ssh-tunnel.md
+++ b/docs/docs/user-guide/ssh-tunnel.md
@@ -43,13 +43,12 @@ Set the database **Host** to `127.0.0.1` and **Port** to `5432`. Loopback is exa
 
 ### Optional: SSH server in the stack
 
-If the host doesn't expose SSH — or you'd rather not publish the database port at all — add a small SSH server to the database's network. Only the SSH port is published; Databasement reaches the database by its container name over the internal network.
+If the host doesn't expose SSH — or you'd rather not publish the database port at all — add a small SSH server to the same Compose project. Only the SSH port is published; Databasement reaches the database by its service name over the project's default network.
 
 ```yaml
 services:
   db:
     image: postgres:16
-    networks: [internal]
 
   sshd:
     image: lscr.io/linuxserver/openssh-server
@@ -58,12 +57,8 @@ services:
       PUBLIC_KEY: "ssh-ed25519 AAAA... databasement-tunnel"
     ports:
       - "2222:2222"   # only SSH is published — not the database
-    networks: [internal]
-
-networks:
-  internal:
 ```
 
-Point the SSH Tunnel at the host on port `2222`, then set the database **Host** to `db` and **Port** to `5432` — the service name resolves on the SSH container's network.
+Point the SSH Tunnel at the host on port `2222`, then set the database **Host** to `db` and **Port** to `5432` — the service name resolves on the project's default network.
 
 For same-host containers sharing a Docker network (no SSH), see [Docker Networking](./database-servers.md#docker-networking) instead.

--- a/docs/docs/user-guide/ssh-tunnel.md
+++ b/docs/docs/user-guide/ssh-tunnel.md
@@ -25,6 +25,14 @@ Enable **SSH Tunnel** on the database server and point it at the SSH host:
 | SSH Username | SSH user |
 | Auth Type | `Password` or `Private Key` (with optional passphrase) |
 
+### Reusing an SSH configuration
+
+Once you've saved an SSH config, the form offers **Use existing** (pick a saved config) or **Set up a new SSH config**. Reusing one lets several database servers share the same host connection — update it once and every server that references it follows.
+
+### Generating an SSH key
+
+With **Auth Type** set to **Private Key**, the form can **Generate a new Ed25519 keypair** for you. Copy the displayed public key into `~/.ssh/authorized_keys` on the SSH server before saving — it's shown only once and the public key isn't stored.
+
 ## Backing up databases on a remote host
 
 When databases run in Docker containers on a remote machine with ports only on an internal network, the tunnel reuses the **same SSH access you already use to manage that host** — no separate agent is needed, and the database stays private.
@@ -48,13 +56,14 @@ If the host doesn't expose SSH — or you'd rather not publish the database port
 ```yaml
 services:
   db:
-    image: postgres:16
+    image: postgres:18
 
   sshd:
     image: lscr.io/linuxserver/openssh-server
     environment:
       USER_NAME: databasement
       PUBLIC_KEY: "ssh-ed25519 AAAA... databasement-tunnel"
+      DOCKER_MODS: linuxserver/mods:openssh-server-ssh-tunnel
     ports:
       - "2222:2222"   # only SSH is published — not the database
 ```
@@ -62,3 +71,16 @@ services:
 Point the SSH Tunnel at the host on port `2222`, then set the database **Host** to `db` and **Port** to `5432` — the service name resolves on the project's default network.
 
 For same-host containers sharing a Docker network (no SSH), see [Docker Networking](./database-servers.md#docker-networking) instead.
+
+## Security
+
+:::info Keep the database private
+What matters most is that the database is not reachable from the public internet: either because its host is on a private network, or because you bound the port to loopback (`127.0.0.1:5432:5432`).
+:::
+
+Optionally, restrict the SSH key to forwarding only in `authorized_keys`:
+
+```
+restrict,port-forwarding ssh-ed25519 AAAA... databasement-tunnel
+```
+

--- a/docs/docs/user-guide/volumes.md
+++ b/docs/docs/user-guide/volumes.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Storage Volumes


### PR DESCRIPTION
## What

Adds a dedicated **SSH Tunnel** page (`docs/docs/user-guide/ssh-tunnel.md`) and reduces the `SSH Tunnel` section in `database-servers.md` to a short cross-link.

Addresses #374 — how to back up databases in Docker containers on a remote host whose ports aren't exposed.

## Page contents

- How the tunnel works (`ssh -N -L`, forward target resolved on the SSH-host side).
- **No database tools are needed on the SSH host** — dump tools run in the Databasement container and connect through the tunnel.
- Configuration field table.
- Remote-host backup: publish the DB port to host loopback (`127.0.0.1:5432:5432`) and tunnel to it; the DB stays private and reuses existing SSH access (no agent / no SSH container).
- Security: key-only auth + a forwarding-only `authorized_keys` restriction.

## Other

- Renumbers the user-guide sidebar to insert SSH Tunnel at position 3 (also fixes the pre-existing position-5 collision between Volumes and Organizations).
- `npm run build` passes (no broken links / MDX errors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “SSH Tunnel” user guide page explaining local port-forwarding used for each backup/restore, including that tunnels are created and closed per operation and that SSH credentials are encrypted at rest.
  * Reworked the “SSH Tunnel” section in the database-servers guide to improve clarity around the tunnel workflow and security guidance.
  * Updated user-guide sidebar ordering across multiple pages for improved navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->