### PR TITLE
feat: support Telegram notification topics

### DIFF
--- a/app/Enums/NotificationChannelType.php
+++ b/app/Enums/NotificationChannelType.php
@@ -105,7 +105,7 @@ enum NotificationChannelType: string
             self::Slack => ['Type' => 'Webhook'],
             self::Discord => array_filter(['Channel ID' => $config['channel_id'] ?? '']),
             self::DiscordWebhook => ['Type' => 'Webhook'],
-            self::Telegram => array_filter(['Chat ID' => $config['chat_id'] ?? '']),
+            self::Telegram => array_filter(['Chat ID' => $config['chat_id'] ?? '', 'Topic ID' => $config['topic_id'] ?? '']),
             self::Pushover => ['Type' => 'Push'],
             self::Gotify => array_filter(['URL' => $config['url'] ?? '']),
             self::Webhook => array_filter(['URL' => $config['url'] ?? '']),

--- a/app/Livewire/Forms/NotificationChannelForm.php
+++ b/app/Livewire/Forms/NotificationChannelForm.php
@@ -29,6 +29,8 @@ class NotificationChannelForm extends Form
 
     public string $config_chat_id = '';
 
+    public string $config_topic_id = '';
+
     public string $config_user_key = '';
 
     public string $config_url = '';
