### PR TITLE
ci: address SonarQube findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN php artisan vendor:publish --force --tag=livewire:assets
 FROM node:22-slim AS frontend-build
 
 WORKDIR /app
-COPY package.json .
-RUN npm install
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
 
 COPY --from=backend-build /app /app
 RUN npm run build

--- a/app/Services/AdminerService.php
+++ b/app/Services/AdminerService.php
@@ -20,7 +20,7 @@ class AdminerService
         $this->defineAdminerObject();
 
         chdir($vendorAdminer);
-        include $vendorAdminer.'/adminer.php';
+        include_once $vendorAdminer.'/adminer.php';
     }
 
     /**


### PR DESCRIPTION
## Summary
Resolves SonarQube findings flagged on the codebase.

### Dockerfile
- Replace `npm install` with `npm ci --ignore-scripts`:
  - **Locked, resolved versions** — `npm ci` installs from `package-lock.json` (now copied into the frontend-build stage alongside `package.json`).
  - **`--ignore-scripts`** — skips lifecycle scripts. The only one defined is `prepare: husky`, which is git-hook setup and irrelevant inside the image.

### AdminerService
- Use `include_once` instead of `include` for `adminer.php` to prevent accidental double-inclusion.

## Testing
- Built the Docker image locally — `npm ci --ignore-scripts` succeeds and `vite build` produces all assets (`app-*.js`, `app-*.css`, `adminer-*.css`, `manifest.json`).
- `vendor/bin/pint --dirty` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential multiple file inclusion issue in admin service.

* **Chores**
  * Improved build process with locked dependency installation for consistent, reproducible builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->