### PR TITLE
feat(dev): agent-optimized tool output via laravel/pao

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,16 @@ make test-coverage                  # Run tests with coverage report
 
 Tests run in parallel by default using Pest's parallel testing feature. This significantly speeds up the test suite (~12-18s for 350+ tests). Use `make test-sequential` if you need to debug test order issues.
 
+#### Agent-Optimized Output (laravel/pao)
+
+When you run `make test` / `make phpstan` / `make lint-check`, output is compact JSON, not verbose logs. A passing run is one line:
+
+```json
+{"tool":"pest","result":"passed","tests":18,"passed":18,"assertions":79,"duration_ms":8657}
+```
+
+A failing run adds a `failures` array with the file, line, and message for each failure — that's the detail to act on. Set `PAO_DISABLE=1` to force verbose output if you need it.
+
 ### Test Strategy
 - Focus on testing business logic and behaviors
 - Do not test framework internals or trust that Laravel/Livewire works correctly

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PHP_SERVICE    := app
 # Forward AI-agent env vars (Claude Code, Cursor, Gemini, ...) into the container so
 # laravel/pao detects the agent and emits compact JSON output instead of verbose logs.
 # `-e VAR` is only added when VAR is set on the host, avoiding empty-string false positives.
-AGENT_ENV := $(foreach v,CLAUDECODE CLAUDE_CODE AI_AGENT CURSOR_AGENT GEMINI_CLI,$(if $($(v)),-e $(v)))
+AGENT_ENV := $(foreach v,CLAUDECODE CLAUDE_CODE AI_AGENT CURSOR_AGENT GEMINI_CLI PAO_DISABLE,$(if $($(v)),-e $(v)))
 PHP_EXEC  := $(DOCKER_COMPOSE) exec --user application -T $(AGENT_ENV) $(PHP_SERVICE)
 PHP_COMPOSER   := $(PHP_EXEC) composer
 PHP_ARTISAN    := $(PHP_EXEC) php artisan

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,12 @@ NC     := \033[0m # No Color
 # Docker / PHP helpers
 DOCKER_COMPOSE := docker compose
 PHP_SERVICE    := app
-PHP_EXEC       := $(DOCKER_COMPOSE) exec --user application -T $(PHP_SERVICE)
+
+# Forward AI-agent env vars (Claude Code, Cursor, Gemini, ...) into the container so
+# laravel/pao detects the agent and emits compact JSON output instead of verbose logs.
+# `-e VAR` is only added when VAR is set on the host, avoiding empty-string false positives.
+AGENT_ENV := $(foreach v,CLAUDECODE CLAUDE_CODE AI_AGENT CURSOR_AGENT GEMINI_CLI,$(if $($(v)),-e $(v)))
+PHP_EXEC  := $(DOCKER_COMPOSE) exec --user application -T $(AGENT_ENV) $(PHP_SERVICE)
 PHP_COMPOSER   := $(PHP_EXEC) composer
 PHP_ARTISAN    := $(PHP_EXEC) php artisan
 NPM_EXEC       := npm

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
         "larastan/larastan": "^3.8",
         "laravel/boost": "^2.1",
         "laravel/pail": "^1.2.2",
+        "laravel/pao": "^1.1",
         "laravel/pint": "^1.18",
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c11af9d95eac5bec02ec16b3b96c8463",
+    "content-hash": "1c0c2699f17c2b0453ad5cb9888f765a",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -10879,6 +10879,68 @@
             "time": "2026-04-16T10:02:43+00:00"
         },
         {
+            "name": "laravel/agent-detector",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/agent-detector.git",
+                "reference": "90694b9256099591cf9e55d08c18ba7a00bf099f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/agent-detector/zipball/90694b9256099591cf9e55d08c18ba7a00bf099f",
+                "reference": "90694b9256099591cf9e55d08c18ba7a00bf099f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.24.0",
+                "pestphp/pest": "^3.8.5|^4.1.0",
+                "pestphp/pest-plugin-type-coverage": "^3.0|^4.0.2",
+                "phpstan/phpstan": "^2.1.26",
+                "rector/rector": "^2.1.7",
+                "symfony/var-dumper": "^7.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\AgentDetector\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Detect if code is running in an AI agent or automated development environment",
+            "homepage": "https://github.com/laravel/agent-detector",
+            "keywords": [
+                "Agent",
+                "ai",
+                "automation",
+                "claude",
+                "cursor",
+                "detection",
+                "devin",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/agent-detector/issues",
+                "source": "https://github.com/laravel/agent-detector"
+            },
+            "time": "2026-04-29T18:32:34+00:00"
+        },
+        {
             "name": "laravel/boost",
             "version": "v2.4.8",
             "source": {
@@ -11023,6 +11085,91 @@
                 "source": "https://github.com/laravel/pail"
             },
             "time": "2026-05-20T22:24:57+00:00"
+        },
+        {
+            "name": "laravel/pao",
+            "version": "v1.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pao.git",
+                "reference": "41b3c61ebeddce52a446afe6d21e0b02983fb2f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pao/zipball/41b3c61ebeddce52a446afe6d21e0b02983fb2f6",
+                "reference": "41b3c61ebeddce52a446afe6d21e0b02983fb2f6",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/agent-detector": "^2.0.2",
+                "php": "^8.3"
+            },
+            "conflict": {
+                "laravel/framework": "<12.0.0",
+                "nunomaduro/collision": "<8.9.3",
+                "pestphp/pest": "<4.6.3 || >=6.0.0",
+                "phpunit/phpunit": "<12.5.23 || >=13.0.0 <13.1.7 || >=14.0.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^7.20.0",
+                "laravel/pint": "^1.29.1",
+                "orchestra/testbench": "^10.11.0 || ^11.1.0",
+                "pestphp/pest": "^4.7.2 || ^5.0.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.4 || ^5.0.0",
+                "phpstan/phpstan": "^2.2.2",
+                "rector/rector": "^2.4.5",
+                "symfony/process": "^7.4.8 || ^8.1.0",
+                "symfony/var-dumper": "^7.4.8 || ^8.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Laravel\\Pao\\Drivers\\Pest\\Plugin"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Pao\\Laravel\\ServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Pao\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "Agent-optimized output for PHP testing tools",
+            "keywords": [
+                "Agent",
+                "PHPStan",
+                "ai",
+                "dev",
+                "paratest",
+                "pest",
+                "php",
+                "phpunit",
+                "rector",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pao/issues",
+                "source": "https://github.com/laravel/pao"
+            },
+            "time": "2026-06-22T19:58:00+00:00"
         },
         {
             "name": "laravel/pint",


### PR DESCRIPTION
## Summary

Adds [`laravel/pao`](https://github.com/laravel/pao) (dev-only) so testing/analysis tools emit **compact JSON** instead of verbose logs when run inside an AI agent (Claude Code, Cursor, ...), cutting token usage dramatically. Human devs are unaffected — they keep normal colored output.

A passing run collapses to one line:
```json
{"tool":"pest","result":"passed","tests":1261,"passed":1261,"assertions":3511,"duration_ms":96142}
```
Failures include a `failures` array with file/line/message.

## The Docker wrinkle

PAO detects agents via env vars (`CLAUDECODE`, `AI_AGENT`, ...) read through `getenv()`. Since all tools run inside the container via `docker compose exec`, those host vars never reached PAO. The Makefile's `PHP_EXEC` now forwards them into the container — but **only when set on the host**, avoiding empty-string false positives that would wrongly trigger agent mode for human devs:

```makefile
AGENT_ENV := $(foreach v,CLAUDECODE CLAUDE_CODE AI_AGENT CURSOR_AGENT GEMINI_CLI,$(if $($(v)),-e $(v)))
PHP_EXEC  := $(DOCKER_COMPOSE) exec --user application -T $(AGENT_ENV) $(PHP_SERVICE)
```

This covers `make test`, `make phpstan`, `make lint-check`, and the Husky pre-commit hook (which calls the same targets).

## Changes
- `composer.json` / `composer.lock`: add `laravel/pao ^1.1` to `require-dev`
- `Makefile`: forward AI-agent env vars into the container via `PHP_EXEC`
- `CLAUDE.md`: document the compact output format and `PAO_DISABLE=1` escape hatch

## Testing
- `make test-filter` and full `make test` verified compact JSON output as an agent
- Confirmed no `-e` flags are added (verbose output preserved) when no agent env is present
- Pre-commit hook passes: pint, phpstan (0 errors), 1261 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for “agent-optimized output” formatting for test, static analysis, and linting runs, including an example of compact JSON output and failure details.
  * Documented how to force verbose output when needed.

* **Developer Experience**
  * Improved containerized command execution by forwarding supported agent-related environment settings into the runtime.
  * Enhanced structured pass/fail reporting to make automated validation output easier to consume.

* **Chores**
  * Added `laravel/pao` as a development dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->