### PR TITLE
fix(docs): prepare-versions.sh aborted when a tag has no ../static references

### DIFF
--- a/docs/scripts/prepare-versions.sh
+++ b/docs/scripts/prepare-versions.sh
@@ -44,7 +44,7 @@ for MINOR in $MINORS; do
     # Older tags reference static assets as ../static/…, which no longer
     # resolves once the files are nested under versioned_docs/. Rewrite to
     # absolute static paths (served from docs/static of the current build).
-    grep -rl '\.\./static/' docs/docs 2>/dev/null | xargs -r sed -i 's#\.\./static/#/#g'
+    find docs/docs -type f \( -name '*.md' -o -name '*.mdx' \) -exec sed -i 's#\.\./static/#/#g' {} +
     (cd "$DOCS_DIR" && npx docusaurus docs:version "$MINOR")
 done
 


### PR DESCRIPTION
## Summary

The v1.6.0 docs deploy failed ([run](https://github.com/David-Crty/databasement/actions/runs/28624844611)) while snapshotting version 1.6.

**Cause:** the legacy-asset rewrite used `grep -rl '../static/' | xargs sed`, and `grep` exits 1 when it finds nothing. Under `set -euo pipefail` that aborts the script. v1.6.0 is the first tag whose docs already use the fixed `/img/...` path, so the 1.6 snapshot was the first zero-match case — earlier local testing (through 1.5.6) always had at least one match.

**Fix:** run the rewrite unconditionally via `find … -exec sed`, which is idempotent and exits 0 regardless of matches.

## Validation

- Reproduced the failure locally on `main` (script exits 1 at "Versioning docs 1.6")
- With the fix: all 7 minors (1.0–1.6) snapshot successfully, zero `../static/` references remain, and the full production build succeeds

After merge, re-deploy the v1.6.0 docs by running the "Deploy Documentation" workflow manually (workflow_dispatch from main) — re-running the failed tag run would use the tag's old script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed legacy static asset links in versioned documentation so links are rewritten more reliably during docs version preparation.
  * Improved handling across markdown and MDX files in the docs archive, helping prevent broken image and asset paths in older docs versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->