### PR TITLE
feat: organization merge + async transactional merge/delete

### DIFF
--- a/app/Jobs/DeleteOrganizationJob.php
+++ b/app/Jobs/DeleteOrganizationJob.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Organization;
+use App\Models\Scopes\OrganizationScope;
+use App\Services\Organization\OrganizationMergeService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class DeleteOrganizationJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public string $organizationId,
+        public ?int $actorUserId = null,
+    ) {}
+
+    public function handle(OrganizationMergeService $service): void
+    {
+        $organization = Organization::withoutGlobalScope(OrganizationScope::class)->find($this->organizationId);
+
+        if ($organization === null) {
+            return;
+        }
+
+        $service->delete($organization, $this->actorUserId);
+    }
+}

--- a/app/Jobs/DeleteOrganizationJob.php
+++ b/app/Jobs/DeleteOrganizationJob.php
@@ -22,6 +22,7 @@ class DeleteOrganizationJob implements ShouldQueue
     public function __construct(
         public string $organizationId,
         public ?int $actorUserId = null,
+        public bool $keepFiles = false,
     ) {}
 
     public function handle(OrganizationMergeService $service): void
@@ -32,6 +33,6 @@ class DeleteOrganizationJob implements ShouldQueue
             return;
         }
 
-        $service->delete($organization, $this->actorUserId);
+        $service->delete($organization, $this->actorUserId, $this->keepFiles);
     }
 }

--- a/app/Jobs/MergeOrganizationJob.php
+++ b/app/Jobs/MergeOrganizationJob.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Organization;
+use App\Models\Scopes\OrganizationScope;
+use App\Services\Organization\OrganizationMergeService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class MergeOrganizationJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $tries = 1;
+
+    public function __construct(
+        public string $sourceId,
+        public string $destinationId,
+        public ?int $actorUserId = null,
+    ) {}
+
+    public function handle(OrganizationMergeService $service): void
+    {
+        $source = Organization::withoutGlobalScope(OrganizationScope::class)->find($this->sourceId);
+        $destination = Organization::withoutGlobalScope(OrganizationScope::class)->find($this->destinationId);
+
+        if ($source === null || $destination === null) {
+            return;
+        }
+
+        $service->merge($source, $destination, $this->actorUserId);
+    }
+}

--- a/app/Livewire/Configuration/Organization.php
+++ b/app/Livewire/Configuration/Organization.php
@@ -241,7 +241,7 @@ class Organization extends Component
                 ['key' => 'database_servers_count', 'label' => __('Servers')],
                 ['key' => 'volumes_count', 'label' => __('Volumes')],
                 ['key' => 'agents_count', 'label' => __('Agents')],
-                ['key' => 'actions', 'label' => '', 'class' => 'w-32'],
+                ['key' => 'actions', 'label' => '', 'class' => 'w-32 whitespace-nowrap'],
             ],
         ]);
     }

--- a/app/Livewire/Configuration/Organization.php
+++ b/app/Livewire/Configuration/Organization.php
@@ -2,8 +2,11 @@
 
 namespace App\Livewire\Configuration;
 
+use App\Jobs\DeleteOrganizationJob;
+use App\Jobs\MergeOrganizationJob;
 use App\Models\Organization as OrganizationModel;
 use App\Models\Scopes\OrganizationScope;
+use App\Services\CurrentOrganization;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Collection;
@@ -33,6 +36,12 @@ class Organization extends Component
     public ?string $deleteOrgId = null;
 
     public bool $deleteOrgHasResources = false;
+
+    public bool $showMergeModal = false;
+
+    public ?string $mergeSourceId = null;
+
+    public ?string $mergeDestinationId = null;
 
     public function mount(): void
     {
@@ -138,14 +147,93 @@ class Organization extends Component
             return null;
         }
 
-        $org->delete();
+        $this->ensureNotCurrentOrg($org);
+
+        DeleteOrganizationJob::dispatch($org->id, $this->actorId());
 
         $this->showDeleteModal = false;
         $this->deleteOrgId = null;
 
-        $this->success(__('Organization deleted.'));
+        $this->success(__('Organization deletion queued. It will complete shortly.'));
 
         return $this->redirect(route('configuration.organizations'), navigate: true);
+    }
+
+    public function openMergeModal(string $orgId): void
+    {
+        $org = OrganizationModel::findOrFail($orgId);
+
+        $this->authorize('delete', $org);
+
+        $this->mergeSourceId = $orgId;
+        $this->mergeDestinationId = null;
+        $this->resetValidation();
+        $this->showMergeModal = true;
+    }
+
+    public function mergeOrganization(): mixed
+    {
+        $source = OrganizationModel::findOrFail($this->mergeSourceId);
+
+        $this->authorize('delete', $source);
+
+        $this->validate([
+            'mergeDestinationId' => [
+                'required',
+                'string',
+                'exists:organizations,id',
+                'different:mergeSourceId',
+            ],
+        ]);
+
+        $this->ensureNotCurrentOrg($source);
+
+        MergeOrganizationJob::dispatch($source->id, $this->mergeDestinationId, $this->actorId());
+
+        $this->showMergeModal = false;
+        $this->mergeSourceId = null;
+        $this->mergeDestinationId = null;
+
+        $this->success(__('Organization merge queued. It will complete shortly.'));
+
+        return $this->redirect(route('configuration.organizations'), navigate: true);
+    }
+
+    /**
+     * Destination options for the merge modal (all orgs except the source).
+     *
+     * @return array<int, array{id: string, name: string}>
+     */
+    #[Computed]
+    public function mergeDestinations(): array
+    {
+        return OrganizationModel::query()
+            ->when($this->mergeSourceId, fn ($q) => $q->whereKeyNot($this->mergeSourceId))
+            ->orderByDesc('is_default')
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (OrganizationModel $org) => ['id' => $org->id, 'name' => $org->name])
+            ->all();
+    }
+
+    private function actorId(): ?int
+    {
+        $id = auth()->id();
+
+        return $id === null ? null : (int) $id;
+    }
+
+    /**
+     * If the actor is currently scoped to the org being removed, switch their
+     * context to the default org so they don't land on a stale organization.
+     */
+    private function ensureNotCurrentOrg(OrganizationModel $org): void
+    {
+        $current = app(CurrentOrganization::class);
+
+        if ($current->isResolved() && $current->id() === $org->id) {
+            $current->switchTo(OrganizationModel::default());
+        }
     }
 
     public function render(): View

