### PR TITLE
refactor: BackupJobStatus enum + centralized snapshot/job query scopes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,13 @@ make lint-check         # Check code style without fixing
 
 make phpstan            # Run PHPStan static analysis
 make analyse            # Alias for phpstan
+
+make ide-helper         # Regenerate model type hints for PHPStan
 ```
+
+### Model Type Hints (IDE Helper)
+
+PHPStan reads model property/method types from `_ide_helper_models.php` (gitignored, generated). After changing a model's casts, `$fillable`, relationships, or scopes, run `make ide-helper` so PHPStan sees the new types. Without it, PHPStan may report wrong-type or undefined-method errors. Only run `make ide-helper` (which uses `--write-mixin`); never `ide-helper:models --write`, as that pollutes the model files with inline docblocks.
 
 ### Database Operations
 ```bash

--- a/app/Console/Commands/RecoverStuckJobsCommand.php
+++ b/app/Console/Commands/RecoverStuckJobsCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Enums\BackupJobStatus;
 use App\Facades\AppConfig;
 use App\Models\AgentJob;
 use App\Models\BackupJob;
@@ -86,13 +87,13 @@ class RecoverStuckJobsCommand extends Command
         $cutoff = now()->subSeconds($timeout);
 
         $stuckJobs = BackupJob::query()
-            ->whereIn('status', ['running', 'pending'])
+            ->inProgress()
             ->where(function ($query) use ($cutoff) {
                 $query->where(function ($q) use ($cutoff) {
-                    $q->where('status', 'running')
+                    $q->where('status', BackupJobStatus::Running)
                         ->where('started_at', '<', $cutoff);
                 })->orWhere(function ($q) use ($cutoff) {
-                    $q->where('status', 'pending')
+                    $q->where('status', BackupJobStatus::Pending)
                         ->where('created_at', '<', $cutoff);
                 });
             })
@@ -104,7 +105,7 @@ class RecoverStuckJobsCommand extends Command
 
         foreach ($stuckJobs as $job) {
             $job->markFailed(
-                new RuntimeException('Job timed out: stuck in '.$job->status.' state beyond the configured timeout.')
+                new RuntimeException('Job timed out: stuck in '.$job->status->value.' state beyond the configured timeout.')
             );
         }
 

--- a/app/Console/Commands/RunScheduledRestores.php
+++ b/app/Console/Commands/RunScheduledRestores.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Jobs\ProcessRestoreJob;
+use App\Models\BackupJob;
 use App\Models\Restore;
 use App\Models\ScheduledRestore;
 use App\Services\Backup\BackupJobFactory;
@@ -88,7 +89,10 @@ class RunScheduledRestores extends Command
     {
         return Restore::query()
             ->where('scheduled_restore_id', $scheduledRestore->id)
-            ->whereHas('job', fn (Builder $q) => $q->whereIn('status', ['pending', 'running']))
+            ->whereHas('job', function (Builder $q) {
+                /** @var Builder<BackupJob> $q */
+                $q->inProgress();
+            })
             ->exists();
     }
 

--- a/app/Enums/BackupJobStatus.php
+++ b/app/Enums/BackupJobStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum BackupJobStatus: string
+{
+    case Pending = 'pending';
+    case Running = 'running';
+    case Completed = 'completed';
+    case Failed = 'failed';
+}

--- a/app/Livewire/Dashboard/JobsActivityChart.php
+++ b/app/Livewire/Dashboard/JobsActivityChart.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Dashboard;
 
+use App\Enums\BackupJobStatus;
 use App\Models\BackupJob;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Carbon;
@@ -39,10 +40,10 @@ class JobsActivityChart extends Component
             /** @var Collection<int, BackupJob> $dayJobs */
             $dayJobs = $jobs->get($dateKey, collect());
 
-            $completed[] = $dayJobs->where('status', 'completed')->count();
-            $failed[] = $dayJobs->where('status', 'failed')->count();
-            $running[] = $dayJobs->where('status', 'running')->count();
-            $pending[] = $dayJobs->where('status', 'pending')->count();
+            $completed[] = $dayJobs->where('status', BackupJobStatus::Completed)->count();
+            $failed[] = $dayJobs->where('status', BackupJobStatus::Failed)->count();
+            $running[] = $dayJobs->where('status', BackupJobStatus::Running)->count();
+            $pending[] = $dayJobs->where('status', BackupJobStatus::Pending)->count();
         }
 
         $this->chart = [

--- a/app/Livewire/Dashboard/SnapshotsCard.php
+++ b/app/Livewire/Dashboard/SnapshotsCard.php
@@ -37,11 +37,11 @@ class SnapshotsCard extends Component
 
     private function loadData(): void
     {
-        $baseQuery = Snapshot::forCurrentOrg()->whereRelation('job', 'status', 'completed');
+        $baseQuery = Snapshot::forCurrentOrg()->completed();
 
         $this->totalSnapshots = $baseQuery->count();
         $this->verifiedSnapshots = (clone $baseQuery)->whereNotNull('file_verified_at')->count();
-        $this->missingSnapshots = (clone $baseQuery)->where('file_exists', false)->count();
+        $this->missingSnapshots = (clone $baseQuery)->fileMissing()->count();
     }
 
     public function placeholder(): View

--- a/app/Livewire/Dashboard/StorageCard.php
+++ b/app/Livewire/Dashboard/StorageCard.php
@@ -27,7 +27,7 @@ class StorageCard extends Component
 
     private function loadData(): void
     {
-        $totalBytes = Snapshot::forCurrentOrg()->whereRelation('job', 'status', 'completed')->sum('file_size');
+        $totalBytes = Snapshot::forCurrentOrg()->completed()->sum('file_size');
         $this->totalStorage = Formatters::humanFileSize((int) $totalBytes);
     }
 

--- a/app/Livewire/Dashboard/SuccessRateCard.php
+++ b/app/Livewire/Dashboard/SuccessRateCard.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Dashboard;
 
+use App\Enums\BackupJobStatus;
 use App\Models\BackupJob;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Carbon;
@@ -35,20 +36,20 @@ class SuccessRateCard extends Component
         $counts = BackupJob::forCurrentOrg()
             ->toBase()
             ->where('created_at', '>=', $thirtyDaysAgo)
-            ->whereIn('status', ['completed', 'failed'])
+            ->whereIn('status', [BackupJobStatus::Completed, BackupJobStatus::Failed])
             ->selectRaw('status, count(*) as total')
             ->groupBy('status')
             ->pluck('total', 'status');
 
-        $completed = (int) ($counts['completed'] ?? 0);
-        $failed = (int) ($counts['failed'] ?? 0);
+        $completed = (int) ($counts[BackupJobStatus::Completed->value] ?? 0);
+        $failed = (int) ($counts[BackupJobStatus::Failed->value] ?? 0);
         $total = $completed + $failed;
 
         if ($total > 0) {
             $this->successRate = round(($completed / $total) * 100, 1);
         }
 
-        $this->runningJobs = BackupJob::forCurrentOrg()->where('status', 'running')->count();
+        $this->runningJobs = BackupJob::forCurrentOrg()->where('status', BackupJobStatus::Running)->count();
     }
 
     public function placeholder(): View

