### PR TITLE
Ship .env.example instead of a committed APP_KEY

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,4 @@ yarn-error.log
 /transmission
 docker
 Dockerfile
+.env

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Databasement
-APP_ENV=local
-APP_KEY=base64:AGzEQKd61YVyasGQvOBSyjxmxUnn6A7J1rremGD3EEA=
-APP_DEBUG=true
+APP_ENV=production
+APP_KEY=
+APP_DEBUG=false
 APP_URL=http://localhost:2226
 
 APP_LOCALE=en
@@ -26,7 +26,7 @@ DB_HOST=mysql
 DB_PORT=3306
 DB_DATABASE=databasement
 DB_USERNAME=root
-DB_PASSWORD=root
+DB_PASSWORD=
 
 
 SESSION_DRIVER=database

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ frankenphp
 .scribe
 
 coverage
+.env

--- a/docker/php/scripts/docker-entrypoint.sh
+++ b/docker/php/scripts/docker-entrypoint.sh
@@ -12,4 +12,15 @@ if [ -z "${APP_DISPLAY_TIMEZONE:-}" ] && [ -n "${TZ:-}" ] && [ "${TZ}" != "UTC" 
 fi
 export TZ=UTC
 
+# Fail fast when no application encryption key is configured. Databasement uses
+# APP_KEY to encrypt stored database credentials, SSH private keys and cloud
+# secrets, so it must be a unique, secret value per deployment (never the repo
+# default). Accept it either as a real environment variable or from .env.
+if [ -z "${APP_KEY:-}" ] && ! grep -qE '^APP_KEY=base64:' /app/.env 2>/dev/null; then
+    echo "ERROR: APP_KEY is not set." >&2
+    echo "Generate one with: docker run --rm davidcrty/databasement:latest php artisan key:generate --show" >&2
+    echo "Then pass it as the APP_KEY environment variable (or set it in .env)." >&2
+    exit 1
+fi
+
 exec "$@"


### PR DESCRIPTION
Hey! First off, really nice project.

While reading and using a little bit of Claude through it I noticed one thing.

What I noticed
The repo tracks a real `.env` that includes a concrete `APP_KEY` (and
`APP_DEBUG=true`). Because the Dockerfile does `COPY . /app`, that file lands in
the image, and `APP_KEY` isn't overridden there. So any `docker run` /
`docker compose` deployment that forgets to set its own `APP_KEY` silently falls
back to a key that's public in this repo.

Since Databasement encrypts stored DB credentials, SSH private keys and cloud
secrets with `APP_KEY`, a shared key means those could be decrypted by anyone
who has the image. The Helm chart already guards against this (it `fail`s
without a key) — this just brings the Docker path in line.

What this PR does
- Replaces the committed `.env` with a sanitized **`.env.example`** (blank
  `APP_KEY`, `APP_DEBUG=false`, no DB password) and stops tracking `.env`.
- Ignores `.env` in git and Docker builds so real secrets never get baked in.
- Makes the container entrypoint **fail fast with a helpful message** when no
  `APP_KEY` is set, mirroring the Helm behaviour.

Note for maintainers
- Local dev now follows the standard Laravel flow: `cp .env.example .env &&
  php artisan key:generate`.
- Worth **rotating the currently committed key**, since it's already public in
  git history.

Thanks for the great tool! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent application containers from starting without a configured application key.
  * Improved error guidance when the application key is missing.

* **Chores**
  * Updated environment templates with safer production defaults.
  * Prevented local environment files from being included in version control and Docker build contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->