### PR TITLE
fix(docker): set HOME for the application user so PostgreSQL TLS works

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -146,6 +146,12 @@ ENV ENABLE_QUEUE_WORKER="false"
 ENV ENABLE_DATABASE_MIGRATION="true"
 ENV TZ="UTC"
 
+# supervisord drops to `application` via setuid without rewriting the environment,
+# so children would inherit root's HOME=/root (mode 0700). libpq treats a permission
+# error on $HOME/.postgresql/postgresql.crt as fatal to the TLS handshake, breaking
+# PostgreSQL connections over SSL.
+ENV HOME=/home/application
+
 HEALTHCHECK NONE
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["/usr/local/bin/start.sh"]


### PR DESCRIPTION
## Problem

Reported in #434: connecting to a Neon (serverless PostgreSQL) server fails with

```
psql: error: connection to server at "ep-...aws.neon.tech", port 5432 failed:
could not open certificate file "/root/.postgresql/postgresql.crt": Permission denied
... connection is insecure (try using `sslmode=require`)
```

The report reads like a missing `sslmode` option, but the root cause is ours.

`supervisord` starts as root and drops to the `application` user via `setuid()`, copying its environment verbatim — it never rewrites `HOME`. So FrankenPHP, the queue worker and the scheduler all run as `application` while still carrying `HOME=/root`, which is mode `0700`. Confirmed on the published image:

```
$ docker exec --user application <container> sh -c 'tr "\0" "\n" < /proc/21/environ | grep ^HOME'
HOME=/root
```

libpq — used by `psql`, `pg_dump`, `pg_restore` **and** PDO — always looks for a client certificate at `$HOME/.postgresql/postgresql.crt`. It tolerates the file being *absent* (`ENOENT`), but a *permission* error (`EACCES`) is fatal to the TLS handshake. Laravel's `Process` facade wraps Symfony Process, which inherits the parent environment, so the bad `HOME` propagates into every dump/restore shell-out.

## Impact beyond Neon

With the default `sslmode=prefer`, the failed TLS attempt silently downgrades to a plaintext connection. Neon refuses that fallback, which is the only reason the bug became visible — on providers that accept plaintext, **PostgreSQL backups against TLS-capable servers have been running unencrypted**. Reproduced from inside the container against a TLS-enabled Postgres, driving the app's real `Symfony\Component\Process` code path:

| `HOME` seen by PHP | `sslmode` | Result |
| --- | --- | --- |
| `/root` (current) | `prefer` (default) | connects, `pg_stat_ssl.ssl = f` — **silently unencrypted** |
| `/root` (current) | `require` | fails with the exact error from #434 |
| `/home/application` (fixed) | either | connects, `pg_stat_ssl.ssl = t` |

Note the middle row: **adding an `sslmode=require` option would not have fixed the reported issue** — the handshake dies before `sslmode` is ever consulted.

## Fix

One line — bake `HOME` into the image:

```dockerfile
ENV HOME=/home/application
```

Setting it in the image (rather than exporting it in `start.sh`) means root's environment is already correct before supervisord starts, so its `setuid` children inherit the right value with no patching. It also covers the paths `start.sh` wouldn't: the non-root branch, agent mode (`exec php artisan agent:run`), and Kubernetes `runAsUser` deployments, where `HOME` otherwise falls back to `/` or an unwritable path.

After this, libpq's default `prefer` mode negotiates TLS correctly and Neon connects with no extra configuration. It also fixes the PDO paths (`listDatabases`, `prepareForRestore`), which hit the same libpq lookup.

## Verification

Ran the published image with the fixed `HOME` (an `ENV` and a `-e` are equivalent at runtime) and confirmed:

- all supervisord children (`frankenphp`, `php`, `sh`) now inherit `HOME=/home/application`
- PHP shelling out to `psql` over TLS reports `ssl = t`, where it previously reported `ssl = f`

No PHP surface changed, so there's nothing to unit-test; the behaviour only manifests inside the built image under supervisord. Build stages are unaffected — `backend-build` already runs as `USER 1000`, for which Docker resolved `HOME=/home/application` from `/etc/passwd` anyway, so composer's cache location doesn't move.

## Follow-up

Refs #434 — deliberately not closing it. The original request (an explicit SSL-mode selector: `require` / `verify-ca` / `verify-full`) is still worth doing on top of this, since `prefer` gives no guarantee against a downgrade and Neon's own connection string specifies `sslmode=require`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PostgreSQL SSL connection issues by ensuring application processes use the correct home directory and certificate path.
  * Improved environment handling for processes running under the application account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->