--- a/app/Livewire/Dashboard/SuccessRateCard.php
+++ b/app/Livewire/Dashboard/SuccessRateCard.php
@@ -47,6 +47,8 @@ class SuccessRateCard extends Component
 
         if ($total > 0) {
             $this->successRate = round(($completed / $total) * 100, 1);
+        } else {
+            $this->successRate = 0;
         }
 
         $this->runningJobs = BackupJob::forCurrentOrg()->where('status', BackupJobStatus::Running)->count();

--- a/app/Livewire/DatabaseServer/Show.php
+++ b/app/Livewire/DatabaseServer/Show.php
@@ -51,9 +51,7 @@ class Show extends Component
         ]);
 
         $this->server = $server;
-        $this->snapshotsCount = $server->snapshots()
-            ->whereHas('job', fn ($q) => $q->whereRaw('status = ?', ['completed']))
-            ->count();
+        $this->snapshotsCount = $server->snapshots()->completed()->count();
         $this->restoresCount = Restore::where('target_server_id', $server->id)->count();
     }
 

--- a/app/Livewire/Menu/RestoresMenuItem.php
+++ b/app/Livewire/Menu/RestoresMenuItem.php
@@ -17,7 +17,7 @@ class RestoresMenuItem extends Component
     public function getActiveRestoresCountProperty(): int
     {
         return BackupJob::forCurrentOrg()
-            ->whereIn('status', ['running', 'pending'])
+            ->inProgress()
             ->whereHas('restore')
             ->count();
     }

--- a/app/Livewire/Menu/SnapshotsMenuItem.php
+++ b/app/Livewire/Menu/SnapshotsMenuItem.php
@@ -17,7 +17,7 @@ class SnapshotsMenuItem extends Component
     public function getActiveSnapshotsCountProperty(): int
     {
         return BackupJob::forCurrentOrg()
-            ->whereIn('status', ['running', 'pending'])
+            ->inProgress()
             ->whereHas('snapshot')
             ->count();
     }

