### PR TITLE
fix: restore snapshot counter fix regressed by #390

### DIFF
--- a/app/Livewire/DatabaseServer/Show.php
+++ b/app/Livewire/DatabaseServer/Show.php
@@ -51,7 +51,9 @@ class Show extends Component
         ]);
 
         $this->server = $server;
-        $this->snapshotsCount = $server->snapshots()->count();
+        $this->snapshotsCount = $server->snapshots()
+            ->whereHas('job', fn ($q) => $q->whereRaw('status = ?', ['completed']))
+            ->count();
         $this->restoresCount = Restore::where('target_server_id', $server->id)->count();
     }
 

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -56,7 +56,7 @@ class DatabaseServerQuery
 
         return DatabaseServer::query()
             ->with(['backups.volume', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])
-            ->withCount('snapshots')
+            ->withCount(['snapshots' => fn (Builder $q) => $q->whereHas('job', fn (Builder $q) => $q->whereRaw('status = ?', ['completed']))])
             ->addSelect([
                 'restores_count' => Restore::selectRaw('count(*)')
                     ->whereColumn('target_server_id', 'database_servers.id'),

--- a/database/factories/SnapshotFactory.php
+++ b/database/factories/SnapshotFactory.php
@@ -92,6 +92,26 @@ class SnapshotFactory extends Factory
     }
 
     /**
+     * Mark the snapshot's job as completed.
+     */
+    public function completed(): static
+    {
+        return $this->afterCreating(function (Snapshot $snapshot) {
+            $snapshot->job->update(['status' => 'completed']);
+        });
+    }
+
+    /**
+     * Mark the snapshot's job as failed.
+     */
+    public function failed(): static
+    {
+        return $this->afterCreating(function (Snapshot $snapshot) {
+            $snapshot->job->update(['status' => 'failed']);
+        });
+    }
+
+    /**
      * Set the snapshot file as missing.
      */
     public function fileMissing(): static

--- a/tests/Feature/DatabaseServer/IndexTest.php
+++ b/tests/Feature/DatabaseServer/IndexTest.php
@@ -135,5 +135,6 @@ test('index snapshot badge only counts completed snapshots', function () {
 
     Livewire::actingAs($user)
         ->test(Index::class)
-        ->assertSee('2');
+        ->assertSeeHtml('data-tip="View snapshots"')
+        ->assertSeeHtml('<span>2</span>');
 });

--- a/tests/Feature/DatabaseServer/IndexTest.php
+++ b/tests/Feature/DatabaseServer/IndexTest.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\DatabaseServer\Index;
 use App\Models\DatabaseServer;
+use App\Models\Snapshot;
 use App\Models\User;
 use Livewire\Livewire;
 
@@ -122,4 +123,17 @@ test('user can toggle backups for a server from the index', function () {
         ->call('toggleBackupsEnabled', $server->id);
 
     expect($server->fresh()->backups_enabled)->toBeTrue();
+});
+
+test('index snapshot badge only counts completed snapshots', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->create();
+
+    Snapshot::factory()->forServer($server)->completed()->create();
+    Snapshot::factory()->forServer($server)->completed()->create();
+    Snapshot::factory()->forServer($server)->failed()->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->assertSee('2');
 });

--- a/tests/Feature/DatabaseServer/ShowTest.php
+++ b/tests/Feature/DatabaseServer/ShowTest.php
@@ -4,6 +4,7 @@ use App\Livewire\DatabaseServer\Show;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\ScheduledRestore;
+use App\Models\Snapshot;
 use App\Models\User;
 use Livewire\Livewire;
 
@@ -81,4 +82,17 @@ test('confirmRestore on a Redis server opens the redis info modal', function () 
         ->test(Show::class, ['server' => $server])
         ->call('confirmRestore')
         ->assertSet('showRedisRestoreModal', true);
+});
+
+test('snapshot counter only includes completed snapshots', function () {
+    $user = User::factory()->create();
+    $server = DatabaseServer::factory()->create();
+
+    Snapshot::factory()->forServer($server)->completed()->create();
+    Snapshot::factory()->forServer($server)->completed()->create();
+    Snapshot::factory()->forServer($server)->failed()->create();
+
+    Livewire::actingAs($user)
+        ->test(Show::class, ['server' => $server])
+        ->assertSet('snapshotsCount', 2);
 });


### PR DESCRIPTION
Closes #396

## Summary

- Reapplies the completed-only filter on `snapshotsCount` in `Show.php` (reverted by #390)
- Reapplies the `withCount` filter in `DatabaseServerQuery::buildFromParams()` (reverted by #390)
- Restores `completed()` / `failed()` factory states to `SnapshotFactory` (removed by #390)
- Restores the regression test in `ShowTest` (removed by #390)

## Test plan

- [x] `make test-filter FILTER=ShowTest` — all 7 tests pass including the restored regression test
- [ ] Visit server index with a server that has a failed snapshot — badge shows only completed count
- [ ] Visit server Show page — snapshot count excludes failed snapshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Server snapshot counts now include **only** snapshots whose associated job is marked **completed**. Failed or in-progress snapshots are no longer reflected in the counts on both the server **“show”** page and the **index** snapshot badge.

* **Tests**
  * Added Livewire feature tests to verify the UI displays completed-snapshot counts only.

* **Chores**
  * Enhanced the snapshot factory with `completed` and `failed` states to support the new test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->