### PR TITLE
docs: document remote agents + reusable agent status indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 
 - **Multi-database support** - Manage MySQL, PostgreSQL, MariaDB, Microsoft SQL Server, MongoDB, SQLite, Firebird, and Redis/Valkey servers from a single interface
 - **SSH tunnel support** - Connect to databases in private networks through a bastion/jump server with password or key-based authentication
+- **Remote agents** - Back up databases in firewalled or isolated networks with no inbound port: a lightweight agent connects out over HTTPS, dumps locally, and uploads to your storage
 - **Automated backups** - Schedule recurring backups on daily or weekly intervals. Flexible retention policies: simple time-based (days) or GFS (grandfather-father-son)
 - **Multiple compression options** - gzip, zstd (20-40% better compression), or encrypted (AES-256 for sensitive data)
 - **Cross-server restore** - Restore snapshots from production to staging, or between any compatible servers

--- a/app/Models/Agent.php
+++ b/app/Models/Agent.php
@@ -69,4 +69,16 @@ class Agent extends Model
         return $this->last_heartbeat_at !== null
             && $this->last_heartbeat_at->isAfter(now()->subMinutes(1));
     }
+
+    /**
+     * Connection status for display: 'online', 'offline', or 'never'.
+     */
+    public function connectionStatus(): string
+    {
+        if ($this->isOnline()) {
+            return 'online';
+        }
+
+        return $this->last_heartbeat_at !== null ? 'offline' : 'never';
+    }
 }

--- a/docs/docs/user-guide/agents.md
+++ b/docs/docs/user-guide/agents.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 4
+---
+
+# Remote Agents
+
+A remote **agent** backs up databases that Databasement cannot reach directly — without opening any inbound port to them.
+
+Instead of Databasement connecting **in** to your database (as an [SSH tunnel](./ssh-tunnel.md) does), you run a small agent next to the database that connects **out** to Databasement. The database stays completely private; only outbound HTTPS is ever needed.
+
+:::info Egress, not ingress
+The SSH tunnel needs **inbound** access (Databasement reaches into the network). An agent needs only **outbound** HTTPS. That makes it the right fit for hardened, firewalled, or multi-tenant environments where opening inbound ports is forbidden.
+:::
+
+## How it works
+
+The agent is the same Databasement image running in agent mode (`agent:run`). It polls the server over HTTPS, claims any job assigned to it, runs the dump on its own network, uploads the result straight to your storage volume, and reports back. It never receives an inbound connection and never touches the server's database.
+
+```
+  ┌─────────────────────── your private network ──────────────────────┐
+  │                                                                    │
+  │   ┌──────────┐        ┌──────────────┐        ┌──────────────┐     │
+  │   │ Database │◄───────│    Agent     │───────►│    Volume    │     │
+  │   └──────────┘  dump  │ (agent:run)  │ upload │ (S3 / SFTP)  │     │
+  │                       └──────┬───────┘        └──────────────┘     │
+  │                              │                                     │
+  └──────────────────────────────┼─────────────────────────────────────┘
+                                 │  outbound HTTPS only
+                                 │  (poll → claim → report)
+                                 ▼
+                       ┌──────────────────┐
+                       │   Databasement   │
+                       │      server      │
+                       └──────────────────┘
+```
+
+1. **Poll** — the agent sends a heartbeat and asks the server for work.
+2. **Claim** — the server hands back a job describing the database, the schedule, and the destination volume.
+3. **Run** — the agent dumps the database (it reaches it on the local network) and uploads the snapshot to the volume.
+4. **Report** — the agent acknowledges the result (filename, size, checksum, logs) so the snapshot shows up in the UI like any other.
+
+## When to use an agent
+
+- The database lives in a network where **no inbound port** can be opened (compliance, firewall, customer-managed VPC).
+- You back up databases in **many isolated networks** and want one Databasement server orchestrating them all over HTTPS.
+- An [SSH tunnel](./ssh-tunnel.md) isn't possible because there's no SSH host to reach.
+
+If you *can* reach the database directly or over SSH, prefer that — it's simpler. The agent's unique value is the outbound-only connectivity.
+
+## Setup
+
+1. **Create an agent** — go to **Agents → Add Agent**, then copy the token shown once on creation.
+2. **Run the agent** next to your database, pointing it at your server:
+
+   ```bash
+   docker run -d --restart unless-stopped \
+     --name databasement-agent \
+     -e DATABASEMENT_URL='https://databasement.example.com' \
+     -e DATABASEMENT_AGENT_TOKEN='<paste-token>' \
+     davidcrty/databasement:1
+   ```
+
+   When `DATABASEMENT_URL` is set, the container runs in agent mode — it only executes `agent:run` and needs no database configuration of its own.
+
+3. **Assign the agent** to a database server by setting its **Agent** field. From then on, that server's backups run through the agent.
+
+The **Agents** page shows each agent's connection status, so you can confirm it's polling.
+
+## Constraints
+
+- **No local volume** — the agent uploads from its own network, so it must use a reachable destination (S3-compatible or SFTP/FTP), not the server's local storage.
+- **Backups only** — restore is not available for agent-backed servers.