@@ -85,6 +87,7 @@ class NotificationChannelForm extends Form
     {
         $this->has_config_bot_token = ! empty($config['bot_token']);
         $this->config_chat_id = $config['chat_id'] ?? '';
+        $this->config_topic_id = $config['topic_id'] ?? '';
     }
 
     /**
@@ -144,6 +147,7 @@ class NotificationChannelForm extends Form
             NotificationChannelType::Telegram => array_merge($rules, [
                 'config_bot_token' => [($isEdit && $this->has_config_bot_token) ? 'nullable' : 'required', 'string', 'max:500'],
                 'config_chat_id' => ['required', 'string', 'max:100'],
+                'config_topic_id' => ['nullable', 'integer', 'min:1'],
             ]),
             NotificationChannelType::Pushover => array_merge($rules, [
                 'config_token' => [($isEdit && $this->has_config_token) ? 'nullable' : 'required', 'string', 'max:500'],
@@ -175,7 +179,7 @@ class NotificationChannelForm extends Form
             NotificationChannelType::Slack => ['webhook_url' => $this->config_webhook_url],
             NotificationChannelType::Discord => ['token' => $this->config_token, 'channel_id' => $this->config_channel_id],
             NotificationChannelType::DiscordWebhook => ['url' => $this->config_url],
-            NotificationChannelType::Telegram => ['bot_token' => $this->config_bot_token, 'chat_id' => $this->config_chat_id],
+            NotificationChannelType::Telegram => ['bot_token' => $this->config_bot_token, 'chat_id' => $this->config_chat_id, 'topic_id' => $this->config_topic_id],
             NotificationChannelType::Pushover => ['token' => $this->config_token, 'user_key' => $this->config_user_key],
             NotificationChannelType::Gotify => ['url' => $this->config_url, 'token' => $this->config_token],
             NotificationChannelType::Webhook => ['url' => $this->config_url, 'secret' => $this->config_secret],

--- a/app/Notifications/Concerns/HasChannelRouting.php
+++ b/app/Notifications/Concerns/HasChannelRouting.php
@@ -70,8 +70,9 @@ trait HasChannelRouting
     public function toTelegram(object $notifiable): TelegramMessage
     {
         $chatId = (string) ($notifiable->routes['telegram'] ?? '');
+        $topicId = (string) ($notifiable->channelConfig['topic_id'] ?? '');
 
-        return $this->getMessage()->toTelegram($chatId);
+        return $this->getMessage()->toTelegram($chatId, $topicId);
     }
 
     public function toPushover(object $notifiable): PushoverMessage

--- a/app/Notifications/FailedNotificationMessage.php
+++ b/app/Notifications/FailedNotificationMessage.php
@@ -74,7 +74,7 @@ class FailedNotificationMessage
             ]);
     }
 
-    public function toTelegram(string $chatId): TelegramMessage
+    public function toTelegram(string $chatId, ?string $topicId = null): TelegramMessage
     {
         $lines = ['<b>'.e($this->title).'</b>', '', e($this->body), ''];
 
@@ -88,9 +88,15 @@ class FailedNotificationMessage
         $lines[] = '';
         $lines[] = '<i>'.e($this->footerText).'</i>';
 
+        $options = ['parse_mode' => 'HTML'];
+
+        if ($topicId !== null && $topicId !== '') {
+            $options['message_thread_id'] = (int) $topicId;
+        }
+
         return TelegramMessage::create(implode("\n", $lines))
             ->to($chatId)
-            ->options(['parse_mode' => 'HTML'])
+            ->options($options)
             ->button($this->actionText, $this->actionUrl);
     }
 

--- a/app/Notifications/SuccessNotificationMessage.php
+++ b/app/Notifications/SuccessNotificationMessage.php
@@ -70,7 +70,7 @@ class SuccessNotificationMessage
             ]);
     }
 
-    public function toTelegram(string $chatId): TelegramMessage
+    public function toTelegram(string $chatId, ?string $topicId = null): TelegramMessage
     {
         $lines = ['<b>'.e($this->title).'</b>', '', e($this->body), ''];
 
@@ -81,9 +81,15 @@ class SuccessNotificationMessage
         $lines[] = '';
         $lines[] = '<i>'.e($this->footerText).'</i>';
 
+        $options = ['parse_mode' => 'HTML'];
+
+        if ($topicId !== null && $topicId !== '') {
+            $options['message_thread_id'] = (int) $topicId;
+        }
+
         return TelegramMessage::create(implode("\n", $lines))
             ->to($chatId)
-            ->options(['parse_mode' => 'HTML'])
+            ->options($options)
             ->button($this->actionText, $this->actionUrl);
     }
 

--- a/docs/docs/self-hosting/configuration/notification.md
+++ b/docs/docs/self-hosting/configuration/notification.md
@@ -164,6 +164,17 @@ To receive failure notifications via Telegram, you need a bot token and a chat I
 
 Enter both the **Bot Token** and **Chat ID** on the Configuration page.
 
+### Sending to a Topic (optional)
+
+For forum-style groups that have **Topics** enabled, you can route notifications to a specific topic by setting the optional **Topic ID** field.
+
+1. Open the target topic in Telegram and post a message in it
+2. Open `https://api.telegram.org/bot<YOUR_BOT_TOKEN>/getUpdates` in a browser
+3. Find the `message_thread_id` value in the JSON response
+4. Enter it as the **Topic ID** on the Configuration page
+
+Leave **Topic ID** empty to send to the group's default (General) topic.
+
 ## Pushover {#pushover}
 
 [Pushover](https://pushover.net/) delivers push notifications to your phone and desktop.

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -592,6 +592,8 @@
   "Telegram": "Telegram",
   "Telegram Bot Token": "Jeton du bot Telegram",
   "Telegram Chat ID": "ID du chat Telegram",
+  "Topic ID": "ID du sujet",
+  "Optional. The message thread ID for sending to a specific topic in a forum group.": "Optionnel. L’ID du fil de discussion pour envoyer vers un sujet précis dans un groupe forum.",
   "Temporary directory for backup and restore operations.": "Répertoire temporaire pour les opérations de sauvegarde et restauration.",
   "Test": "Test",
   "Test Connection": "Tester la connexion",

--- a/resources/views/livewire/configuration/notification.blade.php
+++ b/resources/views/livewire/configuration/notification.blade.php
@@ -97,6 +97,7 @@
             @elseif ($channelForm->type === 'telegram')
                 <x-password wire:model="channelForm.config_bot_token" :label="__('Bot Token')" :placeholder="$channelForm->has_config_bot_token ? '********' : ''" />
                 <x-input wire:model="channelForm.config_chat_id" :label="__('Chat ID')" required />
+                <x-input wire:model="channelForm.config_topic_id" :label="__('Topic ID')" :hint="__('Optional. The message thread ID for sending to a specific topic in a forum group.')" />
             @elseif ($channelForm->type === 'pushover')
                 <x-password wire:model="channelForm.config_token" :label="__('App Token')" :placeholder="$channelForm->has_config_token ? '********' : ''" />
                 <x-password wire:model="channelForm.config_user_key" :label="__('User Key')" :placeholder="$channelForm->has_config_user_key ? '********' : ''" />

--- a/tests/Feature/Configuration/NotificationTest.php
+++ b/tests/Feature/Configuration/NotificationTest.php
@@ -139,7 +139,7 @@ test('admin can create notification channels of various types', function (string
     'slack' => ['slack', ['config_webhook_url' => 'https://hooks.slack.com/services/test'], ['has_config_webhook_url' => true]],
     'discord' => ['discord', ['config_token' => 'bot-token', 'config_channel_id' => '123456'], ['has_config_token' => true, 'config_channel_id' => '123456']],
     'discord_webhook' => ['discord_webhook', ['config_url' => 'https://discord.com/api/webhooks/123/abc'], ['has_config_url' => true]],
-    'telegram' => ['telegram', ['config_bot_token' => 'bot-token', 'config_chat_id' => '-123456'], ['has_config_bot_token' => true, 'config_chat_id' => '-123456']],
+    'telegram' => ['telegram', ['config_bot_token' => 'bot-token', 'config_chat_id' => '-123456', 'config_topic_id' => '42'], ['has_config_bot_token' => true, 'config_chat_id' => '-123456', 'config_topic_id' => '42']],
     'pushover' => ['pushover', ['config_token' => 'app-token', 'config_user_key' => 'user-key'], ['has_config_token' => true, 'has_config_user_key' => true]],
     'gotify' => ['gotify', ['config_url' => 'https://gotify.example.com', 'config_token' => 'app-token'], ['config_url' => 'https://gotify.example.com', 'has_config_token' => true]],
     'webhook' => ['webhook', ['config_url' => 'https://webhook.example.com/notify'], ['config_url' => 'https://webhook.example.com/notify', 'has_config_secret' => false]],

--- a/tests/Feature/Notifications/FailureNotificationTest.php
+++ b/tests/Feature/Notifications/FailureNotificationTest.php
@@ -178,6 +178,23 @@ test('send refreshes service configs from channel config before dispatching', fu
     expect($sent)->toHaveCount(3);
 });
 
+test('telegram notification sets message_thread_id only when a topic id is configured', function (string $topicId, ?int $expected) {
+    $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
+    $snapshot = createTestSnapshot($server);
+    $notification = new BackupFailedNotification($snapshot, new \Exception('Test error'));
+
+    $telegram = $notification->toTelegram((object) [
+        'routes' => ['telegram' => '123456'],
+        'channelConfig' => ['topic_id' => $topicId],
+    ]);
+
+    expect($telegram->getPayloadValue('chat_id'))->toBe('123456')
+        ->and($telegram->getPayloadValue('message_thread_id'))->toBe($expected);
+})->with([
+    'with topic id' => ['42', 42],
+    'without topic id' => ['', null],
+]);
+
 test('via method returns channels based on configured routes', function () {
     $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
     $snapshot = createTestSnapshot($server);


### PR DESCRIPTION
## Summary

Adds an optional **Topic ID** field to Telegram notification channels, so notifications can be routed to a specific topic (message thread) inside a Telegram forum group.

Previously, only a Bot Token and Chat ID could be configured, and every message landed in the group's default (General) topic — the topic ID was never sent to Telegram. This implements the request in #402.

## How it works

- **Chat ID** (required) — which group/chat to send to.
- **Topic ID** (optional) — which topic *inside* that group. When set, it's passed through to Telegram's `sendMessage` API as `message_thread_id`. When empty, behaviour is unchanged (General topic).

## Changes

- `FailedNotificationMessage` / `SuccessNotificationMessage` — `toTelegram()` now accepts an optional topic ID and sets `message_thread_id` when present.
- `HasChannelRouting` — reads `topic_id` from the channel config and forwards it.
- `NotificationChannelForm` — new `config_topic_id` field (load, validation `nullable|integer|min:1`, persist).
- `NotificationChannelType` — Topic ID shown in the channel config summary when set.
- `notification.blade.php` — optional Topic ID input with a hint.
- `lang/fr.json` — French translations.
- Docs — how to find and use a Topic ID.

## Tests

- New dataset-driven test asserting `message_thread_id` is set when a topic is configured and omitted otherwise.
- Extended the Telegram config save/reload test to round-trip the topic ID.

Full suite green (1156 passed), Pint + PHPStan clean.

Closes #402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram notification channels can now optionally target a specific forum topic using a Topic ID.
  * Telegram message summaries now show both Chat ID and Topic ID when configured.

* **Bug Fixes**
  * Telegram notifications now include the correct thread targeting when a Topic ID is set.
  * Failure and success messages continue to send normally when no Topic ID is provided.

* **Documentation**
  * Added guidance for setting up Telegram topic-based delivery in the configuration docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->