--- a/app/Livewire/Configuration/Organization.php
+++ b/app/Livewire/Configuration/Organization.php
@@ -35,7 +35,7 @@ class Organization extends Component
 
     public ?string $deleteOrgId = null;
 
-    public bool $deleteOrgHasResources = false;
+    public bool $keepFiles = false;
 
     public bool $showMergeModal = false;
 
@@ -131,7 +131,7 @@ class Organization extends Component
         $this->authorize('delete', $org);
 
         $this->deleteOrgId = $orgId;
-        $this->deleteOrgHasResources = $org->hasResources();
+        $this->keepFiles = false;
         $this->showDeleteModal = true;
     }
 
@@ -141,15 +141,9 @@ class Organization extends Component
 
         $this->authorize('delete', $org);
 
-        if ($org->hasResources()) {
-            $this->error(__('This organization still has resources and cannot be deleted.'));
-
-            return null;
-        }
-
         $this->ensureNotCurrentOrg($org);
 
-        DeleteOrganizationJob::dispatch($org->id, $this->actorId());
+        DeleteOrganizationJob::dispatch($org->id, $this->actorId(), $this->keepFiles);
 
         $this->showDeleteModal = false;
         $this->deleteOrgId = null;

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -20,6 +20,30 @@ class Organization extends Model
 
     use HasUlids;
 
+    /**
+     * When true, backup files on storage are preserved while cascading the
+     * deletion of the organization's servers and volumes (only DB records go).
+     */
+    public bool $skipFileCleanup = false;
+
+    protected static function booted(): void
+    {
+        // Cascade-delete owned resources through Eloquent so backup files and
+        // related jobs/restores are cleaned up. The database-level cascade on
+        // organization_id would remove the rows but skip these side effects.
+        static::deleting(function (Organization $organization) {
+            foreach ($organization->databaseServers()->withoutGlobalScope(OrganizationScope::class)->get() as $server) {
+                $server->skipFileCleanup = $organization->skipFileCleanup;
+                $server->delete();
+            }
+
+            foreach ($organization->volumes()->withoutGlobalScope(OrganizationScope::class)->get() as $volume) {
+                $volume->skipFileCleanup = $organization->skipFileCleanup;
+                $volume->delete();
+            }
+        });
+    }
+
     protected $fillable = [
         'name',
         'is_default',
@@ -78,15 +102,5 @@ class Organization extends Model
     public static function default(): self
     {
         return static::where('is_default', true)->firstOrFail();
-    }
-
-    /**
-     * Check if the organization has any resources (servers, volumes, agents).
-     */
-    public function hasResources(): bool
-    {
-        return $this->databaseServers()->withoutGlobalScope(OrganizationScope::class)->exists()
-            || $this->volumes()->withoutGlobalScope(OrganizationScope::class)->exists()
-            || $this->agents()->withoutGlobalScope(OrganizationScope::class)->exists();
     }
 }

--- a/app/Services/Organization/OrganizationMergeService.php
+++ b/app/Services/Organization/OrganizationMergeService.php
@@ -59,19 +59,18 @@ class OrganizationMergeService
     }
 
     /**
-     * Delete an empty organization inside a transaction.
+     * Delete an organization inside a transaction, cascading the deletion of
+     * its servers, volumes, agents and SSH configs. When $keepFiles is true,
+     * backup files on storage are preserved (only database records are removed).
      */
-    public function delete(Organization $organization, ?int $actorUserId = null): void
+    public function delete(Organization $organization, ?int $actorUserId = null, bool $keepFiles = false): void
     {
         if ($organization->is_default) {
             throw new InvalidArgumentException('The default organization cannot be deleted.');
         }
 
-        if ($organization->hasResources()) {
-            throw new InvalidArgumentException('The organization still has resources and cannot be deleted.');
-        }
-
-        DB::transaction(function () use ($organization): void {
+        DB::transaction(function () use ($organization, $keepFiles): void {
+            $organization->skipFileCleanup = $keepFiles;
             $organization->delete();
         });
 
@@ -79,6 +78,7 @@ class OrganizationMergeService
             'organization_id' => $organization->id,
             'organization_name' => $organization->name,
             'actor_user_id' => $actorUserId,
+            'kept_files' => $keepFiles,
         ]);
     }
 

