### PR TITLE
feat: add Operator role

### DIFF
--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -6,6 +6,7 @@ enum UserRole: string
 {
     case Demo = 'demo';
     case Viewer = 'viewer';
+    case Operator = 'operator';
     case Member = 'member';
     case Admin = 'admin';
 
@@ -14,6 +15,7 @@ enum UserRole: string
         return match ($this) {
             self::Admin => __('Admin'),
             self::Member => __('Member'),
+            self::Operator => __('Operator'),
             self::Viewer => __('Viewer'),
             self::Demo => __('Demo'),
         };
@@ -24,6 +26,7 @@ enum UserRole: string
         return match ($this) {
             self::Admin => 'o-shield-check',
             self::Member => 'o-pencil-square',
+            self::Operator => 'o-play-circle',
             self::Viewer => 'o-eye',
             self::Demo => 'o-beaker',
         };
@@ -34,6 +37,7 @@ enum UserRole: string
         return match ($this) {
             self::Admin => 'badge-primary',
             self::Member => 'badge-info',
+            self::Operator => 'badge-accent',
             self::Viewer => 'badge-neutral',
             self::Demo => 'badge-ghost',
         };
@@ -46,7 +50,7 @@ enum UserRole: string
      */
     public static function assignable(): array
     {
-        return [self::Viewer, self::Member, self::Admin];
+        return [self::Viewer, self::Operator, self::Member, self::Admin];
     }
 
     /**
@@ -62,8 +66,9 @@ enum UserRole: string
         return match ($this) {
             self::Demo => 0,
             self::Viewer => 1,
-            self::Member => 2,
-            self::Admin => 3,
+            self::Operator => 2,
+            self::Member => 3,
+            self::Admin => 4,
         };
     }
 

--- a/app/Livewire/Forms/UserForm.php
+++ b/app/Livewire/Forms/UserForm.php
@@ -19,7 +19,7 @@ class UserForm extends Form
     public string $email = '';
 
     /** Per-org role (for the current org context) */
-    #[Validate('required|in:viewer,member,admin')]
+    #[Validate('required|in:viewer,operator,member,admin')]
     public string $role = UserRole::Member->value;
 
     /** Super admin flag (only super admins can set this) */
@@ -103,6 +103,7 @@ class UserForm extends Form
             'name' => $role->label(),
             'description' => match ($role) {
                 UserRole::Viewer => __('Read-only access to all resources'),
+                UserRole::Operator => __('Run backups, restores and downloads, but cannot edit server configuration'),
                 UserRole::Member => __('Full access except user management'),
                 UserRole::Admin => __('Full access including user management'),
                 default => '',

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -363,52 +363,61 @@ class DatabaseServer extends Model
         // Reset extra_config when type changes to avoid stale keys
         $extraConfig = ($previousType !== null && $previousType !== $type) ? [] : ($existingExtraConfig ?? []);
 
-        if (array_key_exists('auth_source', $data)) {
-            if ($type === DatabaseType::MONGODB->value && ($data['auth_source'] !== '' && $data['auth_source'] !== null)) {
-                $extraConfig['auth_source'] = $data['auth_source'];
-            } else {
-                unset($extraConfig['auth_source']);
-            }
-            unset($data['auth_source']);
-        }
+        self::pullExtraConfigKey($data, $extraConfig, 'auth_source',
+            fn ($v) => $type === DatabaseType::MONGODB->value && $v !== '' && $v !== null,
+            fn ($v) => $v,
+        );
 
-        if (array_key_exists('dump_flags', $data)) {
-            if ($type !== DatabaseType::SQLITE->value && ($data['dump_flags'] !== '' && $data['dump_flags'] !== null)) {
-                $extraConfig['dump_flags'] = $data['dump_flags'];
-            } else {
-                unset($extraConfig['dump_flags']);
-            }
-            unset($data['dump_flags']);
-        }
+        self::pullExtraConfigKey($data, $extraConfig, 'dump_flags',
+            fn ($v) => $type !== DatabaseType::SQLITE->value && $v !== '' && $v !== null,
+            fn ($v) => $v,
+        );
 
-        if (array_key_exists('dump_format', $data)) {
-            if ($type === DatabaseType::POSTGRESQL->value && $data['dump_format'] === 'custom') {
-                $extraConfig['dump_format'] = 'custom';
-            } else {
-                unset($extraConfig['dump_format']);
-            }
-            unset($data['dump_format']);
-        }
+        self::pullExtraConfigKey($data, $extraConfig, 'dump_format',
+            fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v === 'custom',
+            fn () => 'custom',
+        );
 
-        if (array_key_exists('dump_privileges', $data)) {
-            if ($type === DatabaseType::POSTGRESQL->value && $data['dump_privileges']) {
-                $extraConfig['dump_privileges'] = true;
-            } else {
-                unset($extraConfig['dump_privileges']);
-            }
-            unset($data['dump_privileges']);
-        }
+        self::pullExtraConfigKey($data, $extraConfig, 'dump_privileges',
+            fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v,
+            fn () => true,
+        );
 
-        if (array_key_exists('ssl_enabled', $data)) {
-            if ($type === DatabaseType::MYSQL->value && $data['ssl_enabled']) {
-                $extraConfig['ssl_enabled'] = true;
-            } else {
-                unset($extraConfig['ssl_enabled']);
-            }
-            unset($data['ssl_enabled']);
-        }
+        self::pullExtraConfigKey($data, $extraConfig, 'ssl_enabled',
+            fn ($v) => $type === DatabaseType::MYSQL->value && $v,
+            fn () => true,
+        );
 
         $data['extra_config'] = $extraConfig ?: null;
+    }
+
+    /**
+     * Pull a single field out of $data and fold it into $extraConfig.
+     *
+     * When the key is present in $data it is removed from $data and either
+     * stored in $extraConfig (using $store to derive the value) if $keep
+     * returns true, or cleared from $extraConfig otherwise. Keys absent from
+     * $data are left untouched.
+     *
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $extraConfig
+     * @param  callable(mixed): bool  $keep
+     * @param  callable(mixed): mixed  $store
+     */
+    private static function pullExtraConfigKey(array &$data, array &$extraConfig, string $key, callable $keep, callable $store): void
+    {
+        if (! array_key_exists($key, $data)) {
+            return;
+        }
+
+        $value = $data[$key];
+        unset($data[$key]);
+
+        if ($keep($value)) {
+            $extraConfig[$key] = $store($value);
+        } else {
+            unset($extraConfig[$key]);
+        }
     }
 
     /**

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -363,30 +363,20 @@ class DatabaseServer extends Model
         // Reset extra_config when type changes to avoid stale keys
         $extraConfig = ($previousType !== null && $previousType !== $type) ? [] : ($existingExtraConfig ?? []);
 
-        self::pullExtraConfigKey($data, $extraConfig, 'auth_source',
-            fn ($v) => $type === DatabaseType::MONGODB->value && $v !== '' && $v !== null,
-            fn ($v) => $v,
-        );
+        // Each rule: [key, keep?, store]. $keep decides whether the field is
+        // relevant for the current type and worth persisting; $store derives the
+        // stored value. Keys absent from $data are left untouched (see pullExtraConfigKey).
+        $rules = [
+            ['auth_source',     fn ($v) => $type === DatabaseType::MONGODB->value && $v !== '' && $v !== null, fn ($v) => $v],
+            ['dump_flags',      fn ($v) => $type !== DatabaseType::SQLITE->value && $v !== '' && $v !== null,  fn ($v) => $v],
+            ['dump_format',     fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v === 'custom',       fn () => 'custom'],
+            ['dump_privileges', fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v,                    fn () => true],
+            ['ssl_enabled',     fn ($v) => $type === DatabaseType::MYSQL->value && $v,                         fn () => true],
+        ];
 
-        self::pullExtraConfigKey($data, $extraConfig, 'dump_flags',
-            fn ($v) => $type !== DatabaseType::SQLITE->value && $v !== '' && $v !== null,
-            fn ($v) => $v,
-        );
-
-        self::pullExtraConfigKey($data, $extraConfig, 'dump_format',
-            fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v === 'custom',
-            fn () => 'custom',
-        );
-
-        self::pullExtraConfigKey($data, $extraConfig, 'dump_privileges',
-            fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v,
-            fn () => true,
-        );
-
-        self::pullExtraConfigKey($data, $extraConfig, 'ssl_enabled',
-            fn ($v) => $type === DatabaseType::MYSQL->value && $v,
-            fn () => true,
-        );
+        foreach ($rules as [$key, $keep, $store]) {
+            self::pullExtraConfigKey($data, $extraConfig, $key, $keep, $store);
+        }
 
         $data['extra_config'] = $extraConfig ?: null;
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -170,6 +170,21 @@ class User extends Authenticatable
         return in_array($this->currentOrgRole(), [UserRole::Admin, UserRole::Member]);
     }
 
+    /**
+     * Whether the user can run backup/restore/download operations.
+     * Operators sit between Viewer and Member: they can operate backups but
+     * cannot edit server configuration. Members and Admins can do everything
+     * an Operator can, so they are included here too.
+     */
+    public function canOperate(): bool
+    {
+        if ($this->isSuperAdmin()) {
+            return true;
+        }
+
+        return in_array($this->currentOrgRole(), [UserRole::Admin, UserRole::Member, UserRole::Operator]);
+    }
+
     public function canManageUsers(): bool
     {
         return $this->isAdmin();

--- a/app/Policies/DatabaseServerPolicy.php
+++ b/app/Policies/DatabaseServerPolicy.php
@@ -97,7 +97,7 @@ class DatabaseServerPolicy
 
     /**
      * Determine whether the user can run a backup.
-     * Demo users can trigger backups.
+     * Operators, Members, Admins and demo users can trigger backups.
      */
     public function backup(User $user, DatabaseServer $databaseServer): bool
     {
@@ -105,15 +105,15 @@ class DatabaseServerPolicy
             return false;
         }
 
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 
     /**
      * Determine whether the user can restore to a server.
-     * Demo users can trigger restores.
+     * Operators, Members, Admins and demo users can trigger restores.
      */
     public function restore(User $user, DatabaseServer $databaseServer): bool
     {
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 }

--- a/app/Policies/RestorePolicy.php
+++ b/app/Policies/RestorePolicy.php
@@ -28,12 +28,12 @@ class RestorePolicy
 
     /**
      * Determine whether the user can start a new restore or schedule one.
-     * Demo users can create both. Final authorization on the target server
-     * is still checked via DatabaseServerPolicy@restore.
+     * Operators (and above) plus demo users can create. Final authorization on
+     * the target server is still checked via DatabaseServerPolicy@restore.
      */
     public function create(User $user): bool
     {
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 
     /**
@@ -43,7 +43,7 @@ class RestorePolicy
      */
     public function update(User $user, ScheduledRestore $restore): bool
     {
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 
     /**
@@ -51,7 +51,7 @@ class RestorePolicy
      */
     public function delete(User $user, Restore|ScheduledRestore $restore): bool
     {
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 
     /**
@@ -59,6 +59,6 @@ class RestorePolicy
      */
     public function run(User $user, ScheduledRestore $restore): bool
     {
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 }

--- a/app/Policies/SnapshotPolicy.php
+++ b/app/Policies/SnapshotPolicy.php
@@ -36,20 +36,21 @@ class SnapshotPolicy
 
     /**
      * Determine whether the user can download the snapshot.
-     * Demo users can download snapshots.
+     * Operators, Members, Admins and demo users can download.
      */
     public function download(User $user, Snapshot $snapshot): bool
     {
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 
     /**
      * Determine whether the user can use this snapshot as the source of a restore.
-     * Demo users can trigger restores. Final authorization on the target server
-     * is still checked separately via DatabaseServerPolicy@restore.
+     * Operators, Members, Admins and demo users can trigger restores. Final
+     * authorization on the target server is still checked separately via
+     * DatabaseServerPolicy@restore.
      */
     public function restoreFrom(User $user, Snapshot $snapshot): bool
     {
-        return $user->isDemo() || $user->canPerformActions();
+        return $user->isDemo() || $user->canOperate();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -206,7 +206,7 @@ class AppServiceProvider extends ServiceProvider
 
             if (! empty($roleMapping['strict']) && ! $hasMapping) {
                 throw new \InvalidArgumentException(
-                    'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured. Set at least one of: OAUTH_OIDC_ROLE_MAP_ADMIN, OAUTH_OIDC_ROLE_MAP_MEMBER, OAUTH_OIDC_ROLE_MAP_VIEWER'
+                    'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured. Set at least one of: OAUTH_OIDC_ROLE_MAP_ADMIN, OAUTH_OIDC_ROLE_MAP_MEMBER, OAUTH_OIDC_ROLE_MAP_OPERATOR, OAUTH_OIDC_ROLE_MAP_VIEWER'
                 );
             }
         }

--- a/app/Services/OAuthService.php
+++ b/app/Services/OAuthService.php
@@ -101,8 +101,8 @@ class OAuthService
         // Normalize to array and lowercase for case-insensitive matching
         $userGroups = array_map('mb_strtolower', (array) $claimValue);
 
-        // Check roles in priority order: admin > member > viewer
-        foreach ([UserRole::Admin, UserRole::Member, UserRole::Viewer] as $role) {
+        // Check roles in priority order: admin > member > operator > viewer
+        foreach ([UserRole::Admin, UserRole::Member, UserRole::Operator, UserRole::Viewer] as $role) {
             $configuredGroups = $this->parseGroupList(config("oauth.role_mapping.{$role->value}", ''));
 
             if ($configuredGroups !== [] && array_intersect($userGroups, $configuredGroups) !== []) {

--- a/config/oauth.php
+++ b/config/oauth.php
@@ -20,7 +20,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | The role assigned to new users created via OAuth when no matching
-    | email exists in the database. Must be one of: viewer, member, admin
+    | email exists in the database. Must be one of: viewer, operator, member, admin
     |
     */
     'default_role' => env('OAUTH_DEFAULT_ROLE', 'member'),
@@ -77,7 +77,7 @@ return [
     |
     | Map OIDC group claims to Databasement roles. When at least one
     | ROLE_MAP is set, mapping is active. Roles are checked in priority
-    | order: admin > member > viewer. The first match wins.
+    | order: admin > member > operator > viewer. The first match wins.
     |
     | When strict mode is enabled, users without a matching group are
     | denied access entirely (even returning users).
@@ -87,6 +87,7 @@ return [
         'claim' => env('OAUTH_OIDC_ROLE_CLAIM', 'groups'),
         'admin' => env('OAUTH_OIDC_ROLE_MAP_ADMIN', ''),
         'member' => env('OAUTH_OIDC_ROLE_MAP_MEMBER', ''),
+        'operator' => env('OAUTH_OIDC_ROLE_MAP_OPERATOR', ''),
         'viewer' => env('OAUTH_OIDC_ROLE_MAP_VIEWER', ''),
         'strict' => env('OAUTH_OIDC_ROLE_STRICT', false),
     ],

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -96,6 +96,14 @@ class UserFactory extends Factory
     }
 
     /**
+     * Set the user's role in the default org to operator.
+     */
+    public function operator(): static
+    {
+        return $this->state(['role' => UserRole::Operator]);
+    }
+
+    /**
      * Set the user's role in the default org to viewer.
      */
     public function viewer(): static

--- a/docs/docs/user-guide/permissions.md
+++ b/docs/docs/user-guide/permissions.md
@@ -8,69 +8,74 @@ Databasement uses a role-based access control system. Roles are assigned **per o
 
 ## User Roles
 
-| Role            | Scope  | Description                                                                |
-|-----------------|--------|----------------------------------------------------------------------------|
-| **Super Admin** | Global | Full access to all organizations, user deletion, and global configuration  |
-| **Admin**       | Org    | Full access within the org, including user management                      |
-| **Member**      | Org    | Can manage database servers, volumes, and backups, but cannot manage users |
-| **Viewer**      | Org    | Read-only access to view resources and monitor backup status               |
+| Role            | Scope  | Description                                                                            |
+|-----------------|--------|---------------------------------------------------------------------------------------|
+| **Super Admin** | Global | Full access to all organizations, user deletion, and global configuration             |
+| **Admin**       | Org    | Full access within the org, including user management                                 |
+| **Member**      | Org    | Can manage database servers, volumes, and backups, but cannot manage users            |
+| **Operator**    | Org    | Can run backups, restores, and downloads, but cannot edit configuration or manage users |
+| **Viewer**      | Org    | Read-only access to view resources and monitor backup status                          |
+
+Roles are ordered from most to least privileged: **Admin → Member → Operator → Viewer**. Each role can do everything the role below it can, plus more.
+
+The **Operator** role is for people who run backup operations but should not change infrastructure — for example, developers who trigger a backup before a deployment and restore if something goes wrong, while leaving server connection settings to your admins.
 
 ## Permissions by Resource
 
 ### Database Servers
 
-| Action            |    Viewer    |    Member    | Admin |
-|-------------------|:------------:|:------------:|:-----:|
-| View list         |      ✅       |      ✅       |   ✅   |
-| Create            |      ❌       |      ✅       |   ✅   |
-| Edit              |      ❌       |      ✅       |   ✅   |
-| Delete            |      ❌       |      ✅       |   ✅   |
-| Run backup        |      ❌       |      ✅       |   ✅   |
-| Restore to server |      ❌       |      ✅       |   ✅   |
-| Open Adminer      | configurable | configurable |   ✅   |
+| Action            |    Viewer    |   Operator   |    Member    | Admin |
+|-------------------|:------------:|:------------:|:------------:|:-----:|
+| View list         |      ✅       |      ✅       |      ✅       |   ✅   |
+| Create            |      ❌       |      ❌       |      ✅       |   ✅   |
+| Edit              |      ❌       |      ❌       |      ✅       |   ✅   |
+| Delete            |      ❌       |      ❌       |      ✅       |   ✅   |
+| Run backup        |      ❌       |      ✅       |      ✅       |   ✅   |
+| Restore to server |      ❌       |      ✅       |      ✅       |   ✅   |
+| Open Adminer      | configurable | configurable | configurable |   ✅   |
 
 Adminer access is enabled by default for Admins only. A Super Admin can change the threshold or disable the feature under **Configuration → Application**. See [Browsing Data with Adminer](./database-servers.md#browsing-data-with-adminer).
 
 ### Volumes
 
-| Action    | Viewer | Member | Admin |
-|-----------|:------:|:------:|:-----:|
-| View list |   ✅    |   ✅    |   ✅   |
-| Create    |   ❌    |   ✅    |   ✅   |
-| Edit      |   ❌    |   ✅    |   ✅   |
-| Delete    |   ❌    |   ✅    |   ✅   |
+| Action    | Viewer | Operator | Member | Admin |
+|-----------|:------:|:--------:|:------:|:-----:|
+| View list |   ✅    |    ✅     |   ✅    |   ✅   |
+| Create    |   ❌    |    ❌     |   ✅    |   ✅   |
+| Edit      |   ❌    |    ❌     |   ✅    |   ✅   |
+| Delete    |   ❌    |    ❌     |   ✅    |   ✅   |
 
 ### Agents
 
-| Action           | Viewer | Member | Admin |
-|------------------|:------:|:------:|:-----:|
-| View list        |   ✅    |   ✅    |   ✅   |
-| Create           |   ❌    |   ✅    |   ✅   |
-| Edit             |   ❌    |   ✅    |   ✅   |
-| Regenerate token |   ❌    |   ✅    |   ✅   |
-| Delete           |   ❌    |   ✅    |   ✅   |
+| Action           | Viewer | Operator | Member | Admin |
+|------------------|:------:|:--------:|:------:|:-----:|
+| View list        |   ✅    |    ✅     |   ✅    |   ✅   |
+| Create           |   ❌    |    ❌     |   ✅    |   ✅   |
+| Edit             |   ❌    |    ❌     |   ✅    |   ✅   |
+| Regenerate token |   ❌    |    ❌     |   ✅    |   ✅   |
+| Delete           |   ❌    |    ❌     |   ✅    |   ✅   |
 
 See [Remote Agents](./agents.md) for how agents back up databases in firewalled or isolated networks.
 
 ### Snapshots
 
-| Action       | Viewer | Member | Admin |
-|--------------|:------:|:------:|:-----:|
-| View list    |   ✅    |   ✅    |   ✅   |
-| View details |   ✅    |   ✅    |   ✅   |
-| Download     |   ❌    |   ✅    |   ✅   |
-| Delete       |   ❌    |   ✅    |   ✅   |
+| Action       | Viewer | Operator | Member | Admin |
+|--------------|:------:|:--------:|:------:|:-----:|
+| View list    |   ✅    |    ✅     |   ✅    |   ✅   |
+| View details |   ✅    |    ✅     |   ✅    |   ✅   |
+| Download     |   ❌    |    ✅     |   ✅    |   ✅   |
+| Delete       |   ❌    |    ❌     |   ✅    |   ✅   |
 
 ### Users
 
-| Action                       | Viewer | Member | Admin |
-|------------------------------|:------:|:------:|:-----:|
-| View list                    |   ✅    |   ✅    |   ✅   |
-| Invite new user              |   ❌    |   ❌    |   ✅   |
-| Edit user role               |   ❌    |   ❌    |   ✅   |
-| Delete user                  |   ❌    |   ❌    |   ✅*  |
-| Remove from organization     |   ❌    |   ❌    |   ✅   |
-| Copy invitation link         |   ❌    |   ❌    |   ✅   |
+| Action                       | Viewer | Operator | Member | Admin |
+|------------------------------|:------:|:--------:|:------:|:-----:|
+| View list                    |   ✅    |    ✅     |   ✅    |   ✅   |
+| Invite new user              |   ❌    |    ❌     |   ❌    |   ✅   |
+| Edit user role               |   ❌    |    ❌     |   ❌    |   ✅   |
+| Delete user                  |   ❌    |    ❌     |   ❌    |   ✅*  |
+| Remove from organization     |   ❌    |    ❌     |   ❌    |   ✅   |
+| Copy invitation link         |   ❌    |    ❌     |   ❌    |   ✅   |
 
 \* Org admins can only delete users who belong to their organization and no other. See restrictions below.
 

--- a/lang/el.json
+++ b/lang/el.json
@@ -371,6 +371,8 @@
   "Manual Restore Required": "Απαιτείται χειροκίνητο Restore",
   "Maximum number of seconds a backup or restore job can run before timing out.": "Μέγιστος αριθμός δευτερολέπτων που μπορεί να εκτελεστεί μια εργασία backup ή restore πριν λήξει το χρονικό όριο.",
   "Member": "Μέλος",
+  "Operator": "Χειριστής",
+  "Run backups, restores and downloads, but cannot edit server configuration": "Εκτέλεση backup, restore και λήψεων, χωρίς δυνατότητα επεξεργασίας της διαμόρφωσης του διακομιστή",
   "Message": "Μήνυμα",
   "Metadata": "Μεταδεδομένα",
   "Missing": "Λείπει",

--- a/lang/es.json
+++ b/lang/es.json
@@ -374,6 +374,8 @@
   "Manual Restore Required": "Se requiere restauración manual",
   "Maximum number of seconds a backup or restore job can run before timing out.": "Número máximo de segundos que un trabajo de backup o restauración puede ejecutarse antes de agotar el tiempo de espera.",
   "Member": "Miembro",
+  "Operator": "Operador",
+  "Run backups, restores and downloads, but cannot edit server configuration": "Ejecutar backups, restores y descargas, pero no puede editar la configuración del servidor",
   "Message": "Mensaje",
   "Metadata": "Metadatos",
   "Missing": "Faltante",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -374,6 +374,8 @@
   "Manual Restore Required": "Restauration manuelle requise",
   "Maximum number of seconds a backup or restore job can run before timing out.": "Nombre maximum de secondes pendant lesquelles une tâche de sauvegarde ou restauration peut s’exécuter avant expiration.",
   "Member": "Membre",
+  "Operator": "Opérateur",
+  "Run backups, restores and downloads, but cannot edit server configuration": "Lancer des backups, restores et téléchargements, sans pouvoir modifier la configuration du serveur",
   "Message": "Message",
   "Metadata": "Métadonnées",
   "Missing": "Manquant",

--- a/tests/Feature/Auth/OAuthTest.php
+++ b/tests/Feature/Auth/OAuthTest.php
@@ -41,6 +41,7 @@ beforeEach(function () {
     Config::set('oauth.role_mapping.claim', 'groups');
     Config::set('oauth.role_mapping.admin', '');
     Config::set('oauth.role_mapping.member', '');
+    Config::set('oauth.role_mapping.operator', '');
     Config::set('oauth.role_mapping.viewer', '');
     Config::set('oauth.role_mapping.strict', false);
 });
@@ -282,6 +283,18 @@ test('oidc role mapping assigns member role from matching group', function () {
 
     $user = User::where('email', 'member@example.com')->first();
     expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Member);
+});
+
+test('oidc role mapping assigns operator role from matching group', function () {
+    enableOidcProvider();
+    Config::set('oauth.role_mapping.operator', 'databasement-operators');
+
+    Socialite::fake('oidc', fakeOidcUser('oidc-op', 'operator@example.com', 'Operator', ['databasement-operators']));
+
+    $this->get(route('oauth.callback', 'oidc'));
+
+    $user = User::where('email', 'operator@example.com')->first();
+    expect($user->roleIn(\App\Models\Organization::default()))->toBe(UserRole::Operator);
 });
 
 test('oidc role mapping assigns viewer role from matching group', function () {

--- a/tests/Feature/Authorization/OperatorRoleTest.php
+++ b/tests/Feature/Authorization/OperatorRoleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Models\DatabaseServer;
+use App\Models\ScheduledRestore;
+use App\Models\Snapshot;
+use App\Models\User;
+
+describe('operator role', function () {
+    test('operator can run backup, restore, download and restore-from', function () {
+        $operator = User::factory()->operator()->create();
+        $server = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+        $snapshot = Snapshot::factory()->forServer($server)->create();
+
+        expect($operator->can('backup', $server))->toBeTrue()
+            ->and($operator->can('restore', $server))->toBeTrue()
+            ->and($operator->can('download', $snapshot))->toBeTrue()
+            ->and($operator->can('restoreFrom', $snapshot))->toBeTrue()
+            ->and($operator->can('create', \App\Models\Restore::class))->toBeTrue();
+    });
+
+    test('operator cannot edit server configuration', function () {
+        $operator = User::factory()->operator()->create();
+        $server = DatabaseServer::factory()->create();
+
+        expect($operator->can('create', DatabaseServer::class))->toBeFalse()
+            ->and($operator->can('update', $server))->toBeFalse()
+            ->and($operator->can('delete', $server))->toBeFalse()
+            ->and($operator->can('viewForm', $server))->toBeFalse();
+    });
+
+    test('operator cannot delete snapshots', function () {
+        $operator = User::factory()->operator()->create();
+        $server = DatabaseServer::factory()->create();
+        $snapshot = Snapshot::factory()->forServer($server)->create();
+
+        expect($operator->can('delete', $snapshot))->toBeFalse();
+    });
+
+    test('viewer still cannot run backup, restore or download', function () {
+        $viewer = User::factory()->viewer()->create();
+        $server = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+        $snapshot = Snapshot::factory()->forServer($server)->create();
+
+        expect($viewer->can('backup', $server))->toBeFalse()
+            ->and($viewer->can('restore', $server))->toBeFalse()
+            ->and($viewer->can('download', $snapshot))->toBeFalse()
+            ->and($viewer->can('restoreFrom', $snapshot))->toBeFalse();
+    });
+});
+
+test('operator can manage scheduled restores', function () {
+    $operator = User::factory()->operator()->create();
+    [$source, $target] = createRestoreServerPair('mysql');
+    $scheduledRestore = createScheduledRestore(['source' => $source, 'target' => $target]);
+
+    expect($operator->can('create', ScheduledRestore::class))->toBeTrue()
+        ->and($operator->can('run', $scheduledRestore))->toBeTrue();
+});

--- a/tests/Feature/Models/DatabaseServerTest.php
+++ b/tests/Feature/Models/DatabaseServerTest.php
@@ -110,3 +110,48 @@ test('requiresSftpTransfer returns correct value', function () {
         ->and($sqliteLocal->requiresSftpTransfer())->toBeFalse()
         ->and($mysqlWithSsh->requiresSftpTransfer())->toBeFalse();
 });
+
+test('buildExtraConfig folds type-specific fields into extra_config', function (
+    array $data,
+    ?array $existing,
+    ?string $previousType,
+    ?array $expected,
+) {
+    DatabaseServer::buildExtraConfig($data, $existing, $previousType);
+
+    expect($data['extra_config'])->toEqual($expected);
+
+    // Handled keys are always pulled out of $data.
+    foreach (['auth_source', 'dump_flags', 'dump_format', 'dump_privileges', 'ssl_enabled'] as $key) {
+        expect($data)->not->toHaveKey($key);
+    }
+})->with([
+    // [data, existing, previousType, expected extra_config]
+
+    'keeps type-specific string value' => [
+        ['database_type' => 'mongodb', 'auth_source' => 'records'], null, null, ['auth_source' => 'records'],
+    ],
+    'keeps custom dump_format constant' => [
+        ['database_type' => 'postgres', 'dump_format' => 'custom'], null, null, ['dump_format' => 'custom'],
+    ],
+    'keeps boolean flag when enabled' => [
+        ['database_type' => 'mysql', 'ssl_enabled' => true], null, null, ['ssl_enabled' => true],
+    ],
+    'drops field not relevant to the type' => [
+        ['database_type' => 'sqlite', 'dump_flags' => '--anything'], null, null, null,
+    ],
+    'folds multiple keys at once' => [
+        ['database_type' => 'postgres', 'dump_flags' => '-v', 'dump_format' => 'custom', 'dump_privileges' => true],
+        null, null,
+        ['dump_flags' => '-v', 'dump_format' => 'custom', 'dump_privileges' => true],
+    ],
+    'clears existing key when value no longer qualifies' => [
+        ['database_type' => 'mongodb', 'auth_source' => ''], ['auth_source' => 'records'], null, null,
+    ],
+    'preserves existing config when key absent from data' => [
+        ['database_type' => 'mongodb'], ['auth_source' => 'records'], null, ['auth_source' => 'records'],
+    ],
+    'resets stale config on type change' => [
+        ['database_type' => 'mysql', 'ssl_enabled' => true], ['auth_source' => 'records'], 'mongodb', ['ssl_enabled' => true],
+    ],
+]);

--- a/tests/Feature/Models/DatabaseServerTest.php
+++ b/tests/Feature/Models/DatabaseServerTest.php
@@ -154,4 +154,7 @@ test('buildExtraConfig folds type-specific fields into extra_config', function (
     'resets stale config on type change' => [
         ['database_type' => 'mysql', 'ssl_enabled' => true], ['auth_source' => 'records'], 'mongodb', ['ssl_enabled' => true],
     ],
+    'clears stale config on type change when no replacement keys are provided' => [
+        ['database_type' => 'mysql'], ['auth_source' => 'records'], 'mongodb', null,
+    ],
 ]);

--- a/tests/Feature/OAuthConfigurationValidationTest.php
+++ b/tests/Feature/OAuthConfigurationValidationTest.php
@@ -61,7 +61,7 @@ test('throws exception when strict mode is enabled without any role mappings', f
     $provider = new AppServiceProvider(app());
 
     expect(fn () => $provider->performOAuthValidation())
-        ->toThrow(\InvalidArgumentException::class, 'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured');
+        ->toThrow(\InvalidArgumentException::class, 'OAUTH_OIDC_ROLE_STRICT is enabled but no role mappings are configured. Set at least one of: OAUTH_OIDC_ROLE_MAP_ADMIN, OAUTH_OIDC_ROLE_MAP_MEMBER, OAUTH_OIDC_ROLE_MAP_OPERATOR, OAUTH_OIDC_ROLE_MAP_VIEWER');
 });
 
 test('does not throw when strict mode is enabled with role mappings', function () {

--- a/tests/Feature/OAuthConfigurationValidationTest.php
+++ b/tests/Feature/OAuthConfigurationValidationTest.php
@@ -85,6 +85,28 @@ test('does not throw when strict mode is enabled with role mappings', function (
     expect(fn () => $provider->performOAuthValidation())->not->toThrow(\InvalidArgumentException::class);
 });
 
+test('does not throw when strict mode is satisfied by an operator role mapping', function () {
+    Config::set('oauth.default_role', 'member');
+    Config::set('oauth.providers.oidc', [
+        'enabled' => true,
+        'client_id' => 'id',
+        'client_secret' => 'secret',
+        'base_url' => 'https://idp.example.com',
+    ]);
+    Config::set('oauth.role_mapping', [
+        'claim' => 'groups',
+        'admin' => '',
+        'member' => '',
+        'operator' => 'my-operators',
+        'viewer' => '',
+        'strict' => true,
+    ]);
+
+    $provider = new AppServiceProvider(app());
+
+    expect(fn () => $provider->performOAuthValidation())->not->toThrow(\InvalidArgumentException::class);
+});
+
 test('does not throw strict mode error when oidc is disabled', function () {
     Config::set('oauth.default_role', 'member');
     Config::set('oauth.providers', []);

--- a/tests/Feature/OAuthConfigurationValidationTest.php
+++ b/tests/Feature/OAuthConfigurationValidationTest.php
@@ -10,7 +10,7 @@ test('throws exception for invalid oauth default role', function () {
     $provider = new AppServiceProvider(app());
 
     expect(fn () => $provider->performOAuthValidation())
-        ->toThrow(\InvalidArgumentException::class, "Invalid OAUTH_DEFAULT_ROLE 'invalid_role'. Must be one of: viewer, member, admin");
+        ->toThrow(\InvalidArgumentException::class, "Invalid OAUTH_DEFAULT_ROLE 'invalid_role'. Must be one of: viewer, operator, member, admin");
 });
 
 test('throws exception when enabled provider is missing credentials', function () {


### PR DESCRIPTION
Adds the scoped-down **Operator** role from #327. (The Protected-server flag that was originally in this PR has been dropped to keep the change focused — it can be revisited separately.)

## What

A new `Operator` role sits between `Viewer` and `Member`. An Operator is "a Viewer that can also operate":

- ✅ Trigger backups
- ✅ Restore a database (incl. scheduled restores)
- ✅ Download snapshots
- ✅ Browse servers, snapshots & backups (same visibility as Viewer)
- ❌ Create/edit/delete server configuration & credentials
- ❌ Manage volumes, backup schedules
- ❌ Delete snapshots, manage users

Backed by a new `User::canOperate()` helper (Operator/Member/Admin/super-admin), leaving the existing `canPerformActions()` (Member/Admin) as the gate for configuration changes.

## Notes
- Per-user / per-server / per-database scoping is intentionally **not** included — Organizations already provide that boundary (as discussed in the issue).
- Added `Operator` to the user role picker, OAuth role mapping + priority order, and fr/es/el translations.
- Updated `docs/user-guide/permissions.md` with the new role and per-resource matrix.
- Refactored `DatabaseServer::buildExtraConfig()` to remove repeated set/unset/forget logic via a `pullExtraConfigKey()` helper.

## Tests
New `tests/Feature/Authorization/OperatorRoleTest.php` covers operator capabilities, viewer regression, and scheduled-restore management; plus an OIDC operator role-mapping test. Full suite green (1178 passed), PHPStan + Pint clean.

Closes #327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Operator** role across the app, including OAuth/OIDC mapping and role option/creation support.
  * Operators can run backups/restores, download/restore snapshots, and manage scheduled restores, but cannot edit server configuration.
* **Bug Fixes**
  * Updated authorization to consistently enforce Operator permissions for backup/restore/snapshot actions.
* **Documentation**
  * Refreshed permissions documentation and added localized **Operator** labels/descriptions.
* **Refactor & Tests**
  * Improved handling of type-specific server settings in `extra_config` and added automated tests for Operator permissions and config folding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->