--- a/docs/docs/user-guide/api.md
+++ b/docs/docs/user-guide/api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # REST API

--- a/docs/docs/user-guide/backups.md
+++ b/docs/docs/user-guide/backups.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
 # Backups

--- a/docs/docs/user-guide/mcp.md
+++ b/docs/docs/user-guide/mcp.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # MCP Server

--- a/docs/docs/user-guide/organizations.md
+++ b/docs/docs/user-guide/organizations.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 
 # Organizations

--- a/docs/docs/user-guide/permissions.md
+++ b/docs/docs/user-guide/permissions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Permissions

--- a/docs/docs/user-guide/permissions.md
+++ b/docs/docs/user-guide/permissions.md
@@ -40,6 +40,18 @@ Adminer access is enabled by default for Admins only. A Super Admin can change t
 | Edit      |   ❌    |   ✅    |   ✅   |
 | Delete    |   ❌    |   ✅    |   ✅   |
 
+### Agents
+
+| Action           | Viewer | Member | Admin |
+|------------------|:------:|:------:|:-----:|
+| View list        |   ✅    |   ✅    |   ✅   |
+| Create           |   ❌    |   ✅    |   ✅   |
+| Edit             |   ❌    |   ✅    |   ✅   |
+| Regenerate token |   ❌    |   ✅    |   ✅   |
+| Delete           |   ❌    |   ✅    |   ✅   |
+
+See [Remote Agents](./agents.md) for how agents back up databases in firewalled or isolated networks.
+
 ### Snapshots
 
 | Action       | Viewer | Member | Admin |

--- a/docs/docs/user-guide/snapshots.md
+++ b/docs/docs/user-guide/snapshots.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Snapshots

--- a/docs/docs/user-guide/volumes.md
+++ b/docs/docs/user-guide/volumes.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Storage Volumes

--- a/resources/views/components/agent-status-indicator.blade.php
+++ b/resources/views/components/agent-status-indicator.blade.php
@@ -1,0 +1,17 @@
+@props([
+    'status',
+    'label' => null,
+])
+
+@php
+    [$badgeClass, $icon, $defaultLabel] = match ($status) {
+        'online' => ['badge-success', 'o-signal', __('Online')],
+        'offline' => ['badge-error', 'o-signal-slash', __('Offline')],
+        'never' => ['badge-ghost', 'o-clock', __('Never connected')],
+        default => ['badge-ghost', 'o-question-mark-circle', __(ucfirst((string) $status))],
+    };
+    $resolvedLabel = $label ?? $defaultLabel;
+    $baseClass = $badgeClass.' badge-sm gap-1 whitespace-nowrap';
+@endphp
+
+<x-badge :value="$resolvedLabel" :icon="$icon" {{ $attributes->class([$baseClass]) }} />

--- a/resources/views/livewire/agent/index.blade.php
+++ b/resources/views/livewire/agent/index.blade.php
@@ -28,6 +28,15 @@
 
     <x-alert class="alert-info alert-vertical sm:alert-horizontal rounded-md mb-4" icon="o-information-circle">
         {{ __('Agents run on remote networks to back up database servers that are not directly accessible. They are optional, you only need them if your servers are behind a firewall or private network.') }}
+        <x-slot:actions>
+            <x-button
+                :label="__('Learn more')"
+                link="https://david-crty.github.io/databasement/user-guide/agents"
+                external
+                icon="o-book-open"
+                class="btn-sm"
+            />
+        </x-slot:actions>
     </x-alert>
 
     <!-- SEARCH (Mobile) -->
@@ -63,19 +72,7 @@
             @endscope
 
             @scope('cell_status', $agent)
-                @if($agent->isOnline())
-                    <span class="badge badge-success badge-sm gap-1 whitespace-nowrap">
-                        <span class="w-2 h-2 rounded-full bg-success animate-pulse"></span>
-                        {{ __('Online') }}
-                    </span>
-                @elseif($agent->last_heartbeat_at)
-                    <span class="badge badge-warning badge-sm gap-1 whitespace-nowrap">
-                        <span class="w-2 h-2 rounded-full bg-warning"></span>
-                        {{ __('Offline') }}
-                    </span>
-                @else
-                    <span class="badge badge-ghost badge-sm whitespace-nowrap">{{ __('Never connected') }}</span>
-                @endif
+                <x-agent-status-indicator :status="$agent->connectionStatus()" />
             @endscope
 
             @scope('cell_servers', $agent)

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -9,7 +9,15 @@
 
     <x-alert icon="o-information-circle" class="alert-info mb-4">
         {{ __('Organizations let you group users, servers, and volumes into isolated workspaces.') }}