--- a/app/Livewire/Restore/Modal.php
+++ b/app/Livewire/Restore/Modal.php
@@ -322,8 +322,9 @@ class Modal extends Component
     public function getCompatibleServersProperty(): Collection
     {
         $query = DatabaseServer::query()
-            ->whereHas('snapshots', function ($q) {
-                $q->whereHas('job', fn ($jq) => $jq->whereRaw("status = 'completed'"));
+            ->whereHas('snapshots', function (Builder $q) {
+                /** @var Builder<Snapshot> $q */
+                $q->completed();
             });
 
         if ($this->mode === RestoreModalMode::FromServer && $this->targetServer) {
@@ -357,8 +358,8 @@ class Modal extends Component
         )
             ->when($dbType, fn (Builder $q) => $q->whereRaw('database_type = ?', [$dbType]))
             ->when($this->serverFilter, fn ($q) => $q->where('database_server_id', $this->serverFilter))
-            ->whereHas('job', fn (Builder $q) => $q->whereRaw("status = 'completed'"))
-            ->whereRaw('file_exists = ?', [true])
+            ->completed()
+            ->fileExists()
             ->paginate(20, pageName: 'snapshots');
     }
 

--- a/app/Livewire/ScheduledRestore/Modal.php
+++ b/app/Livewire/ScheduledRestore/Modal.php
@@ -10,6 +10,7 @@ use App\Models\ScheduledRestore;
 use App\Models\Snapshot;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
@@ -194,7 +195,10 @@ class Modal extends Component
     public function getSourceServerOptionsProperty(): array
     {
         return DatabaseServer::query()
-            ->whereHas('snapshots', fn ($q) => $q->whereHas('job', fn ($jq) => $jq->whereRaw('status = ?', ['completed'])))
+            ->whereHas('snapshots', function (Builder $q) {
+                /** @var Builder<Snapshot> $q */
+                $q->completed();
+            })
             ->where('database_type', '!=', DatabaseType::REDIS->value)
             ->orderBy('name')
             ->get(['id', 'name'])
@@ -213,8 +217,8 @@ class Modal extends Component
 
         return Snapshot::query()
             ->where('database_server_id', $this->sourceServerId)
-            ->whereHas('job', fn ($q) => $q->whereRaw('status = ?', ['completed']))
-            ->where('file_exists', true)
+            ->completed()
+            ->fileExists()
             ->distinct()
             ->orderBy('database_name')
             ->pluck('database_name')

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Snapshot;
 
+use App\Enums\BackupJobStatus;
 use App\Enums\DatabaseType;
 use App\Livewire\Concerns\HandlesJobLogsModal;
 use App\Models\BackupJob;
@@ -210,7 +211,7 @@ class Index extends Component
 
         $this->authorize('delete', $job);
 
-        if ($job->status !== 'pending') {
+        if ($job->status !== BackupJobStatus::Pending) {
             $this->error(__('Job is no longer pending and cannot be deleted.'));
             $this->showDeleteModal = false;
 

--- a/app/Mcp/Tools/GetJobStatusTool.php
+++ b/app/Mcp/Tools/GetJobStatusTool.php
@@ -25,7 +25,7 @@ class GetJobStatusTool extends Tool
 
         $lines = [
             "Job ID: {$job->id}",
-            "Status: {$job->status}",
+            "Status: {$job->status->value}",
         ];
 
         if ($job->started_at) {

--- a/app/Mcp/Tools/ListSnapshotsTool.php
+++ b/app/Mcp/Tools/ListSnapshotsTool.php
@@ -34,7 +34,7 @@ class ListSnapshotsTool extends Tool
         }
 
         $lines = $snapshots->map(function (Snapshot $snapshot) {
-            $status = $snapshot->job->status;
+            $status = $snapshot->job->status->value;
             $size = $snapshot->getHumanFileSize();
             $date = $snapshot->created_at?->toDateTimeString() ?? 'unknown';
             $server = $snapshot->databaseServer->name;

--- a/app/Models/BackupJob.php
+++ b/app/Models/BackupJob.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Contracts\BackupLogger;
+use App\Enums\BackupJobStatus;
 use App\Models\Scopes\OrganizationScope;
 use App\Services\CurrentOrganization;
 use App\Support\Formatters;
@@ -32,6 +33,7 @@ class BackupJob extends Model implements BackupLogger
     protected function casts(): array
     {
         return [
+            'status' => BackupJobStatus::class,
             'started_at' => 'datetime',
             'completed_at' => 'datetime',
             'duration_ms' => 'integer',
@@ -59,6 +61,17 @@ class BackupJob extends Model implements BackupLogger
                         ->whereRaw('organization_id = ?', [$orgId]);
                 });
         });
+    }
+
+    /**
+     * Scope to jobs that are still in progress (pending or running).
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeInProgress(Builder $query): Builder
+    {
+        return $query->whereIn('status', [BackupJobStatus::Pending, BackupJobStatus::Running]);
     }
 
     /**
@@ -91,7 +104,7 @@ class BackupJob extends Model implements BackupLogger
     public function markCompleted(): void
     {
         $this->update([
-            'status' => 'completed',
+            'status' => BackupJobStatus::Completed,
             'completed_at' => now(),
             'duration_ms' => $this->calculateDuration(),
         ]);
@@ -103,7 +116,7 @@ class BackupJob extends Model implements BackupLogger
     public function markFailed(\Throwable $exception): void
     {
         $this->update([
-            'status' => 'failed',
+            'status' => BackupJobStatus::Failed,
             'completed_at' => now(),
             'duration_ms' => $this->calculateDuration(),
             'error_message' => $exception->getMessage(),
@@ -127,7 +140,7 @@ class BackupJob extends Model implements BackupLogger
     public function markRunning(): void
     {
         $this->update([
-            'status' => 'running',
+            'status' => BackupJobStatus::Running,
             'started_at' => now(),
         ]);
     }

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\BackupJobStatus;
 use App\Enums\CompressionType;
 use App\Enums\DatabaseType;
 use App\Models\Scopes\OrganizationScope;
@@ -299,5 +300,38 @@ class Snapshot extends Model
     public function scopeForDatabaseServer(Builder $query, DatabaseServer $databaseServer): Builder
     {
         return $query->where('database_server_id', $databaseServer->id);
+    }
+
+    /**
+     * Scope to only snapshots whose backup job completed successfully.
+     *
+     * @param  Builder<Snapshot>  $query
+     * @return Builder<Snapshot>
+     */
+    public function scopeCompleted(Builder $query): Builder
+    {
+        return $query->whereRelation('job', 'status', BackupJobStatus::Completed);
+    }
+
+    /**
+     * Scope to snapshots whose backup file still exists on the volume.
+     *
+     * @param  Builder<Snapshot>  $query
+     * @return Builder<Snapshot>
+     */
+    public function scopeFileExists(Builder $query): Builder
+    {
+        return $query->where('file_exists', true);
+    }
+
+    /**
+     * Scope to snapshots whose backup file is missing from the volume.
+     *
+     * @param  Builder<Snapshot>  $query
+     * @return Builder<Snapshot>
+     */
+    public function scopeFileMissing(Builder $query): Builder
+    {
+        return $query->where('file_exists', false);
     }
 }

--- a/app/Policies/BackupJobPolicy.php
+++ b/app/Policies/BackupJobPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\BackupJobStatus;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\User;
@@ -37,7 +38,7 @@ class BackupJobPolicy
      */
     public function delete(User $user, BackupJob $backupJob): bool
     {
-        return $user->canPerformActions() && $backupJob->status === 'pending';
+        return $user->canPerformActions() && $backupJob->status === BackupJobStatus::Pending;
     }
 
     /**

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -4,6 +4,7 @@ namespace App\Queries;
 
 use App\Models\DatabaseServer;
 use App\Models\Restore;
+use App\Models\Snapshot;
 use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\AllowedFilter;
@@ -56,7 +57,10 @@ class DatabaseServerQuery
 
         return DatabaseServer::query()
             ->with(['backups.volume', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])
-            ->withCount(['snapshots' => fn (Builder $q) => $q->whereHas('job', fn (Builder $q) => $q->whereRaw('status = ?', ['completed']))])
+            ->withCount(['snapshots' => function (Builder $q) {
+                /** @var Builder<Snapshot> $q */
+                return $q->completed();
+            }])
             ->addSelect([
                 'restores_count' => Restore::selectRaw('count(*)')
                     ->whereColumn('target_server_id', 'database_servers.id'),

--- a/app/Services/Backup/BackupJobFactory.php
+++ b/app/Services/Backup/BackupJobFactory.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Backup;
 
+use App\Enums\BackupJobStatus;
 use App\Enums\CompressionType;
 use App\Enums\DatabaseSelectionMode;
 use App\Enums\DatabaseType;
@@ -103,7 +104,7 @@ class BackupJobFactory
         $volume = $backup->volume;
 
         $snapshot = DB::transaction(function () use ($backup, $server, $volume, $databaseName, $method, $triggeredByUserId) {
-            $job = BackupJob::create(['status' => 'pending']);
+            $job = BackupJob::create(['status' => BackupJobStatus::Pending]);
 
             return Snapshot::create([
                 'backup_job_id' => $job->id,
@@ -179,7 +180,7 @@ class BackupJobFactory
         ?string $scheduledRestoreId = null,
     ): Restore {
         $snapshot->loadMissing('job');
-        if ($snapshot->job->status !== 'completed' || $snapshot->filename === '') {
+        if ($snapshot->job->status !== BackupJobStatus::Completed || $snapshot->filename === '') {
             throw ValidationException::withMessages([
                 'snapshot_id' => 'Snapshot is not completed and cannot be restored.',
             ]);
@@ -198,7 +199,7 @@ class BackupJobFactory
         }
 
         $restore = DB::transaction(function () use ($snapshot, $targetServer, $schemaName, $options, $triggeredByUserId, $scheduledRestoreId) {
-            $job = BackupJob::create(['status' => 'pending']);
+            $job = BackupJob::create(['status' => BackupJobStatus::Pending]);
 
             return Restore::create([
                 'backup_job_id' => $job->id,

--- a/app/Services/Backup/LatestSnapshotResolver.php
+++ b/app/Services/Backup/LatestSnapshotResolver.php
@@ -21,8 +21,8 @@ class LatestSnapshotResolver
             ->withoutGlobalScope(OrganizationScope::class)
             ->where('database_server_id', $scheduledRestore->source_server_id)
             ->where('database_name', $scheduledRestore->source_database_name)
-            ->where('file_exists', true)
-            ->whereHas('job', fn ($q) => $q->whereRaw('status = ?', ['completed']))
+            ->fileExists()
+            ->completed()
             ->orderByDesc('created_at')
             ->first();
     }

--- a/app/Services/Backup/SnapshotCleanupService.php
+++ b/app/Services/Backup/SnapshotCleanupService.php
@@ -57,7 +57,7 @@ class SnapshotCleanupService
         $serverName = $backup->databaseServer->name ?? 'Unknown Server';
 
         $expiredSnapshots = Snapshot::where('backup_id', $backup->id)
-            ->whereRelation('job', 'status', 'completed')
+            ->completed()
             ->where('created_at', '<', $cutoffDate)
             ->get();
 
@@ -83,7 +83,7 @@ class SnapshotCleanupService
         }
 
         $allSnapshots = Snapshot::where('backup_id', $backup->id)
-            ->whereRelation('job', 'status', 'completed')
+            ->completed()
             ->orderBy('created_at', 'desc')
             ->get();
 

--- a/app/Services/Backup/SnapshotVerificationService.php
+++ b/app/Services/Backup/SnapshotVerificationService.php
@@ -32,7 +32,7 @@ class SnapshotVerificationService
         $query = Snapshot::query()
             ->whereNotNull('filename')
             ->where('filename', '!=', '')
-            ->whereRelation('job', 'status', 'completed');
+            ->completed();
 
         if ($organizationId) {
             $query->whereHas('databaseServer', function ($sq) use ($organizationId) {

--- a/resources/views/components/job-status-indicator.blade.php
+++ b/resources/views/components/job-status-indicator.blade.php
@@ -4,6 +4,8 @@
 ])
 
 @php
+    $status = $status instanceof \BackedEnum ? $status->value : $status;
+
     [$badgeClass, $icon, $defaultLabel, $useSpinner] = match ($status) {
         'completed' => ['badge-success', 'o-check-circle', __('Completed'), false],
         'failed' => ['badge-error', 'o-x-circle', __('Failed'), false],

--- a/resources/views/livewire/dashboard/job-status-grid.blade.php
+++ b/resources/views/livewire/dashboard/job-status-grid.blade.php
@@ -8,7 +8,7 @@
             <div class="grid gap-1 max-h-48 overflow-y-auto" style="grid-template-columns: repeat(auto-fill, 14px)">
                 @foreach($this->jobs as $job)
                     @php
-                        $colorClass = match($job->status) {
+                        $colorClass = match($job->status->value) {
                             'completed' => 'bg-success',
                             'failed' => 'bg-error',
                             'running' => 'bg-warning',
@@ -30,7 +30,7 @@
                         data-server="{{ $serverName }}"
                         data-database="{{ $databaseName }}"
                         data-type="{{ $jobType }}"
-                        data-status="{{ ucfirst($job->status) }}"
+                        data-status="{{ ucfirst($job->status->value) }}"
                         data-duration="{{ $job->getHumanDuration() ?? '' }}"
                         data-ago="{{ $job->created_at?->diffForHumans(short: true) ?? '' }}"
                         data-date="{{ $job->created_at ? \App\Support\Formatters::humanDate($job->created_at) : '' }}"

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -30,8 +30,8 @@
             :sort-by="$sortBy"
             with-pagination
             :row-decoration="[
-                'bg-error/5' => fn ($restore) => $restore->job?->status === 'failed',
-                'bg-warning/5' => fn ($restore) => $restore->job?->status === 'running',
+                'bg-error/5' => fn ($restore) => $restore->job?->status?->value === 'failed',
+                'bg-warning/5' => fn ($restore) => $restore->job?->status?->value === 'running',
             ]"
         >
             <x-slot:empty>
@@ -122,7 +122,7 @@
             @endscope
 
             @scope('cell_status', $restore)
-                @php $status = $restore->job?->status ?? 'pending'; $job = $restore->job; @endphp
+                @php $status = $restore->job?->status?->value ?? 'pending'; $job = $restore->job; @endphp
                 <x-job-status-indicator :status="$status" />
 
                 @if($status === 'running' && $job?->started_at)

--- a/resources/views/livewire/scheduled-restore/index.blade.php
+++ b/resources/views/livewire/scheduled-restore/index.blade.php
@@ -103,7 +103,7 @@
                 @else
                     @php
                         $skipped = (bool) $scheduledRestore->last_skip_reason;
-                        $verdictStatus = $skipped ? 'skipped' : ($scheduledRestore->lastRestore?->job?->status ?? 'pending');
+                        $verdictStatus = $skipped ? 'skipped' : ($scheduledRestore->lastRestore?->job?->status?->value ?? 'pending');
                     @endphp
 
                     <div class="flex flex-col gap-1">

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -22,9 +22,9 @@
             :sort-by="$sortBy"
             with-pagination
             :row-decoration="[
-                'bg-error/5' => fn ($snapshot) => $snapshot->job?->status === 'failed',
-                'bg-warning/5' => fn ($snapshot) => $snapshot->job?->status === 'running'
-                    || (! $snapshot->file_exists && $snapshot->job?->status === 'completed'),
+                'bg-error/5' => fn ($snapshot) => $snapshot->job?->status?->value === 'failed',
+                'bg-warning/5' => fn ($snapshot) => $snapshot->job?->status?->value === 'running'
+                    || (! $snapshot->file_exists && $snapshot->job?->status?->value === 'completed'),
             ]"
         >
             <x-slot:empty>
@@ -41,7 +41,7 @@
             </x-slot:empty>
 
             @scope('cell_subject', $snapshot)
-                @php $fileMissing = $snapshot->job?->status === 'completed' && ! $snapshot->file_exists; @endphp
+                @php $fileMissing = $snapshot->job?->status?->value === 'completed' && ! $snapshot->file_exists; @endphp
                 <div class="flex items-center gap-3 min-w-0">
                     <x-icon :name="$snapshot->database_type->icon()" class="w-6 h-6 shrink-0" />
                     <div class="min-w-0">
@@ -86,7 +86,7 @@
             @endscope
 
             @scope('cell_status', $snapshot)
-                @php $status = $snapshot->job?->status ?? 'pending'; $job = $snapshot->job; @endphp
+                @php $status = $snapshot->job?->status?->value ?? 'pending'; $job = $snapshot->job; @endphp
                 <x-job-status-indicator :status="$status" />
 
                 @if($status === 'running' && $job?->started_at)
@@ -111,7 +111,7 @@
 
             @scope('actions', $snapshot)
                 @php
-                    $status = $snapshot->job?->status;
+                    $status = $snapshot->job?->status?->value;
                     $job = $snapshot->job;
                     $canRestore = $status === 'completed' && $snapshot->file_exists && $snapshot->database_type !== \App\Enums\DatabaseType::REDIS;
                     $canDownload = $status === 'completed';

--- a/tests/Feature/Agent/AgentApiTest.php
+++ b/tests/Feature/Agent/AgentApiTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\BackupJobStatus;
 use App\Http\Middleware\ThrottleFailedAgentAuth;
 use App\Models\Agent;
 use App\Models\AgentJob;
@@ -84,7 +85,7 @@ describe('job claiming', function () {
 
         // BackupJob should be marked as running with started_at set
         $backupJob = $snapshot->job->fresh();
-        expect($backupJob->status)->toBe('running')
+        expect($backupJob->status)->toBe(BackupJobStatus::Running)
             ->and($backupJob->started_at)->not->toBeNull();
     });
 
@@ -205,7 +206,7 @@ describe('job acknowledgement', function () {
 
         // BackupJob should be completed with logs written
         $backupJob = $snapshot->job;
-        expect($backupJob->status)->toBe('completed')
+        expect($backupJob->status)->toBe(BackupJobStatus::Completed)
             ->and($backupJob->logs)->toHaveCount(2)
             ->and($backupJob->logs[0]['message'])->toBe('Starting backup for database: testdb');
     });
@@ -235,7 +236,7 @@ describe('job failure', function () {
 
         // BackupJob should be failed with logs written
         $backupJob = $agentJob->snapshot->fresh()->job;
-        expect($backupJob->status)->toBe('failed')
+        expect($backupJob->status)->toBe(BackupJobStatus::Failed)
             ->and($backupJob->logs)->toHaveCount(2)
             ->and($backupJob->logs[1]['message'])->toBe('Backup failed: Connection refused');
     });

--- a/tests/Feature/Agent/RecoverStuckJobsTest.php
+++ b/tests/Feature/Agent/RecoverStuckJobsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\BackupJobStatus;
 use App\Facades\AppConfig;
 use App\Models\Agent;
 use App\Models\AgentJob;
@@ -39,7 +40,7 @@ test('fails agent jobs that exceeded max attempts', function () {
         ->and($job->error_message)->toContain('Max attempts');
 
     // BackupJob should be failed too
-    expect($job->snapshot->fresh()->job->status)->toBe('failed');
+    expect($job->snapshot->fresh()->job->status)->toBe(BackupJobStatus::Failed);
 });
 
 test('fails expired discovery jobs without a snapshot', function () {
@@ -84,7 +85,7 @@ test('fails backup jobs stuck in running state beyond timeout', function () {
         ->assertExitCode(0);
 
     $job->refresh();
-    expect($job->status)->toBe('failed')
+    expect($job->status)->toBe(BackupJobStatus::Failed)
         ->and($job->error_message)->toContain('stuck in running state');
 });
 
@@ -100,7 +101,7 @@ test('fails backup jobs stuck in pending state beyond timeout', function () {
         ->assertExitCode(0);
 
     $job->refresh();
-    expect($job->status)->toBe('failed')
+    expect($job->status)->toBe(BackupJobStatus::Failed)
         ->and($job->error_message)->toContain('stuck in pending state');
 });
 
@@ -117,7 +118,7 @@ test('does not touch running backup jobs within timeout', function () {
         ->assertExitCode(0);
 
     $job->refresh();
-    expect($job->status)->toBe('running');
+    expect($job->status)->toBe(BackupJobStatus::Running);
 });
 
 test('does not touch pending backup jobs within timeout', function () {
@@ -130,7 +131,7 @@ test('does not touch pending backup jobs within timeout', function () {
         ->assertExitCode(0);
 
     $job->refresh();
-    expect($job->status)->toBe('pending');
+    expect($job->status)->toBe(BackupJobStatus::Pending);
 });
 
 test('does not touch completed or failed backup jobs', function () {
@@ -152,8 +153,8 @@ test('does not touch completed or failed backup jobs', function () {
     $this->artisan('jobs:recover-stuck')
         ->assertExitCode(0);
 
-    expect($completedJob->fresh()->status)->toBe('completed')
-        ->and($failedJob->fresh()->status)->toBe('failed');
+    expect($completedJob->fresh()->status)->toBe(BackupJobStatus::Completed)
+        ->and($failedJob->fresh()->status)->toBe(BackupJobStatus::Failed);
 });
 
 test('outputs no stuck jobs message when nothing to recover', function () {

--- a/tests/Feature/Console/RunScheduledBackupsTest.php
+++ b/tests/Feature/Console/RunScheduledBackupsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\BackupJobStatus;
 use App\Jobs\ProcessBackupJob;
 use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
@@ -176,7 +177,7 @@ test('server unreachable during all/pattern listing produces a failed preflight 
     expect($failingSnapshot)->not->toBeNull()
         ->and($failingSnapshot->database_name)->toBe('(all databases)')
         ->and($failingSnapshot->method)->toBe('scheduled')
-        ->and($failingSnapshot->job->status)->toBe('failed')
+        ->and($failingSnapshot->job->status)->toBe(BackupJobStatus::Failed)
         ->and($failingSnapshot->job->error_message)->toBe('Connection refused');
 
     expect(Snapshot::where('database_server_id', $normalServer->id)->pluck('database_name')->sort()->values()->all())

--- a/tests/Feature/Dashboard/SuccessRateCardTest.php
+++ b/tests/Feature/Dashboard/SuccessRateCardTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Livewire\Dashboard\SuccessRateCard;
+use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\User;
 use App\Services\Backup\BackupJobFactory;
@@ -26,6 +27,27 @@ test('success rate card calculates correct rate', function () {
         ->actingAs($user)
         ->test(SuccessRateCard::class)
         ->assertSet('successRate', 75.0); // 3 out of 4 = 75%
+});
+
+test('success rate resets to zero when a refresh finds no completed or failed jobs', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['test_db']]);
+
+    $snapshots = $factory->createSnapshots($server->backups->first(), 'manual', $user->id);
+    $snapshots[0]->job->markCompleted();
+
+    $component = Livewire::withoutLazyLoading()
+        ->actingAs($user)
+        ->test(SuccessRateCard::class)
+        ->assertSet('successRate', 100.0);
+
+    // The only counted job ages out of the 30-day window; a refresh must not keep the stale rate.
+    BackupJob::where('id', $snapshots[0]->job->id)->update(['created_at' => now()->subDays(31)]);
+
+    $component->call('refreshDashboard')
+        ->assertSet('successRate', 0.0);
 });
 
 test('success rate card shows running jobs count', function () {

--- a/tests/Feature/Jobs/ProcessBackupJobTest.php
+++ b/tests/Feature/Jobs/ProcessBackupJobTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\BackupLogger;
+use App\Enums\BackupJobStatus;
 use App\Facades\AppConfig;
 use App\Jobs\ProcessBackupJob;
 use App\Models\DatabaseServer;
@@ -61,7 +62,7 @@ test('handle builds config from models and updates snapshot on success', functio
     (new ProcessBackupJob($snapshot->id))->handle($mockBackupTask);
 
     $snapshot->refresh();
-    expect($snapshot->job->status)->toBe('completed')
+    expect($snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($snapshot->filename)->toBe('prod-myapp-2024.sql.gz')
         ->and($snapshot->file_size)->toBe(2048)
         ->and($snapshot->checksum)->toBe('abc123def456')
@@ -136,7 +137,7 @@ test('handle marks job as failed and re-throws on execute failure', function () 
         ->toThrow(\App\Exceptions\ShellProcessFailed::class, 'Access denied for user');
 
     $snapshot->refresh();
-    expect($snapshot->job->status)->toBe('failed')
+    expect($snapshot->job->status)->toBe(BackupJobStatus::Failed)
         ->and($snapshot->job->error_message)->toBe('Access denied for user')
         ->and($snapshot->job->completed_at)->not->toBeNull();
 });

--- a/tests/Feature/Jobs/ProcessRestoreJobTest.php
+++ b/tests/Feature/Jobs/ProcessRestoreJobTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\BackupJobStatus;
 use App\Enums\CompressionType;
 use App\Facades\AppConfig;
 use App\Jobs\ProcessRestoreJob;
@@ -78,7 +79,7 @@ test('handle builds config from models and marks job completed', function () {
     (new ProcessRestoreJob($restore->id))->handle($mockRestoreTask);
 
     $restore->refresh();
-    expect($restore->job->status)->toBe('completed');
+    expect($restore->job->status)->toBe(BackupJobStatus::Completed);
 });
 
 test('handle marks job as failed and re-throws on execute failure', function () {
@@ -114,7 +115,7 @@ test('handle marks job as failed and re-throws on execute failure', function () 
         ->toThrow(\App\Exceptions\ShellProcessFailed::class, 'Access denied for user');
 
     $restore->refresh();
-    expect($restore->job->status)->toBe('failed')
+    expect($restore->job->status)->toBe(BackupJobStatus::Failed)
         ->and($restore->job->error_message)->toBe('Access denied for user')
         ->and($restore->job->completed_at)->not->toBeNull();
 });

--- a/tests/Feature/Livewire/Restore/ModalTest.php
+++ b/tests/Feature/Livewire/Restore/ModalTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\BackupJobStatus;
 use App\Enums\UserRole;
 use App\Jobs\ProcessRestoreJob;
 use App\Livewire\Restore\Modal;
@@ -65,7 +66,7 @@ test('from-server mode: queues restore job and dispatches restore-created', func
 
     expect($restore)->not->toBeNull()
         ->and($restore->schema_name)->toBe('restored_db')
-        ->and($restore->job->status)->toBe('pending');
+        ->and($restore->job->status)->toBe(BackupJobStatus::Pending);
 });
 
 test('rejects restore when the target server is agent-backed', function () {

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\BackupJobStatus;
 use App\Enums\UserRole;
 use App\Livewire\Snapshot\Index;
 use App\Models\BackupJob;
@@ -132,7 +133,7 @@ test('can cancel a pending backup job', function () {
 test('cannot cancel a non-pending job', function () {
     $snapshot = Snapshot::factory()->withFile()->create();
     // Default factory creates a completed job.
-    expect($snapshot->job->status)->toBe('completed');
+    expect($snapshot->job->status)->toBe(BackupJobStatus::Completed);
 
     Livewire::test(Index::class)
         ->call('confirmCancelJob', $snapshot->job->id)

--- a/tests/Feature/Queries/SnapshotQueryTest.php
+++ b/tests/Feature/Queries/SnapshotQueryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\BackupJobStatus;
 use App\Models\DatabaseServer;
 use App\Queries\SnapshotQuery;
 use App\Services\Backup\BackupJobFactory;
@@ -50,7 +51,7 @@ test('can filter snapshots by status', function () {
     $results = SnapshotQuery::buildFromParams(statusFilter: 'completed')->get();
 
     expect($results)->toHaveCount(1)
-        ->and($results->first()->job->status)->toBe('completed');
+        ->and($results->first()->job->status)->toBe(BackupJobStatus::Completed);
 });
 
 test('can sort snapshots by column', function () {

--- a/tests/Integration/BackupRestoreTest.php
+++ b/tests/Integration/BackupRestoreTest.php
@@ -7,6 +7,7 @@
  * Run with: php artisan test --group=integration
  */
 
+use App\Enums\BackupJobStatus;
 use App\Enums\CompressionType;
 use App\Facades\AppConfig;
 use App\Jobs\ProcessBackupJob;
@@ -74,7 +75,7 @@ test('mysql backup and restore workflow', function (string $compression, string 
 
     $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
 
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
         ->and($this->snapshot->compression_type)->toBe(CompressionType::from($compression))
         ->and($this->snapshot->filename)->toEndWith(".sql.{$expectedExt}")
@@ -133,7 +134,7 @@ test('postgres backup and restore workflow', function (?string $dumpFormat) {
     $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
 
     $expectedDumpExt = $dumpFormat === 'custom' ? 'dump' : 'sql';
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
         ->and($this->snapshot->compression_type)->toBe(CompressionType::GZIP)
         ->and($this->snapshot->filename)->toEndWith(".{$expectedDumpExt}.gz")
@@ -184,7 +185,7 @@ test('backup with extra dump flags succeeds', function (string $type, string $fl
     $this->snapshot->refresh();
     $this->snapshot->load('job');
 
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0);
 })->with([
     'mysql with --verbose' => ['mysql', '--verbose'],
@@ -219,7 +220,7 @@ test('sqlite backup and restore workflow', function () {
 
     $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
 
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
         ->and($this->snapshot->getDatabaseServerMetadata()['host'])->toBeNull()
         ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
@@ -272,7 +273,7 @@ test('mongodb backup and restore workflow', function () {
 
     $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
 
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
         ->and($this->snapshot->filename)->toEndWith('.archive.gz')
         ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
@@ -314,7 +315,7 @@ test('mssql backup and restore workflow', function () {
 
     $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
 
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
         ->and($this->snapshot->filename)->toEndWith('.dacpac.gz')
         ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();
@@ -358,7 +359,7 @@ test('redis backup workflow', function () {
 
     $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
 
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
         ->and($this->snapshot->database_name)->toBe('all')
         ->and($this->snapshot->filename)->toEndWith('.rdb.gz')
@@ -387,7 +388,7 @@ test('firebird backup and restore workflow', function () {
 
     $filesystem = $this->filesystemProvider->getForVolume($this->snapshot->volume);
 
-    expect($this->snapshot->job->status)->toBe('completed')
+    expect($this->snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($this->snapshot->file_size)->toBeGreaterThan(0)
         ->and($this->snapshot->filename)->toEndWith('.fbk.gz')
         ->and($filesystem->fileExists($this->snapshot->filename))->toBeTrue();

--- a/tests/Integration/SftpDownloadTest.php
+++ b/tests/Integration/SftpDownloadTest.php
@@ -9,6 +9,7 @@
  * Run with: php artisan test --filter=SftpDownloadTest
  */
 
+use App\Enums\BackupJobStatus;
 use App\Jobs\ProcessBackupJob;
 use App\Models\User;
 use App\Services\Backup\BackupJobFactory;
@@ -41,7 +42,7 @@ test('can download snapshot stored on SFTP volume via streamed route', function 
 
     $filesystem = $filesystemProvider->getForVolume($snapshot->volume);
 
-    expect($snapshot->job->status)->toBe('completed')
+    expect($snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($snapshot->file_size)->toBeGreaterThan(0)
         ->and($filesystem->fileExists($snapshot->filename))->toBeTrue();
 

--- a/tests/Integration/SshTunnelTest.php
+++ b/tests/Integration/SshTunnelTest.php
@@ -10,6 +10,7 @@
  * Run with: php artisan test --filter=SshTunnelTest
  */
 
+use App\Enums\BackupJobStatus;
 use App\Jobs\ProcessBackupJob;
 use App\Jobs\ProcessRestoreJob;
 use App\Services\Backup\BackupJobFactory;
@@ -84,7 +85,7 @@ test('MySQL backup and restore through SSH tunnel', function () {
 
     $filesystem = $filesystemProvider->getForVolume($snapshot->volume);
 
-    expect($snapshot->job->status)->toBe('completed')
+    expect($snapshot->job->status)->toBe(BackupJobStatus::Completed)
         ->and($snapshot->file_size)->toBeGreaterThan(0)
         ->and($filesystem->fileExists($snapshot->filename))->toBeTrue();
 


### PR DESCRIPTION
## Summary

Removes copy-pasted query predicates and magic strings around backup-job status. Three related cleanups (no behavior change):

1. **`BackupJobStatus` enum** (`app/Enums/BackupJobStatus.php`), cast on `BackupJob::$status`. Replaces the bare `'pending'`/`'running'`/`'completed'`/`'failed'` strings scattered across ~20 files (models, services, commands, livewire, policy, MCP tools). `AgentJob` keeps its own `STATUS_*` constants — different lifecycle (it also has `'claimed'`). Blade reads the backing value via `?->value` where a string is needed; the `job-status-indicator` component normalizes a `BackedEnum` to its value so all callers keep working.

2. **`Snapshot::completed()` scope** — replaces three inconsistent spellings of "snapshot whose job completed" (`whereRaw` / `whereHas` / `whereRelation`) at every call site. Two nested string-relation closures keep an explicit `/** @var Builder<Snapshot> */` annotation — larastan can't resolve scopes on a generic `Builder` there ([larastan#171](https://github.com/larastan/larastan/issues/171) / [#494](https://github.com/larastan/larastan/issues/494)); the annotation is a type hint, **not** a suppression, so a typo'd scope still errors.

3. **`Snapshot::fileExists()` / `fileMissing()` and `BackupJob::inProgress()` scopes** — collapse the repeated `file_exists` and `['running','pending']` predicates.

Also documented `make ide-helper` in CLAUDE.md (model type hints feed PHPStan via `_ide_helper_models.php`).

## Test plan

- [x] `make lint-fix` — passes
- [x] `make phpstan` — no errors (regenerated model type hints via `make ide-helper`)
- [x] `make test` — 1137 passed (3191 assertions)

## Notes

Follow-up to the snapshot-counter regression work (#397) — that PR restored the `completed()` filter; this one centralizes it (and the related predicates) so the three-way inconsistency can't drift again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development guidance for keeping IDE helper model type hints in sync (including the recommended IDE helper command).

* **Refactor**
  * Standardized backup job status handling across the app using a unified status enum.
  * Centralized “in-progress” and “completed” filtering via reusable scopes, improving consistency in dashboards and snapshot/restore flows.
  * Updated job status display to reliably use the underlying status value.

* **Tests**
  * Updated assertions to use the new status enum, plus added a dashboard success-rate edge-case test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->