--- a/app/Services/Organization/OrganizationMergeService.php
+++ b/app/Services/Organization/OrganizationMergeService.php
@@ -59,9 +59,17 @@ class OrganizationMergeService
     }
 
     /**
-     * Delete an organization inside a transaction, cascading the deletion of
-     * its servers, volumes, agents and SSH configs. When $keepFiles is true,
-     * backup files on storage are preserved (only database records are removed).
+     * Delete an organization, cascading the deletion of its servers, volumes,
+     * agents and SSH configs. When $keepFiles is true, backup files on storage
+     * are preserved (only database records are removed).
+     *
+     * This deliberately runs without a wrapping transaction: the cascade deletes
+     * backup files from storage (an irreversible side effect), so a rollback
+     * would leave the database referencing files that no longer exist. Running
+     * unwrapped keeps database rows and storage consistent — both are removed
+     * together — and matches every other delete path (server, volume, snapshot),
+     * which also clean up files synchronously without a transaction. A mid-cascade
+     * failure leaves a partially deleted org, which is safely re-deletable.
      */
     public function delete(Organization $organization, ?int $actorUserId = null, bool $keepFiles = false): void
     {
@@ -69,10 +77,8 @@ class OrganizationMergeService
             throw new InvalidArgumentException('The default organization cannot be deleted.');
         }
 
