### PR TITLE
feat(docs): versioned documentation with one docs version per 1.x minor

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Full history + tags: prepare-versions.sh snapshots one docs
+          # version per 1.x minor from the latest patch tag of each minor
+          fetch-depth: 0
 
       - name: Extract version from tag
         id: version
@@ -37,6 +41,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Prepare versioned docs from tags
+        run: ./scripts/prepare-versions.sh
 
       - name: Build documentation
         run: npm run build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,9 +51,13 @@ jobs:
           DOCS_VERSION: ${{ steps.version.outputs.version }}
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        # Clean deploy: removes stale docs files from the branch on every
+        # deploy, but never touches the Helm repository files
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/build
-          destination_dir: .
-          keep_files: true
+          folder: docs/build
+          branch: gh-pages
+          clean-exclude: |
+            charts/**
+            index.yaml
+            artifacthub-repo.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,9 @@ jobs:
           # Full history + tags: prepare-versions.sh snapshots one docs
           # version per 1.x minor from the latest patch tag of each minor
           fetch-depth: 0
+          # Keep the token out of .git/config while npm ci runs third-party
+          # scripts; the deploy action authenticates via its own token input
+          persist-credentials: false
 
       - name: Extract version from tag
         id: version

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -8,6 +8,11 @@
 .docusaurus
 .cache-loader
 
+# Versioned docs snapshots (generated from git tags by scripts/prepare-versions.sh)
+/versioned_docs
+/versioned_sidebars
+/versions.json
+
 # Misc
 .DS_Store
 .env.local

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -3,7 +3,7 @@ sidebar_position: 0
 slug: /
 ---
 
-![Databasement Banner](../static/img/banner-v2.png)
+![Databasement Banner](/img/banner-v2.png)
 
 # Databasement Documentation
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -1,9 +1,21 @@
+import fs from 'fs';
+import path from 'path';
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
 
 const version = process.env.DOCS_VERSION;
 const isLocalBuild = process.env.DOCS_LOCAL === 'true';
+
+// Versioned builds: scripts/prepare-versions.sh snapshots one docs version per
+// 1.x minor from git tags. When versions.json exists, the latest minor is
+// served at the root path and older minors under /<minor>/. Local dev without
+// snapshots keeps the plain single-version behavior.
+const versionsFile = path.join(__dirname, 'versions.json');
+const versions: string[] = fs.existsSync(versionsFile)
+    ? JSON.parse(fs.readFileSync(versionsFile, 'utf8'))
+    : [];
+const isVersioned = versions.length > 0;
 
 const config: Config = {
     title: 'Databasement',
@@ -79,7 +91,20 @@ const config: Config = {
                 docs: {
                     sidebarPath: './sidebars.ts',
                     routeBasePath: '/',
-                    editUrl: 'https://github.com/David-Crty/databasement/tree/main/docs/',
+                    // Versioned snapshots are ephemeral (not in the repo), so
+                    // always point "Edit this page" at the docs source on main.
+                    editUrl: ({docPath}) =>
+                        `https://github.com/David-Crty/databasement/tree/main/docs/docs/${docPath}`,
+                    ...(isVersioned ? {
+                        includeCurrentVersion: false,
+                        lastVersion: versions[0],
+                        versions: {
+                            [versions[0]]: {
+                                label: `${versions[0]} (latest)`,
+                                path: '',
+                            },
+                        },
+                    } : {}),
                 },
                 blog: false,
                 theme: {
@@ -114,7 +139,10 @@ const config: Config = {
                     position: 'left',
                     label: 'User Guide',
                 },
-                ...(version ? [{
+                ...(isVersioned ? [{
+                    type: 'docsVersionDropdown' as const,
+                    position: 'right' as const,
+                }] : version ? [{
                     type: 'html' as const,
                     position: 'right' as const,
                     value: `<span class="badge badge--secondary">v${version}</span>`,

--- a/docs/scripts/prepare-versions.sh
+++ b/docs/scripts/prepare-versions.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Builds Docusaurus versioned_docs snapshots from git tags — one docs version
+# per 1.x minor, using the latest patch tag of each minor. Snapshots are
+# generated at build time and never committed (see docs/.gitignore).
+#
+# Requires the full tag list (CI must checkout with fetch-depth: 0).
+set -euo pipefail
+
+DOCS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(cd "$DOCS_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Preserve the working-tree docs (the ref being built) and restore them when
+# the script exits, even on failure — the loop below overwrites them per tag.
+BACKUP=$(mktemp -d)
+cp -a docs/docs "$BACKUP/docs"
+cp -a docs/sidebars.ts "$BACKUP/sidebars.ts"
+restore_working_tree() {
+    rm -rf docs/docs docs/sidebars.ts
+    cp -a "$BACKUP/docs" docs/docs
+    cp -a "$BACKUP/sidebars.ts" docs/sidebars.ts
+    git restore --staged docs/docs docs/sidebars.ts 2>/dev/null || true
+    rm -rf "$BACKUP"
+}
+trap restore_working_tree EXIT
+
+# Start from a clean slate so the script is idempotent
+rm -rf "$DOCS_DIR/versioned_docs" "$DOCS_DIR/versioned_sidebars" "$DOCS_DIR/versions.json"
+
+MINORS=$(git tag -l 'v1.*' | grep -E '^v1\.[0-9]+\.[0-9]+$' | sed -E 's/^v(1\.[0-9]+)\.[0-9]+$/\1/' | sort -uV)
+
+if [ -z "$MINORS" ]; then
+    echo "No v1.x.y tags found — nothing to version."
+    exit 0
+fi
+
+# Cut versions oldest-first so versions.json ends up newest-first
+for MINOR in $MINORS; do
+    TAG=$(git tag -l "v${MINOR}.*" | grep -E '^v1\.[0-9]+\.[0-9]+$' | sort -V | tail -1)
+    echo "==> Versioning docs ${MINOR} from tag ${TAG}"
+    rm -rf docs/docs docs/sidebars.ts
+    git checkout "$TAG" -- docs/docs docs/sidebars.ts
+    # Older tags reference static assets as ../static/…, which no longer
+    # resolves once the files are nested under versioned_docs/. Rewrite to
+    # absolute static paths (served from docs/static of the current build).
+    grep -rl '\.\./static/' docs/docs 2>/dev/null | xargs -r sed -i 's#\.\./static/#/#g'
+    (cd "$DOCS_DIR" && npx docusaurus docs:version "$MINOR")
+done
+
+echo "==> Generated versions: $(cat "$DOCS_DIR/versions.json")"


### PR DESCRIPTION
## Summary

Adds industry-standard Docusaurus versioning to the docs, driven entirely by git tags — snapshots are rebuilt at deploy time and never committed to the repo.

- **One docs version per 1.x minor**, built from the latest patch tag of that minor — tagging e.g. `v1.5.7` automatically replaces the `1.5` docs
- **Latest minor served at the root URL** (existing links unchanged); older minors under `/<minor>/` with the standard "no longer actively maintained" banner linking to the latest
- **Version dropdown** in the navbar replaces the static version badge
- All existing minors (`1.0`–`1.5`) are backfilled automatically on the first deploy after merge
- Publishing remains tag-triggered only; the deploy step is untouched (`keep_files: true`, Helm chart repo on `gh-pages` unaffected)

## How it works

`docs/scripts/prepare-versions.sh` (new, run by the docs workflow before the build):

1. Lists all `v1.x.y` tags and picks the latest patch per minor
2. Extracts each tag's `docs/docs` + `sidebars.ts` and runs `docusaurus docs:version <minor>` (oldest → newest)
3. Rewrites legacy `../static/…` asset references that break inside `versioned_docs/`
4. Restores the working tree afterwards (trap-protected, safe locally too)

`docusaurus.config.ts` activates versioning only when `versions.json` exists, so local `npm start`/`npm run build` without the script keeps today's single-version behavior. "Edit this page" always points to `docs/docs` on `main` since snapshots don't exist in the repo.

## Notes

- Validated with a full local production build: all 6 versions compile, lunr search indexes everything, `llms.txt` still generates from the latest docs only, and every version root/page serves correctly
- Because GitHub runs the workflow file from the tagged commit, this takes effect on the first tag created **after** this lands on `main`; tags on older history would still run the old single-version deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tag-driven versioned documentation builds, including a version dropdown for older releases and a “latest” indicator.
  * Docs deployment now generates version snapshots automatically from release tags.

* **Bug Fixes**
  * Fixed the documentation homepage banner image path.
  * Improved asset path handling so images resolve correctly on versioned pages.

* **Chores**
  * Updated the docs deployment workflow to use clean publishing with selective exclusions.
  * Added repo ignore rules for generated versioned docs artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->