### PR TITLE
feat(backup): optional multithreaded compression (zstd & 7z)

### DIFF
--- a/app/Enums/CompressionType.php
+++ b/app/Enums/CompressionType.php
@@ -33,4 +33,28 @@ enum CompressionType: string
             self::ENCRYPTED => '7z',
         };
     }
+
+    /**
+     * Highest compression level accepted by the underlying tool.
+     * gzip and 7z cap at 9; zstd goes up to 19.
+     */
+    public function maxLevel(): int
+    {
+        return match ($this) {
+            self::GZIP, self::ENCRYPTED => 9,
+            self::ZSTD => 19,
+        };
+    }
+
+    /**
+     * Whether the underlying tool can spread compression across CPU cores.
+     * zstd (-T0) and 7z (-mmt) do; standard gzip is single-threaded.
+     */
+    public function supportsMultithreading(): bool
+    {
+        return match ($this) {
+            self::ZSTD, self::ENCRYPTED => true,
+            self::GZIP => false,
+        };
+    }
 }

--- a/app/Livewire/Forms/ConfigurationForm.php
+++ b/app/Livewire/Forms/ConfigurationForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Forms;
 
+use App\Enums\CompressionType;
 use App\Facades\AppConfig;
 use Cron\CronExpression;
 use Livewire\Form;
@@ -17,6 +18,8 @@ class ConfigurationForm extends Form
     public string $compression = '';
 
     public int $compression_level = 6;
+
+    public bool $compression_multithread = false;
 
     public int $job_timeout = 7200;
 
@@ -39,12 +42,26 @@ class ConfigurationForm extends Form
 
     public string $schedule_expression = '';
 