-        <a href="https://david-crty.github.io/databasement/docs/user-guide/organizations" target="_blank" rel="noopener noreferrer" class="link link-primary">{{ __('Learn more') }}</a>
+        <x-slot:actions>
+            <x-button
+                :label="__('Learn more')"
+                link="https://david-crty.github.io/databasement/user-guide/organizations"
+                external
+                icon="o-book-open"
+                class="btn-sm"
+            />
+        </x-slot:actions>
     </x-alert>
 
     <div class="flex justify-end mb-4">

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -66,20 +66,9 @@ use App\Enums\DatabaseType;
                                     @php $selectedAgent = $form->getSelectedAgent(); @endphp
                                     @if($selectedAgent)
                                         <div class="flex items-center gap-2 text-sm">
-                                            @if($selectedAgent->isOnline())
-                                                <span class="badge badge-success badge-sm gap-1">
-                                                    <span class="w-2 h-2 rounded-full bg-success animate-pulse"></span>
-                                                    {{ __('Online') }}
-                                                </span>
+                                            <x-agent-status-indicator :status="$selectedAgent->connectionStatus()" />
+                                            @if($selectedAgent->last_heartbeat_at)
                                                 <span class="text-base-content/70">{{ __('Last heartbeat :time', ['time' => $selectedAgent->last_heartbeat_at->diffForHumans()]) }}</span>
-                                            @elseif($selectedAgent->last_heartbeat_at)
-                                                <span class="badge badge-warning badge-sm gap-1">
-                                                    <span class="w-2 h-2 rounded-full bg-warning"></span>
-                                                    {{ __('Offline') }}
-                                                </span>
-                                                <span class="text-base-content/70">{{ __('Last heartbeat :time', ['time' => $selectedAgent->last_heartbeat_at->diffForHumans()]) }}</span>
-                                            @else
-                                                <span class="badge badge-ghost badge-sm">{{ __('Never connected') }}</span>
                                             @endif
                                         </div>
                                     @endif

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -412,10 +412,6 @@
 
             {{-- Agent --}}
             @if($agent)
-                @php
-                    $online = $agent->isOnline();
-                    $neverConnected = $agent->last_heartbeat_at === null;
-                @endphp
                 <div class="card card-border bg-base-100 shadow-sm overflow-hidden">
                     <div class="flex items-center gap-2.5 border-b border-base-200 px-4 py-3">
                         <x-icon name="o-cpu-chip" class="w-4 h-4 opacity-60" />
@@ -424,12 +420,7 @@
                     <div class="p-4 space-y-3">
                         <div class="flex items-center justify-between gap-2">
                             <span class="text-sm font-medium truncate">{{ $agent->name }}</span>
-                            <span class="badge {{ $neverConnected ? 'badge-ghost' : ($online ? 'badge-success' : 'badge-error') }} gap-1.5">
-                                @if(! $neverConnected)
-                                    <span class="status {{ $online ? 'status-success animate-pulse' : 'status-error' }}"></span>
-                                @endif
-                                {{ $neverConnected ? __('Never connected') : ($online ? __('Online') : __('Offline')) }}
-                            </span>
+                            <x-agent-status-indicator :status="$agent->connectionStatus()" />
                         </div>
                         @if($agent->last_heartbeat_at)
                             <p class="text-xs opacity-60">


### PR DESCRIPTION
## Summary

Follow-up to #390 (remote agent). Adds documentation for the agent feature and refactors agent connection-status rendering into a reusable component.

### Docs
- New **Remote Agents** user-guide page (`user-guide/agents`) explaining the purpose (outbound HTTPS / egress vs. inbound SSH / ingress), how it works (poll → claim → run → report) with an ASCII diagram, when to use it, setup, and constraints
- README feature line for remote agents
- "Learn more" docs button on the Agents index info alert; converted the Organizations config alert to the same button pattern and **fixed its broken docs URL** (it had a stray `/docs/` segment)
- Bumped `sidebar_position` of the following user-guide pages so ordering stays sequential

### UI
- New reusable `<x-agent-status-indicator>` Blade component (icon + badge per status), modeled on `job-status-indicator`
- Added `Agent::connectionStatus()` returning `online` / `offline` / `never` to centralize the status logic
- Used the component in the Agents index status column, the database server form, and the server show page

## Test plan
- [x] `make lint-fix` — passes
- [x] `make phpstan` — passes
- [x] `make test` — 1134 passed
- [x] `npm run build` (docs) — succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for remote agents to back up databases from firewalled/isolated networks using outbound HTTPS connectivity
  * Improved agent status reporting across the app with a consistent status indicator (including cleaner heartbeat visibility)

* **Documentation**
  * Added a new Agents user guide covering lifecycle, setup, and when to use agents vs SSH/direct access
  * Expanded Agents-related permissions guidance and updated sidebar/navigation ordering across the user guide

* **UI Improvements**
  * Refreshed “Learn more” links to use consistent button styling in relevant configuration pages
<!-- end of auto-generated comment: release notes by coderabbit.ai -->