### PR TITLE
feat: remove Beta badge from Agents menu (#388)

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -55,7 +55,7 @@
                 @can('viewAny', \App\Models\User::class)
                     <x-menu-item title="{{ __('Users') }}" icon="o-users" link="{{ route('users.index') }}" wire:navigate />
                 @endcan
-                <x-menu-item :title="__('Agents')" icon="o-cpu-chip" :link="route('agents.index')" wire:navigate :badge="__('Beta')" badge-classes="badge-warning badge-soft badge-xs" />
+                <x-menu-item :title="__('Agents')" icon="o-cpu-chip" :link="route('agents.index')" wire:navigate />
                 <x-menu-separator />
                 <x-menu-item :title="__('Configuration')" icon="o-cog-6-tooth" :link="route('configuration.application')" wire:navigate />
                 <x-menu-item title="{{ __('API Docs') }}" no-wire-navigate="true" icon="o-document-text" link="{{ route('scramble.docs.ui') }}" />


### PR DESCRIPTION
## Summary

Removes the **Beta** badge from the Agents menu item in the sidebar.

The remote agent feature was shipped again in `1.5.0` and has now been validated in staging and production by multiple users (#388: @weiw11, @peterbuga, @Dylonni confirmed backups to remote storage work as expected, no issues reported). As planned in the issue thread, the beta flag can now be dropped.

Closes #388

## Changes

- `resources/views/layouts/app.blade.php` — drop `:badge="__('Beta')"` and `badge-classes` from the Agents `<x-menu-item>`

## Test plan

- [x] Lint (Pint), PHPStan, and full test suite pass via pre-commit hook (1142 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The "Beta" badge has been removed from the Agents navigation item in the sidebar, reflecting the feature's updated status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->