+    /**
+     * Keep the compression level within the selected algorithm's ceiling when
+     * the algorithm changes (e.g. switching zstd → gzip drops 19 down to 9).
+     */
+    public function updatedCompression(string $value): void
+    {
+        $max = CompressionType::tryFrom($value)?->maxLevel();
+
+        if ($max !== null && $this->compression_level > $max) {
+            $this->compression_level = $max;
+        }
+    }
+
     public function loadFromConfig(): void
     {
         $this->adminer_enabled = (bool) AppConfig::get('app.adminer_enabled');
         $this->working_directory = (string) AppConfig::get('backup.working_directory');
         $this->compression = (string) AppConfig::get('backup.compression');
         $this->compression_level = (int) AppConfig::get('backup.compression_level');
+        $this->compression_multithread = (bool) AppConfig::get('backup.compression_multithread');
         $this->job_timeout = (int) AppConfig::get('backup.job_timeout');
         $this->job_tries = (int) AppConfig::get('backup.job_tries');
         $this->job_backoff = (int) AppConfig::get('backup.job_backoff');
@@ -77,10 +94,13 @@ class ConfigurationForm extends Form
      */
     private function backupRules(): array
     {
+        $maxLevel = CompressionType::tryFrom($this->compression)?->maxLevel() ?? 19;
+
         return [
             'working_directory' => ['required', 'string', 'max:500', new \App\Rules\SafePath(allowAbsolute: true)],
             'compression' => ['required', 'string', 'in:gzip,zstd,encrypted'],
-            'compression_level' => ['required', 'integer', 'min:1', 'max:'.($this->compression === 'gzip' ? 9 : 19)],
+            'compression_level' => ['required', 'integer', 'min:1', 'max:'.$maxLevel],
+            'compression_multithread' => ['boolean'],
             'job_timeout' => ['required', 'integer', 'min:60', 'max:86400'],
             'job_tries' => ['required', 'integer', 'min:1', 'max:10'],
             'job_backoff' => ['required', 'integer', 'min:0', 'max:3600'],
@@ -123,6 +143,7 @@ class ConfigurationForm extends Form
             'working_directory' => 'backup.working_directory',
             'compression' => 'backup.compression',
             'compression_level' => 'backup.compression_level',
+            'compression_multithread' => 'backup.compression_multithread',
             'job_timeout' => 'backup.job_timeout',
             'job_tries' => 'backup.job_tries',
             'job_backoff' => 'backup.job_backoff',

--- a/app/Services/Agent/AgentJobPayloadBuilder.php
+++ b/app/Services/Agent/AgentJobPayloadBuilder.php
@@ -19,7 +19,7 @@ class AgentJobPayloadBuilder
      * @return array{
      *     database: array<string, mixed>,
      *     volume: array<string, mixed>,
-     *     compression: array{type: string|null, level: int|null},
+     *     compression: array{type: string|null, level: int|null, multithread: bool|null},
      *     backup_path: string,
      *     server_name: string,
      *     post_backup_script: string|null,
@@ -37,6 +37,7 @@ class AgentJobPayloadBuilder
             backupPath: $this->resolveBackupPath($snapshot->backup->path),
             compressionType: CompressionType::tryFrom(AppConfig::get('backup.compression') ?? ''),
             compressionLevel: AppConfig::get('backup.compression_level'),
+            compressionMultithread: (bool) AppConfig::get('backup.compression_multithread'),
             postBackupScript: AppConfig::get('backup.post_backup_script'),
         );
 

--- a/app/Services/AppConfigService.php
+++ b/app/Services/AppConfigService.php
@@ -18,6 +18,7 @@ class AppConfigService
         'backup.working_directory' => ['type' => 'string', 'is_sensitive' => false, 'default' => '/tmp/backups'],
         'backup.compression' => ['type' => 'string', 'is_sensitive' => false, 'default' => 'gzip'],
         'backup.compression_level' => ['type' => 'integer', 'is_sensitive' => false, 'default' => 6],
+        'backup.compression_multithread' => ['type' => 'boolean', 'is_sensitive' => false, 'default' => false],
         'backup.job_timeout' => ['type' => 'integer', 'is_sensitive' => false, 'default' => 7200],
         'backup.job_tries' => ['type' => 'integer', 'is_sensitive' => false, 'default' => 3],
         'backup.job_backoff' => ['type' => 'integer', 'is_sensitive' => false, 'default' => 60],

--- a/app/Services/Backup/BackupTask.php
+++ b/app/Services/Backup/BackupTask.php
@@ -77,7 +77,7 @@ class BackupTask
             }
 
             // Compress
-            $compressor = $this->compressorFactory->make($config->compressionType, $config->compressionLevel);
+            $compressor = $this->compressorFactory->make($config->compressionType, $config->compressionLevel, $config->compressionMultithread);
             $archive = $compressor->compress($workingFile);
             $fileSize = filesize($archive);
             if ($fileSize === false) {

--- a/app/Services/Backup/Compressors/BaseCompressor.php
+++ b/app/Services/Backup/Compressors/BaseCompressor.php
@@ -10,7 +10,8 @@ abstract class BaseCompressor implements CompressorInterface
         protected readonly ShellProcessor $shellProcessor,
         private readonly int $level,
         private readonly int $minLevel,
-        private readonly int $maxLevel
+        private readonly int $maxLevel,
+        private readonly bool $multithread = false
     ) {}
 
     public function compress(string $inputPath): string
@@ -61,5 +62,10 @@ abstract class BaseCompressor implements CompressorInterface
     protected function getLevel(): int
     {
         return max($this->minLevel, min($this->maxLevel, $this->level));
+    }
+
+    protected function isMultithreaded(): bool
+    {
+        return $this->multithread;
     }
 }

--- a/app/Services/Backup/Compressors/CompressorFactory.php
+++ b/app/Services/Backup/Compressors/CompressorFactory.php
@@ -15,18 +15,20 @@ class CompressorFactory
     /**
      * Create a compressor instance based on configuration.
      */
-    public function make(?CompressionType $type = null, ?int $level = null): CompressorInterface
+    public function make(?CompressionType $type = null, ?int $level = null, ?bool $multithread = null): CompressorInterface
     {
         $type = $type ?? CompressionType::from(AppConfig::get('backup.compression'));
         $level = $level ?? (int) AppConfig::get('backup.compression_level');
+        $multithread = $multithread ?? (bool) AppConfig::get('backup.compression_multithread');
 
         return match ($type) {
             CompressionType::GZIP => new GzipCompressor($this->shellProcessor, $level),
-            CompressionType::ZSTD => new ZstdCompressor($this->shellProcessor, $level),
+            CompressionType::ZSTD => new ZstdCompressor($this->shellProcessor, $level, $multithread),
             CompressionType::ENCRYPTED => new EncryptedCompressor(
                 $this->shellProcessor,
                 $level,
-                $this->getEncryptionKey()
+                $this->getEncryptionKey(),
+                $multithread
             ),
         };
     }

--- a/app/Services/Backup/Compressors/EncryptedCompressor.php
+++ b/app/Services/Backup/Compressors/EncryptedCompressor.php
@@ -13,9 +13,10 @@ class EncryptedCompressor extends BaseCompressor
     public function __construct(
         ShellProcessor $shellProcessor,
         int $level,
-        private readonly ?string $password = null
+        private readonly ?string $password = null,
+        bool $multithread = false
     ) {
-        parent::__construct($shellProcessor, $level, minLevel: 1, maxLevel: 9);
+        parent::__construct($shellProcessor, $level, minLevel: 1, maxLevel: 9, multithread: $multithread);
     }
 
     public function decompress(string $compressedFile): string
@@ -39,6 +40,11 @@ class EncryptedCompressor extends BaseCompressor
         // 7z a -t7z -mx={level} -mhe=on -p{password} output.7z input
         // -mhe=on encrypts headers (file names)
         $command = sprintf('7z a -t7z -mx=%d -mhe=on', $this->getLevel());
+
+        // -mmt=on spreads compression across all available CPU cores
+        if ($this->isMultithreaded()) {
+            $command .= ' -mmt=on';
+        }
 
         if ($this->password !== null) {
             $command .= sprintf(' -p%s', escapeshellarg($this->password));

--- a/app/Services/Backup/Compressors/ZstdCompressor.php
+++ b/app/Services/Backup/Compressors/ZstdCompressor.php
@@ -7,9 +7,9 @@ use App\Services\Backup\ShellProcessor;
 
 class ZstdCompressor extends BaseCompressor
 {
-    public function __construct(ShellProcessor $shellProcessor, int $level)
+    public function __construct(ShellProcessor $shellProcessor, int $level, bool $multithread = false)
     {
-        parent::__construct($shellProcessor, $level, minLevel: 1, maxLevel: 19);
+        parent::__construct($shellProcessor, $level, minLevel: 1, maxLevel: 19, multithread: $multithread);
     }
 
     public function getExtension(): string
@@ -20,7 +20,10 @@ class ZstdCompressor extends BaseCompressor
     public function getCompressCommandLine(string $inputPath): string
     {
         // --rm removes the original file after compression (like gzip does by default)
-        return sprintf('zstd -%d --rm %s', $this->getLevel(), escapeshellarg($inputPath));
+        // -T0 spreads compression across all available CPU cores
+        $threads = $this->isMultithreaded() ? ' -T0' : '';
+
+        return sprintf('zstd -%d%s --rm %s', $this->getLevel(), $threads, escapeshellarg($inputPath));
     }
 
     public function getDecompressCommandLine(string $outputPath): string

--- a/app/Services/Backup/DTO/BackupConfig.php
+++ b/app/Services/Backup/DTO/BackupConfig.php
@@ -14,6 +14,7 @@ readonly class BackupConfig
         public string $backupPath = '',
         public ?CompressionType $compressionType = null,
         public ?int $compressionLevel = null,
+        public ?bool $compressionMultithread = null,
         public ?string $postBackupScript = null,
     ) {}
 
@@ -23,7 +24,7 @@ readonly class BackupConfig
      * @return array{
      *     database: array<string, mixed>,
      *     volume: array<string, mixed>,
-     *     compression: array{type: string|null, level: int|null},
+     *     compression: array{type: string|null, level: int|null, multithread: bool|null},
      *     backup_path: string,
      *     server_name: string,
      *     post_backup_script: string|null,
@@ -40,6 +41,7 @@ readonly class BackupConfig
             'compression' => [
                 'type' => $this->compressionType?->value,
                 'level' => $this->compressionLevel,
+                'multithread' => $this->compressionMultithread,
             ],
             'backup_path' => $this->backupPath,
             'server_name' => $this->database->serverName,
@@ -53,7 +55,7 @@ readonly class BackupConfig
      * @param  array{
      *     database: array{type: string, host?: string, port?: int, username?: string, password?: string, extra_config?: array<string, mixed>|null, database_name: string},
      *     volume: array{type: string, name?: string, config?: array<string, mixed>},
-     *     compression: array{type: string|null, level: int|null},
+     *     compression: array{type: string|null, level: int|null, multithread?: bool|null},
      *     backup_path?: string,
      *     server_name: string,
      *     post_backup_script?: string|null,
@@ -73,6 +75,7 @@ readonly class BackupConfig
                 ? CompressionType::from($payload['compression']['type'])
                 : null,
             compressionLevel: $payload['compression']['level'] ?? null,
+            compressionMultithread: $payload['compression']['multithread'] ?? null,
             postBackupScript: $payload['post_backup_script'] ?? null,
         );
     }

--- a/resources/views/livewire/configuration/backup.blade.php
+++ b/resources/views/livewire/configuration/backup.blade.php
@@ -127,9 +127,31 @@
                         <x-select wire:model.live="form.compression" :options="$compressionOptions" :disabled="!$this->canManage" />
                     </x-config-row>
 
-                    <x-config-row :label="__('Compression Level')" :description="__('1-9 for gzip/encrypted, 1-19 for zstd.')">
-                        <x-input wire:model.blur="form.compression_level" type="number" min="1" max="19" :disabled="!$this->canManage" />
+                    @php
+                        $compressionType = \App\Enums\CompressionType::tryFrom($form->compression);
+                        $maxLevel = $compressionType?->maxLevel() ?? 19;
+                    @endphp
+
+                    <x-config-row :label="__('Compression Level')" :description="__('Higher levels compress smaller but run slower.')">
+                        <div class="flex items-center gap-4">
+                            <div class="flex-1">
+                                <x-range
+                                    wire:model.live.debounce.200ms="form.compression_level"
+                                    :min="1"
+                                    :max="$maxLevel"
+                                    class="range-primary range-xs"
+                                    :disabled="!$this->canManage"
+                                />
+                            </div>
+                            <span class="badge badge-neutral shrink-0 font-mono whitespace-nowrap tabular-nums">{{ $form->compression_level }} / {{ $maxLevel }}</span>
+                        </div>
                     </x-config-row>
+
+                    @if ($compressionType?->supportsMultithreading())
+                        <x-config-row :label="__('Multithreaded Compression')" :description="__('Use all available CPU cores to speed up compression.')">
+                            <x-toggle wire:model.live="form.compression_multithread" :disabled="!$this->canManage" />
+                        </x-config-row>
+                    @endif
 
                     <x-config-row :label="__('Job Timeout')" :description="__('Maximum number of seconds a backup or restore job can run before timing out.')">
                         <x-input wire:model.blur="form.job_timeout" type="number" min="60" max="86400" :disabled="!$this->canManage" />

--- a/tests/Feature/AppConfigTest.php
+++ b/tests/Feature/AppConfigTest.php
@@ -18,6 +18,7 @@ test('get returns default values', function () {
     expect(AppConfig::get('backup.working_directory'))->toBe('/tmp/backups')
         ->and(AppConfig::get('backup.compression'))->toBe('gzip')
         ->and(AppConfig::get('backup.compression_level'))->toBe(6)
+        ->and(AppConfig::get('backup.compression_multithread'))->toBeFalse()
         ->and(AppConfig::get('backup.job_timeout'))->toBe(7200)
         ->and(AppConfig::get('backup.job_tries'))->toBe(3)
         ->and(AppConfig::get('backup.job_backoff'))->toBe(60)

--- a/tests/Feature/Configuration/BackupTest.php
+++ b/tests/Feature/Configuration/BackupTest.php
@@ -46,6 +46,26 @@ test('saving backup config persists values', function () {
         ->and(AppConfig::get('backup.job_timeout'))->toBe(3600);
 });
 
+test('saving backup config persists multithreading toggle', function () {
+    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
+        ->test(Backup::class)
+        ->set('form.compression', 'zstd')
+        ->set('form.compression_multithread', true)
+        ->call('saveBackupConfig')
+        ->assertHasNoErrors();
+
+    expect(AppConfig::get('backup.compression_multithread'))->toBeTrue();
+});
+
+test('switching to gzip clamps the compression level to its ceiling', function () {
+    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
+        ->test(Backup::class)
+        ->set('form.compression', 'zstd')
+        ->set('form.compression_level', 19)
+        ->set('form.compression', 'gzip')
+        ->assertSet('form.compression_level', 9);
+});
+
 test('saving backup config persists post-backup and post-restore scripts', function () {
     Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
         ->test(Backup::class)

--- a/tests/Feature/Services/Backup/Compressors/CompressorFactoryTest.php
+++ b/tests/Feature/Services/Backup/Compressors/CompressorFactoryTest.php
@@ -27,6 +27,28 @@ test('factory creates correct compressor from config', function (string $configV
     'encrypted' => ['encrypted', EncryptedCompressor::class],
 ]);
 
+test('factory applies multithreading from config', function () {
+    AppConfig::set('backup.compression', 'zstd');
+    AppConfig::set('backup.compression_level', 6);
+    AppConfig::set('backup.compression_multithread', true);
+
+    $factory = new CompressorFactory($this->shellProcessor);
+    $compressor = $factory->make();
+
+    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("zstd -6 -T0 --rm '/path/to/dump.sql'");
+});
+
+test('factory omits multithreading when config disables it', function () {
+    AppConfig::set('backup.compression', 'zstd');
+    AppConfig::set('backup.compression_level', 6);
+    AppConfig::set('backup.compression_multithread', false);
+
+    $factory = new CompressorFactory($this->shellProcessor);
+    $compressor = $factory->make();
+
+    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("zstd -6 --rm '/path/to/dump.sql'");
+});
+
 test('factory throws exception when encrypted and key is missing', function () {
     config(['backup.encryption_key' => null]);
     $factory = new CompressorFactory($this->shellProcessor);

--- a/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
+++ b/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
@@ -18,6 +18,12 @@ test('encrypted command generation', function () {
         ->and($compressor->getDecompressCommandLine('/path/to/dump.sql.7z'))->toBe("7z x -y -o'/path/to' -p'secret123' '/path/to/dump.sql.7z'");
 });
 
+test('encrypted multithreading adds -mmt=on flag', function () {
+    $compressor = new EncryptedCompressor($this->shellProcessor, 6, 'secret123', multithread: true);
+
+    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("7z a -t7z -mx=6 -mhe=on -mmt=on -p'secret123' '/path/to/dump.sql.7z' '/path/to/dump.sql'");
+});
+
 test('encrypted compression level is clamped to valid range', function (int $inputLevel, int $expectedLevel) {
     $compressor = new EncryptedCompressor($this->shellProcessor, $inputLevel);
 

--- a/tests/Feature/Services/Backup/Compressors/ZstdCompressorTest.php
+++ b/tests/Feature/Services/Backup/Compressors/ZstdCompressorTest.php
@@ -17,6 +17,12 @@ test('zstd command generation', function () {
         ->and($compressor->getDecompressCommandLine('/path/to/dump.sql.zst'))->toBe("zstd -d --rm '/path/to/dump.sql.zst'");
 });
 
+test('zstd multithreading adds -T0 flag', function () {
+    $compressor = new ZstdCompressor($this->shellProcessor, 6, multithread: true);
+
+    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("zstd -6 -T0 --rm '/path/to/dump.sql'");
+});
+
 test('zstd compression level is clamped to valid range', function (int $inputLevel, int $expectedLevel) {
     $compressor = new ZstdCompressor($this->shellProcessor, $inputLevel);
 

--- a/tests/Unit/Services/Backup/DTO/BackupConfigTest.php
+++ b/tests/Unit/Services/Backup/DTO/BackupConfigTest.php
@@ -24,8 +24,9 @@ test('toPayload and fromPayload are symmetric', function () {
         databaseName: 'myapp',
         workingDirectory: '/tmp/work',
         backupPath: 'backups/2026/02',
-        compressionType: CompressionType::GZIP,
+        compressionType: CompressionType::ZSTD,
         compressionLevel: 6,
+        compressionMultithread: true,
         postBackupScript: '/usr/local/bin/notify.sh',
     );
 
@@ -42,8 +43,9 @@ test('toPayload and fromPayload are symmetric', function () {
         ->and($restored->databaseName)->toBe('myapp')
         ->and($restored->workingDirectory)->toBe('/tmp/restored')
         ->and($restored->backupPath)->toBe('backups/2026/02')
-        ->and($restored->compressionType)->toBe(CompressionType::GZIP)
+        ->and($restored->compressionType)->toBe(CompressionType::ZSTD)
         ->and($restored->compressionLevel)->toBe(6)
+        ->and($restored->compressionMultithread)->toBeTrue()
         ->and($restored->postBackupScript)->toBe('/usr/local/bin/notify.sh');
 });
 


### PR DESCRIPTION
Closes #432

## What

Adds an optional **Multithreaded Compression** setting that lets `zstd` (`-T0`) and `7z` (`-mmt=on`) spread compression across all CPU cores. On a machine with many vCPUs the compression step was previously pinned to a single core; this lets large dumps finish faster.

Standard `gzip` is single-threaded by design, so the toggle only appears for algorithms that actually support it (`CompressionType::supportsMultithreading()`). No new dependency (e.g. `pigz`) is introduced.

**Default: off.** It preserves existing upgrade behavior (no surprise CPU saturation for co-located databases), and the default `gzip` compression ignores the flag anyway — so the only users it affects are those who deliberately pick `zstd`/`encrypted`, who see the toggle right there.

## Changes

- New `backup.compression_multithread` app config (boolean, default `false`).
- Flag threaded through `CompressorFactory` → `BaseCompressor`, and through the **agent job payload** (`BackupConfig`), so it applies to both local and remote-agent backups.
- `zstd` gets `-T0`, `7z` gets `-mmt=on` when enabled.
- UI: replaced the compression-level number input with a **Mary UI range slider** whose ceiling is driven by `CompressionType::maxLevel()` (9 for gzip/7z, 19 for zstd). Switching algorithm clamps the level to the new max. Multithread toggle sits directly under it.

## Local verification (in the app Docker container)

Tooling present: `zstd 1.5.7`, `7-Zip 26.00` (reports `Threads:16`), `gzip 1.14`, 16 cores.

Command round-trips (compress → decompress → content matches):

| Algorithm | Command | Result |
|---|---|---|
| zstd | `zstd -6 -T0 --rm dump.sql` | ✅ round-trips, `-T0` accepted |
| 7z (encrypted) | `7z a -t7z -mx=6 -mhe=on -mmt=on -p… out.7z in` | ✅ round-trips, password enforced (wrong pw rejected), `-mmt` accepted |
| gzip | `gzip -6 dump.sql` | ✅ round-trips |

zstd threading speedup — 224 MB dump, level 12:

| Mode | Wall time | User time | Output size |
|---|---|---|---|
| single-thread | 3.02s | 10.2s | 3.1 MB |
| `-T0` (all cores) | **2.12s** | 12.3s | 3.1 MB |

~30% faster wall-clock, identical output size, higher user-time confirms the extra cores engaged. (7z's `-mmt=on` was verified functionally — flag accepted, `Threads:16`, correct round-trip — but not micro-benchmarked, since LZMA's per-thread dictionaries make single-threaded runs on large files slow/memory-heavy in the container.)

## Tests

Full suite green (`1267 passed`), Pint + PHPStan clean. Added coverage for: `zstd -T0` / `7z -mmt=on` command generation, factory reading the config flag, payload symmetry, config-form save + level-clamp-on-algorithm-change, and the new default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional multithreaded compression for supported compression methods.
  * Added a backup configuration toggle for multithreaded compression.
  * Compression level controls now adapt to the selected compression method.
  * Compression levels are automatically adjusted when switching algorithms.
  * Added support for higher compression limits where applicable.

* **Bug Fixes**
  * Prevented compression levels from exceeding the selected algorithm’s supported maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->