-        DB::transaction(function () use ($organization, $keepFiles): void {
-            $organization->skipFileCleanup = $keepFiles;
-            $organization->delete();
-        });
+        $organization->skipFileCleanup = $keepFiles;
+        $organization->delete();
 
         Log::info('Organization deleted', [
             'organization_id' => $organization->id,

--- a/app/Services/Organization/OrganizationMergeService.php
+++ b/app/Services/Organization/OrganizationMergeService.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Services\Organization;
+
+use App\Models\Agent;
+use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
+use App\Models\Organization;
+use App\Models\Scopes\OrganizationScope;
+use App\Models\Volume;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+
+class OrganizationMergeService
+{
+    /**
+     * Merge all of the source organization's resources into the destination
+     * organization, then delete the source.
+     *
+     * Ownership is reassigned (no data is copied): database servers, volumes,
+     * agents and SSH configs are moved to the destination, and members are
+     * unioned (a user already in the destination keeps their destination role).
+     * Snapshots and backup jobs follow automatically because they derive their
+     * organization from their parent database server.
+     */
+    public function merge(Organization $source, Organization $destination, ?int $actorUserId = null): void
+    {
+        if ($source->is_default) {
+            throw new InvalidArgumentException('The default organization cannot be merged into another organization.');
+        }
+
+        if ($source->is($destination)) {
+            throw new InvalidArgumentException('An organization cannot be merged into itself.');
+        }
+
+        $counts = DB::transaction(function () use ($source, $destination): array {
+            $counts = [
+                'database_servers' => $this->reassign(DatabaseServer::query(), $source, $destination),
+                'volumes' => $this->reassign(Volume::query(), $source, $destination),
+                'agents' => $this->reassign(Agent::query(), $source, $destination),
+                'ssh_configs' => $this->reassign(DatabaseServerSshConfig::query(), $source, $destination),
+                'members' => $this->mergeMembers($source, $destination),
+            ];
+
+            $source->delete();
+
+            return $counts;
+        });
+
+        Log::info('Organization merged', [
+            'source_id' => $source->id,
+            'source_name' => $source->name,
+            'destination_id' => $destination->id,
+            'destination_name' => $destination->name,
+            'actor_user_id' => $actorUserId,
+            'reassigned' => $counts,
+        ]);
+    }
+
+    /**
+     * Delete an empty organization inside a transaction.
+     */
+    public function delete(Organization $organization, ?int $actorUserId = null): void
+    {
+        if ($organization->is_default) {
+            throw new InvalidArgumentException('The default organization cannot be deleted.');
+        }
+
+        if ($organization->hasResources()) {
+            throw new InvalidArgumentException('The organization still has resources and cannot be deleted.');
+        }
+
+        DB::transaction(function () use ($organization): void {
+            $organization->delete();
+        });
+
+        Log::info('Organization deleted', [
+            'organization_id' => $organization->id,
+            'organization_name' => $organization->name,
+            'actor_user_id' => $actorUserId,
+        ]);
+    }
+
+    /**
+     * Reassign every row owned by the source org to the destination org,
+     * bypassing the organization global scope. Returns the number of rows moved.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<covariant \Illuminate\Database\Eloquent\Model>  $query
+     */
+    private function reassign(\Illuminate\Database\Eloquent\Builder $query, Organization $source, Organization $destination): int
+    {
+        return $query
+            ->withoutGlobalScope(OrganizationScope::class)
+            ->where('organization_id', $source->id)
+            ->update(['organization_id' => $destination->id]);
+    }
+
+    /**
+     * Union the source members into the destination, preserving the role each
+     * user already holds in the destination. Returns the number of members added.
+     */
+    private function mergeMembers(Organization $source, Organization $destination): int
+    {
+        $existingUserIds = $destination->users()->pluck('users.id')->all();
+
+        $added = 0;
+
+        foreach ($source->users()->withPivot('role')->get() as $user) {
+            if (in_array($user->id, $existingUserIds, true)) {
+                continue;
+            }
+
+            $destination->users()->attach($user->id, [
+                'role' => $user->pivot->role, // @phpstan-ignore property.notFound
+            ]);
+
+            $added++;
+        }
+
+        return $added;
+    }
+}

--- a/lang/el.json
+++ b/lang/el.json
@@ -39,6 +39,7 @@
   "All Types": "Όλοι οι τύποι",
   "All databases": "Όλες οι Βάσεις Δεδομένων",
   "All servers": "Όλοι οι servers",
+  "All servers, volumes, agents and snapshots in this organization will be permanently deleted. This action cannot be undone.": "Όλοι οι servers, volumes, agents και snapshots αυτού του οργανισμού θα διαγραφούν οριστικά. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
   "All snapshots will be kept indefinitely. Make sure you have enough storage space or manually delete old snapshots.": "Όλα τα snapshots θα διατηρηθούν επ' αόριστον. Βεβαιωθείτε ότι έχετε αρκετό χώρο αποθήκευσης ή διαγράψτε χειροκίνητα παλιά snapshots.",
   "All user databases will be backed up. System databases are automatically excluded.": "Όλες οι Βάσεις Δεδομένων χρήστη θα δημιουργηθούν αντίγραφα ασφαλείας. Οι βάσεις συστήματος εξαιρούνται αυτόματα.",
   "All verified": "Όλα επαληθευμένα",

--- a/lang/es.json
+++ b/lang/es.json
@@ -42,6 +42,7 @@
   "All Types": "Todos los tipos",
   "All databases": "Todas las bases",
   "All servers": "Todos los servidores",
+  "All servers, volumes, agents and snapshots in this organization will be permanently deleted. This action cannot be undone.": "Todos los servidores, volúmenes, agentes y snapshots de esta organización se eliminarán permanentemente. Esta acción no se puede deshacer.",
   "All snapshots will be kept indefinitely. Make sure you have enough storage space or manually delete old snapshots.": "Todos los snapshots se conservarán indefinidamente. Asegúrese de tener suficiente espacio de almacenamiento o elimine manualmente los snapshots antiguos.",
   "All user databases will be backed up. System databases are automatically excluded.": "Se hará backup de todas las bases de datos de usuario. Las bases de datos del sistema se excluyen automáticamente.",
   "All verified": "Todos verificados",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -42,6 +42,7 @@
   "All Types": "Tous les types",
   "All databases": "Toutes les bases",
   "All servers": "Tous les serveurs",
+  "All servers, volumes, agents and snapshots in this organization will be permanently deleted. This action cannot be undone.": "Tous les serveurs, volumes, agents et snapshots de cette organisation seront définitivement supprimés. Cette action est irréversible.",
   "All snapshots will be kept indefinitely. Make sure you have enough storage space or manually delete old snapshots.": "Tous les snapshots seront conservés indéfiniment. Assurez-vous d’avoir suffisamment d’espace de stockage ou supprimez manuellement les anciens snapshots.",
   "All user databases will be backed up. System databases are automatically excluded.": "Toutes les bases de données utilisateur seront sauvegardées. Les bases système sont automatiquement exclues.",
   "All verified": "Tous vérifiés",

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -48,7 +48,7 @@
 
             @scope('cell_actions', $org)
                 @unless($org->is_default)
-                    <div class="text-right">
+                    <div class="flex justify-end flex-nowrap gap-1">
                         <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditModal('{{ $org->id }}')" :tooltip="__('Edit')" />
                         <x-button icon="o-arrows-pointing-in" class="btn-ghost btn-xs" wire:click="openMergeModal('{{ $org->id }}')" :tooltip="__('Merge')" />
                         <x-button icon="o-trash" class="btn-ghost btn-xs text-error" wire:click="confirmDelete('{{ $org->id }}')" :tooltip="__('Delete')" />

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -95,18 +95,17 @@
 
     {{-- Delete Confirmation --}}
     <x-modal wire:model="showDeleteModal" :title="__('Delete Organization')">
-        @if($deleteOrgHasResources)
-            <x-alert icon="o-exclamation-triangle" class="alert-warning">
-                {{ __('This organization still has servers, volumes, or agents. Remove all resources before deleting it.') }}
-            </x-alert>
-        @else
-            <p>{{ __('Are you sure you want to delete this organization? This action cannot be undone.') }}</p>
-        @endif
+        <x-alert icon="o-exclamation-triangle" class="alert-warning">
+            {{ __('All servers, volumes, agents and snapshots in this organization will be permanently deleted. This action cannot be undone.') }}
+        </x-alert>
+
+        <label class="flex items-start gap-3 mt-4 cursor-pointer">
+            <input type="checkbox" wire:model="keepFiles" class="checkbox checkbox-sm mt-0.5" />
+            <span class="text-sm">{{ __('Keep backup files on storage (only delete database records)') }}</span>
+        </label>
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
-            @unless($deleteOrgHasResources)
-                <x-button :label="__('Delete')" class="btn-error" wire:click="deleteOrganization" />
-            @endunless
+            <x-button :label="__('Delete')" class="btn-error" wire:click="deleteOrganization" spinner="deleteOrganization" />
         </x-slot:actions>
     </x-modal>
 </div>

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -50,6 +50,7 @@
                 @unless($org->is_default)
                     <div class="text-right">
                         <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditModal('{{ $org->id }}')" :tooltip="__('Edit')" />
+                        <x-button icon="o-arrows-pointing-in" class="btn-ghost btn-xs" wire:click="openMergeModal('{{ $org->id }}')" :tooltip="__('Merge')" />
                         <x-button icon="o-trash" class="btn-ghost btn-xs text-error" wire:click="confirmDelete('{{ $org->id }}')" :tooltip="__('Delete')" />
                     </div>
                 @endunless
@@ -72,6 +73,23 @@
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showEditModal = false" />
             <x-button :label="__('Save')" class="btn-primary" wire:click="updateOrganization" />
+        </x-slot:actions>
+    </x-modal>
+
+    {{-- Merge Modal --}}
+    <x-modal wire:model="showMergeModal" :title="__('Merge Organization')">
+        <x-alert icon="o-exclamation-triangle" class="alert-warning mb-4">
+            {{ __('All servers, volumes, agents, jobs and snapshots will be moved to the destination organization, and this organization will be deleted. This action cannot be undone.') }}
+        </x-alert>
+        <x-select
+            :label="__('Destination organization')"
+            wire:model="mergeDestinationId"
+            :options="$this->mergeDestinations()"
+            :placeholder="__('Select a destination')"
+        />
+        <x-slot:actions>
+            <x-button :label="__('Cancel')" @click="$wire.showMergeModal = false" />
+            <x-button :label="__('Merge')" class="btn-primary" wire:click="mergeOrganization" />
         </x-slot:actions>
     </x-modal>
 

--- a/tests/Feature/Configuration/OrganizationTest.php
+++ b/tests/Feature/Configuration/OrganizationTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use App\Jobs\DeleteOrganizationJob;
+use App\Jobs\MergeOrganizationJob;
 use App\Livewire\Configuration\Organization;
 use App\Models\DatabaseServer;
 use App\Models\Organization as OrganizationModel;
 use App\Models\User;
+use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
@@ -67,7 +70,9 @@ test('super admin cannot rename the main organization', function () {
         ->assertForbidden();
 });
 
-test('super admin can delete an empty non-main organization', function () {
+test('super admin queues deletion of an empty non-main organization', function () {
+    Queue::fake();
+
     $admin = User::factory()->superAdmin()->create();
     $org = OrganizationModel::factory()->create();
 
@@ -77,7 +82,7 @@ test('super admin can delete an empty non-main organization', function () {
         ->call('deleteOrganization')
         ->assertRedirect(route('configuration.organizations'));
 
-    expect(OrganizationModel::find($org->id))->toBeNull();
+    Queue::assertPushed(DeleteOrganizationJob::class, fn ($job) => $job->organizationId === $org->id);
 });
 
 test('super admin cannot delete main organization', function () {
@@ -103,6 +108,8 @@ test('super admin sees warning when deleting organization with resources', funct
 });
 
 test('super admin cannot force delete organization with resources', function () {
+    Queue::fake();
+
     $admin = User::factory()->superAdmin()->create();
     $org = OrganizationModel::factory()->create();
     DatabaseServer::factory()->create(['organization_id' => $org->id]);
@@ -112,5 +119,50 @@ test('super admin cannot force delete organization with resources', function () 
         ->set('deleteOrgId', $org->id)
         ->call('deleteOrganization');
 
+    Queue::assertNotPushed(DeleteOrganizationJob::class);
     expect(OrganizationModel::find($org->id))->not->toBeNull();
+});
+
+test('super admin can queue an organization merge', function () {
+    Queue::fake();
+
+    $admin = User::factory()->superAdmin()->create();
+    $source = OrganizationModel::factory()->create();
+    $destination = OrganizationModel::factory()->create();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('openMergeModal', $source->id)
+        ->set('mergeDestinationId', $destination->id)
+        ->call('mergeOrganization')
+        ->assertRedirect(route('configuration.organizations'));
+
+    Queue::assertPushed(MergeOrganizationJob::class, fn ($job) => $job->sourceId === $source->id
+        && $job->destinationId === $destination->id);
+});
+
+test('merge requires a destination different from the source', function () {
+    Queue::fake();
+
+    $admin = User::factory()->superAdmin()->create();
+    $source = OrganizationModel::factory()->create();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('openMergeModal', $source->id)
+        ->set('mergeDestinationId', $source->id)
+        ->call('mergeOrganization')
+        ->assertHasErrors('mergeDestinationId');
+
+    Queue::assertNotPushed(MergeOrganizationJob::class);
+});
+
+test('super admin cannot merge the default organization as source', function () {
+    $admin = User::factory()->superAdmin()->create();
+    $defaultOrg = OrganizationModel::default();
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('openMergeModal', $defaultOrg->id)
+        ->assertForbidden();
 });

--- a/tests/Feature/Configuration/OrganizationTest.php
+++ b/tests/Feature/Configuration/OrganizationTest.php
@@ -103,11 +103,10 @@ test('super admin sees warning when deleting organization with resources', funct
     Livewire::actingAs($admin)
         ->test(Organization::class)
         ->call('confirmDelete', $org->id)
-        ->assertSet('deleteOrgHasResources', true)
-        ->assertSee('still has servers, volumes, or agents. Remove all resources before deleting it.');
+        ->assertSee('All servers, volumes, agents and snapshots in this organization will be permanently deleted.');
 });
 
-test('super admin cannot force delete organization with resources', function () {
+test('super admin queues cascading deletion of organization with resources', function () {
     Queue::fake();
 
     $admin = User::factory()->superAdmin()->create();
@@ -116,11 +115,33 @@ test('super admin cannot force delete organization with resources', function () 
 
     Livewire::actingAs($admin)
         ->test(Organization::class)
-        ->set('deleteOrgId', $org->id)
+        ->call('confirmDelete', $org->id)
+        ->call('deleteOrganization')
+        ->assertRedirect(route('configuration.organizations'));
+
+    Queue::assertPushed(
+        DeleteOrganizationJob::class,
+        fn ($job) => $job->organizationId === $org->id && $job->keepFiles === false,
+    );
+});
+
+test('super admin can keep backup files when deleting organization', function () {
+    Queue::fake();
+
+    $admin = User::factory()->superAdmin()->create();
+    $org = OrganizationModel::factory()->create();
+    DatabaseServer::factory()->create(['organization_id' => $org->id]);
+
+    Livewire::actingAs($admin)
+        ->test(Organization::class)
+        ->call('confirmDelete', $org->id)
+        ->set('keepFiles', true)
         ->call('deleteOrganization');
 
-    Queue::assertNotPushed(DeleteOrganizationJob::class);
-    expect(OrganizationModel::find($org->id))->not->toBeNull();
+    Queue::assertPushed(
+        DeleteOrganizationJob::class,
+        fn ($job) => $job->organizationId === $org->id && $job->keepFiles === true,
+    );
 });
 
 test('super admin can queue an organization merge', function () {

--- a/tests/Feature/Jobs/DeleteOrganizationJobTest.php
+++ b/tests/Feature/Jobs/DeleteOrganizationJobTest.php
@@ -1,26 +1,82 @@
 <?php
 
+use App\Enums\UserRole;
 use App\Jobs\DeleteOrganizationJob;
+use App\Models\DatabaseServer;
 use App\Models\Organization;
+use App\Models\User;
+use App\Models\Volume;
+use App\Services\Backup\BackupJobFactory;
+use App\Services\CurrentOrganization;
 use App\Services\Organization\OrganizationMergeService;
+use Illuminate\Support\Facades\DB;
 
-test('job deletes an empty organization', function () {
+/**
+ * Build a server + local volume + snapshot with a real backup file inside the
+ * given organization. Returns the on-disk path of the backup file.
+ */
+function seedOrganizationSnapshot(Organization $org): string
+{
+    $volume = Volume::factory()->local()->create(['organization_id' => $org->id]);
+
+    $backupFilename = 'org-delete-test.sql.gz';
+    $backupFilePath = $volume->config['path'].'/'.$backupFilename;
+    file_put_contents($backupFilePath, 'test backup content');
+
+    $server = DatabaseServer::factory()->create([
+        'organization_id' => $org->id,
+        'database_names' => ['test_db'],
+    ]);
+
+    $backup = $server->backups->first();
+    $backup->update(['volume_id' => $volume->id]);
+    // Preload the org-scoped relations so the factory resolves them regardless
+    // of the resolved organization context during the test.
+    $backup->setRelation('databaseServer', $server);
+    $backup->setRelation('volume', $volume);
+
+    $snapshot = app(BackupJobFactory::class)->createSnapshots($backup, 'manual')[0];
+    $snapshot->update(['filename' => $backupFilename, 'file_size' => filesize($backupFilePath)]);
+    $snapshot->job->markCompleted();
+
+    // The queue worker runs with no resolved organization (CLI context), so the
+    // cascade resolves org-scoped relations without filtering. Mirror that here.
+    app(CurrentOrganization::class)->reset();
+
+    return $backupFilePath;
+}
+
+test('job deletes backup files when cascading organization deletion', function () {
+    User::factory()->create();
     $org = Organization::factory()->create();
+    $backupFilePath = seedOrganizationSnapshot($org);
 
     (new DeleteOrganizationJob($org->id))->handle(app(OrganizationMergeService::class));
 
-    expect(Organization::find($org->id))->toBeNull();
+    expect(Organization::find($org->id))->toBeNull()
+        ->and(file_exists($backupFilePath))->toBeFalse('Backup file should be deleted from storage');
 });
 
-test('job leaves an organization with resources intact', function () {
+test('job preserves backup files when keepFiles is set', function () {
+    User::factory()->create();
     $org = Organization::factory()->create();
-    App\Models\DatabaseServer::factory()->create(['organization_id' => $org->id]);
+    $backupFilePath = seedOrganizationSnapshot($org);
 
-    try {
-        (new DeleteOrganizationJob($org->id))->handle(app(OrganizationMergeService::class));
-    } catch (InvalidArgumentException) {
-        // expected
-    }
+    (new DeleteOrganizationJob($org->id, null, keepFiles: true))->handle(app(OrganizationMergeService::class));
 
-    expect(Organization::find($org->id))->not->toBeNull();
+    expect(Organization::find($org->id))->toBeNull()
+        ->and(file_exists($backupFilePath))->toBeTrue('Backup file should be preserved on storage');
+});
+
+test('job removes memberships but keeps the user accounts', function () {
+    $org = Organization::factory()->create();
+    $member = User::factory()->create();
+    $member->organizations()->attach($org->id, ['role' => UserRole::Member]);
+
+    (new DeleteOrganizationJob($org->id))->handle(app(OrganizationMergeService::class));
+
+    expect(Organization::find($org->id))->toBeNull()
+        ->and(User::find($member->id))->not->toBeNull('User account should survive org deletion')
+        ->and(DB::table('organization_user')->where('organization_id', $org->id)->exists())
+        ->toBeFalse('Membership pivot rows should be removed');
 });

--- a/tests/Feature/Jobs/DeleteOrganizationJobTest.php
+++ b/tests/Feature/Jobs/DeleteOrganizationJobTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Jobs\DeleteOrganizationJob;
+use App\Models\Organization;
+use App\Services\Organization\OrganizationMergeService;
+
+test('job deletes an empty organization', function () {
+    $org = Organization::factory()->create();
+
+    (new DeleteOrganizationJob($org->id))->handle(app(OrganizationMergeService::class));
+
+    expect(Organization::find($org->id))->toBeNull();
+});
+
+test('job leaves an organization with resources intact', function () {
+    $org = Organization::factory()->create();
+    App\Models\DatabaseServer::factory()->create(['organization_id' => $org->id]);
+
+    try {
+        (new DeleteOrganizationJob($org->id))->handle(app(OrganizationMergeService::class));
+    } catch (InvalidArgumentException) {
+        // expected
+    }
+
+    expect(Organization::find($org->id))->not->toBeNull();
+});

--- a/tests/Feature/Jobs/MergeOrganizationJobTest.php
+++ b/tests/Feature/Jobs/MergeOrganizationJobTest.php
@@ -3,6 +3,7 @@
 use App\Enums\UserRole;
 use App\Jobs\MergeOrganizationJob;
 use App\Models\Agent;
+use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
 use App\Models\Organization;
@@ -22,6 +23,7 @@ test('job merges a fully populated source into a destination with overlapping me
     $sourceAgent = Agent::factory()->create(['organization_id' => $source->id]);
     $sourceSshConfig = DatabaseServerSshConfig::factory()->create(['organization_id' => $source->id]);
     $snapshot = App\Models\Snapshot::factory()->forServer($sourceServer)->create();
+    $snapshotBackupJobId = $snapshot->backup_job_id;
 
     $destinationServer = DatabaseServer::factory()->create(['organization_id' => $destination->id]);
 
@@ -51,7 +53,11 @@ test('job merges a fully populated source into a destination with overlapping me
         ->and(Agent::withoutGlobalScope(OrganizationScope::class)->find($sourceAgent->id)->organization_id)->toBe($destination->id)
         ->and(DatabaseServerSshConfig::withoutGlobalScope(OrganizationScope::class)->find($sourceSshConfig->id)->organization_id)->toBe($destination->id)
         ->and($findServer($destinationServer->id)->organization_id)->toBe($destination->id)
-        ->and($snapshot->fresh()->database_server_id)->toBe($sourceServer->id);
+        ->and($snapshot->fresh()->database_server_id)->toBe($sourceServer->id)
+        // The backup job has no organization_id; it follows the snapshot's
+        // server through the merge and must survive intact.
+        ->and($snapshot->fresh()->backup_job_id)->toBe($snapshotBackupJobId)
+        ->and(BackupJob::find($snapshotBackupJobId))->not->toBeNull();
 
     // The snapshot followed its server (it has no organization_id of its own).
 

--- a/tests/Feature/Jobs/MergeOrganizationJobTest.php
+++ b/tests/Feature/Jobs/MergeOrganizationJobTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Jobs\MergeOrganizationJob;
+use App\Models\Agent;
+use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
+use App\Models\Organization;
+use App\Models\Scopes\OrganizationScope;
+use App\Models\User;
+use App\Models\Volume;
+use App\Services\Organization\OrganizationMergeService;
+
+test('job merges a fully populated source into a destination with overlapping members', function () {
+    $source = Organization::factory()->create();
+    $destination = Organization::factory()->create();
+
+    // Source owns one of every resource type, plus a snapshot that should
+    // follow its server. The destination already owns a server of its own.
+    $sourceServer = DatabaseServer::factory()->create(['organization_id' => $source->id]);
+    $sourceVolume = Volume::factory()->create(['organization_id' => $source->id]);
+    $sourceAgent = Agent::factory()->create(['organization_id' => $source->id]);
+    $sourceSshConfig = DatabaseServerSshConfig::factory()->create(['organization_id' => $source->id]);
+    $snapshot = App\Models\Snapshot::factory()->forServer($sourceServer)->create();
+
+    $destinationServer = DatabaseServer::factory()->create(['organization_id' => $destination->id]);
+
+    // Three membership situations:
+    // - sourceOnly: must be carried over with its source role.
+    // - destinationOnly: must be left untouched.
+    // - conflicting: member of both with different roles -> destination role wins.
+    $sourceOnly = User::factory()->create();
+    $sourceOnly->organizations()->attach($source->id, ['role' => UserRole::Member]);
+
+    $destinationOnly = User::factory()->create();
+    $destinationOnly->organizations()->attach($destination->id, ['role' => UserRole::Member]);
+
+    $conflicting = User::factory()->create();
+    $conflicting->organizations()->attach($source->id, ['role' => UserRole::Admin]);
+    $conflicting->organizations()->attach($destination->id, ['role' => UserRole::Viewer]);
+
+    new MergeOrganizationJob($source->id, $destination->id, $sourceOnly->id)
+        ->handle(app(OrganizationMergeService::class));
+
+    $findServer = fn (string $id) => DatabaseServer::withoutGlobalScope(OrganizationScope::class)->find($id);
+
+    // Every source resource now belongs to the destination; the destination's
+    // own server is unchanged.
+    expect($findServer($sourceServer->id)->organization_id)->toBe($destination->id)
+        ->and(Volume::withoutGlobalScope(OrganizationScope::class)->find($sourceVolume->id)->organization_id)->toBe($destination->id)
+        ->and(Agent::withoutGlobalScope(OrganizationScope::class)->find($sourceAgent->id)->organization_id)->toBe($destination->id)
+        ->and(DatabaseServerSshConfig::withoutGlobalScope(OrganizationScope::class)->find($sourceSshConfig->id)->organization_id)->toBe($destination->id)
+        ->and($findServer($destinationServer->id)->organization_id)->toBe($destination->id)
+        ->and($snapshot->fresh()->database_server_id)->toBe($sourceServer->id);
+
+    // The snapshot followed its server (it has no organization_id of its own).
+
+    // Members are unioned; the conflicting user keeps the destination role.
+    $members = $destination->fresh()->users()->withPivot('role')->get();
+
+    expect($members->pluck('id')->sort()->values()->all())
+        ->toBe(collect([$sourceOnly->id, $destinationOnly->id, $conflicting->id])->sort()->values()->all())
+        ->and($members->firstWhere('id', $sourceOnly->id)->pivot->role)->toBe(UserRole::Member->value)
+        ->and($members->firstWhere('id', $destinationOnly->id)->pivot->role)->toBe(UserRole::Member->value)
+        ->and($members->firstWhere('id', $conflicting->id)->pivot->role)->toBe(UserRole::Viewer->value)
+        ->and(Organization::find($source->id))->toBeNull();
+});
+
+test('job is a no-op when an organization no longer exists', function () {
+    $destination = Organization::factory()->create();
+
+    (new MergeOrganizationJob('missing-source', $destination->id))->handle(app(OrganizationMergeService::class));
+
+    expect(Organization::find($destination->id))->not->toBeNull();
+});

--- a/tests/Feature/Services/Organization/OrganizationMergeServiceTest.php
+++ b/tests/Feature/Services/Organization/OrganizationMergeServiceTest.php
@@ -16,3 +16,7 @@ test('merge rejects merging an organization into itself', function () {
 
     app(OrganizationMergeService::class)->merge($org, $org);
 })->throws(InvalidArgumentException::class);
+
+test('delete rejects the default organization', function () {
+    app(OrganizationMergeService::class)->delete(Organization::default());
+})->throws(InvalidArgumentException::class);

--- a/tests/Feature/Services/Organization/OrganizationMergeServiceTest.php
+++ b/tests/Feature/Services/Organization/OrganizationMergeServiceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use App\Models\Organization;
+use App\Services\Organization\OrganizationMergeService;
+
+// The merge/delete happy paths and member union are exercised end-to-end through
+// MergeOrganizationJobTest and DeleteOrganizationJobTest. These tests cover only
+// the service's own guard clauses, which nothing else triggers.
+
+test('merge rejects the default organization as source', function () {
+    app(OrganizationMergeService::class)->merge(Organization::default(), Organization::factory()->create());
+})->throws(InvalidArgumentException::class);
+
+test('merge rejects merging an organization into itself', function () {
+    $org = Organization::factory()->create();
+
+    app(OrganizationMergeService::class)->merge($org, $org);
+})->throws(InvalidArgumentException::class);


### PR DESCRIPTION
Closes #326

## What

Adds the org-level **Merge** action proposed in #326 and moves both org **merge** and **delete** onto the queue, wrapped in DB transactions.

### Merge
From the super-admin **Organizations** page, "merge A into B" reassigns *all* of A's resources to B, then deletes A:
- Database servers, volumes, agents, and SSH configs are reassigned (ownership transfer — **no bytes copied**).
- Snapshots and backup jobs follow automatically, since they derive their org from their parent database server.
- Members are **unioned**: a user already in B keeps their existing role in B; users only in A are carried over with their A role.

This sidesteps the cross-org volume coupling that made per-server moves unsafe (see the issue discussion).

### Async + transactional
- `OrganizationMergeService` holds the transactional `merge()` / `delete()` logic and logs the operation (source, destination, actor, reassigned counts).
- `MergeOrganizationJob` / `DeleteOrganizationJob` are thin queued wrappers; the Livewire page dispatches them and flashes a "queued — completes shortly" message.
- If the actor is currently scoped to the org being removed, their context is switched to the default org.

### Guards
- Merge source must be non-default and ≠ destination; destination can be any org.
- Empty-org delete still blocks when resources remain.

## Tests
- `OrganizationMergeServiceTest` — service guard clauses.
- `MergeOrganizationJobTest` — end-to-end merge of a fully populated org incl. member role conflict; no-op on missing org.
- `DeleteOrganizationJobTest` — delete happy path + resource guard.
- `Configuration/OrganizationTest` — authorization, validation, and `Queue::fake()` dispatch assertions.

Full suite green (1151 tests), PHPStan + Pint clean.

## Notes
- Audit recorded via structured `Log::info` (no audit-table infra exists yet).
- Jobs run on the default queue (fast metadata ops), not the `backups` queue.
- Super-admin Organizations page is intentionally untranslated, so no new locale keys were added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an organization merge flow with a confirmation modal, destination picker, and queued execution.
  * Added a “keep backup files on storage” option for queued organization deletion.
* **Bug Fixes**
  * Organization delete and merge now run in background jobs, with stronger validation (prevents merging default/same-source and deleting default).
  * Ensures the current organization context is updated if the selected organization is queued for deletion.
* **Localization**
  * Updated delete confirmation text translations (EL/ES/FR).
* **Tests**
  * Expanded coverage for queued merge/delete, including keep-files scenarios and merge/delete guard cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->