### PR TITLE
Normalize configuration screens with shared card heading and tables

### DIFF
--- a/app/Livewire/Configuration/Backup.php
+++ b/app/Livewire/Configuration/Backup.php
@@ -208,6 +208,12 @@ class Backup extends Component
             'compressionOptions' => $this->getCompressionOptions(),
             'backupSchedules' => $this->backupSchedules(),
             'showDeprecatedBackupEnv' => config('app.has_deprecated_backup_env'),
+            'scheduleHeaders' => [
+                ['key' => 'name', 'label' => __('Name')],
+                ['key' => 'expression', 'label' => __('Schedule')],
+                ['key' => 'usage', 'label' => __('Used by')],
+                ['key' => 'actions', 'label' => '', 'class' => 'w-24 whitespace-nowrap'],
+            ],
         ]);
     }
 }

--- a/app/Livewire/Configuration/Notification.php
+++ b/app/Livewire/Configuration/Notification.php
@@ -135,6 +135,12 @@ class Notification extends Component
         return view('livewire.configuration.notification', [
             'channelTypeOptions' => $this->getChannelTypeOptions(),
             'notificationChannels' => $this->notificationChannels(),
+            'headers' => [
+                ['key' => 'name', 'label' => __('Name')],
+                ['key' => 'type', 'label' => __('Type')],
+                ['key' => 'config', 'label' => __('Configuration')],
+                ['key' => 'actions', 'label' => '', 'class' => 'w-32 whitespace-nowrap'],
+            ],
         ]);
     }
 }

--- a/app/Livewire/Configuration/Roles.php
+++ b/app/Livewire/Configuration/Roles.php
@@ -143,6 +143,12 @@ class Roles extends Component
             'roles' => $roles,
             'memberCounts' => $this->memberCounts(),
             'abilityGroups' => Ability::grouped(),
+            'headers' => [
+                ['key' => 'name', 'label' => __('Role')],
+                ['key' => 'abilities', 'label' => __('Abilities')],
+                ['key' => 'members', 'label' => __('Members'), 'class' => 'w-28 whitespace-nowrap'],
+                ['key' => 'actions', 'label' => '', 'class' => 'w-24 whitespace-nowrap'],
+            ],
         ]);
     }
 

--- a/app/Models/Backup.php
+++ b/app/Models/Backup.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\DatabaseSelectionMode;
+use App\Support\Formatters;
 use Database\Factories\BackupFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -93,34 +94,14 @@ class Backup extends Model
         $isSqlite = $this->databaseServer->database_type->value === 'sqlite';
 
         if ($isSqlite) {
-            $paths = $this->database_names ?? [];
-            if ($paths === []) {
-                return '';
-            }
-            $basenames = array_map('basename', $paths);
-
-            return count($basenames) <= 2
-                ? implode(', ', $basenames)
-                : $basenames[0].', +'.(count($basenames) - 1);
+            return Formatters::truncatedList(array_map('basename', $this->database_names ?? []), 2);
         }
 
         return match ($this->database_selection_mode) {
             DatabaseSelectionMode::All => __('All databases'),
-            DatabaseSelectionMode::Selected => $this->formatSelectedDatabases(),
+            DatabaseSelectionMode::Selected => Formatters::truncatedList($this->database_names ?? [], 2),
             DatabaseSelectionMode::Pattern => '/'.$this->database_include_pattern.'/',
         };
-    }
-
-    private function formatSelectedDatabases(): string
-    {
-        $names = $this->database_names ?? [];
-        if ($names === []) {
-            return '';
-        }
-
-        return count($names) <= 2
-            ? implode(', ', $names)
-            : $names[0].', +'.(count($names) - 1);
     }
 
     /**

--- a/app/Support/Formatters.php
+++ b/app/Support/Formatters.php
@@ -95,7 +95,7 @@ class Formatters
         $remaining = $names->count() - $limit;
 
         return $remaining > 0
-            ? $shown.' +'.$remaining.' '.__('more')
+            ? __(':shown +:count more', ['shown' => $shown, 'count' => $remaining])
             : $shown;
     }
 

--- a/app/Support/Formatters.php
+++ b/app/Support/Formatters.php
@@ -3,6 +3,7 @@
 namespace App\Support;
 
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Lorisleiva\CronTranslator\CronTranslator;
 
 class Formatters
@@ -79,6 +80,23 @@ class Formatters
         } catch (\Throwable) {
             return $fallback;
         }
+    }
+
+    /**
+     * Join names into a comma-separated list, keeping it short enough to fit in a
+     * popover: beyond $limit entries the rest collapse into a "+N more" suffix.
+     *
+     * @param  \Illuminate\Support\Collection<int, string>|array<int, string>  $names
+     */
+    public static function truncatedList(Collection|array $names, int $limit = 5): string
+    {
+        $names = Collection::make($names);
+        $shown = $names->take($limit)->join(', ');
+        $remaining = $names->count() - $limit;
+
+        return $remaining > 0
+            ? $shown.' +'.$remaining.' '.__('more')
+            : $shown;
     }
 
     /**

--- a/lang/el.json
+++ b/lang/el.json
@@ -7,6 +7,7 @@
   "1/week for N weeks": "1/εβδομάδα για N εβδομάδες",
   "2FA Recovery Codes": "Κωδικοί ανάκτησης 2FA",
   ":count jobs in the last 30 days": ":count εργασίες τις τελευταίες 30 ημέρες",
+  ":shown +:count more": ":shown +:count ακόμη",
   "A descriptive name to identify this token": "Ένα περιγραφικό όνομα για την αναγνώριση αυτού του token",
   "A friendly name to identify this server": "Ένα φιλικό όνομα για την αναγνώριση αυτού του server",
   "A new verification link has been sent to the email address you provided during registration.": "Ένας νέος σύνδεσμος επαλήθευσης στάλθηκε στη διεύθυνση email που δηλώσατε κατά την εγγραφή.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -7,6 +7,7 @@
   "1/week for N weeks": "1/semana durante N semanas",
   "2FA Recovery Codes": "Códigos de recuperación 2FA",
   ":count jobs in the last 30 days": ":count trabajos en los últimos 30 días",
+  ":shown +:count more": ":shown +:count más",
   "A descriptive name to identify this token": "Un nombre descriptivo para identificar este token",
   "A friendly name to identify this server": "Un nombre amigable para identificar este servidor",
   "A new verification link has been sent to the email address you provided during registration.": "Se ha enviado un nuevo enlace de verificación a la dirección de correo electrónico proporcionada durante el registro.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -7,6 +7,7 @@
   "1/week for N weeks": "1/semaine pendant N semaines",
   "2FA Recovery Codes": "Codes de récupération 2FA",
   ":count jobs in the last 30 days": ":count tâches au cours des 30 derniers jours",
+  ":shown +:count more": ":shown +:count de plus",
   "A descriptive name to identify this token": "Un nom descriptif pour identifier ce jeton",
   "A friendly name to identify this server": "Un nom convivial pour identifier ce serveur",
   "A new verification link has been sent to the email address you provided during registration.": "Un nouveau lien de vérification a été envoyé à l’adresse e-mail fournie lors de l’inscription.",

--- a/resources/views/components/card-heading.blade.php
+++ b/resources/views/components/card-heading.blade.php
@@ -1,0 +1,20 @@
+@props(['title' => null, 'subtitle' => null])
+
+{{-- Mary's x-card header keeps title and menu on one row; this stacks them on small screens. --}}
+<div class="flex flex-col gap-3 pb-5 sm:flex-row sm:items-center sm:justify-between">
+    <div class="min-w-0">
+        @if ($title)
+            <div class="text-xl font-bold">{{ $title }}</div>
+        @endif
+
+        @if ($subtitle)
+            <div class="mt-1 text-sm text-base-content/50">{{ $subtitle }}</div>
+        @endif
+    </div>
+
+    @if ($slot->isNotEmpty())
+        <div class="flex flex-wrap items-center justify-end gap-2 sm:shrink-0">
+            {{ $slot }}
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/configuration/application.blade.php
+++ b/resources/views/livewire/configuration/application.blade.php
@@ -11,8 +11,8 @@
 
     @include('livewire.configuration._tabs', ['active' => 'application'])
 
-    <x-card :title="__('Application')" :subtitle="__('Environment variables controlling application behavior.')" shadow class="min-w-0">
-        <x-slot:menu>
+    <x-card shadow class="min-w-0">
+        <x-card-heading :title="__('Application')" :subtitle="__('Environment variables controlling application behavior.')">
             <x-button
                 :label="__('Documentation')"
                 icon="o-book-open"
@@ -20,7 +20,7 @@
                 external
                 class="btn-ghost btn-sm"
             />
-        </x-slot:menu>
+        </x-card-heading>
         @include('livewire.configuration._config-table', ['rows' => $appConfig])
 
         <form wire:submit="saveApplicationConfig" class="mt-4 border-t border-base-200/60 pt-4">

--- a/resources/views/livewire/configuration/authentication.blade.php
+++ b/resources/views/livewire/configuration/authentication.blade.php
@@ -7,8 +7,8 @@
 
     @include('livewire.configuration._tabs', ['active' => 'authentication'])
 
-    <x-card :title="__('SSO')" :subtitle="__('OAuth and Single Sign-On authentication settings.')" shadow class="min-w-0">
-        <x-slot:menu>
+    <x-card shadow class="min-w-0">
+        <x-card-heading :title="__('SSO')" :subtitle="__('OAuth and Single Sign-On authentication settings.')">
             <x-button
                 :label="__('Documentation')"
                 icon="o-book-open"
@@ -16,7 +16,7 @@
                 external
                 class="btn-ghost btn-sm"
             />
-        </x-slot:menu>
+        </x-card-heading>
         @include('livewire.configuration._config-table', ['rows' => $ssoConfig])
     </x-card>
 </div>

--- a/resources/views/livewire/configuration/backup.blade.php
+++ b/resources/views/livewire/configuration/backup.blade.php
@@ -15,92 +15,95 @@
 
     <div class="grid gap-6">
         <!-- Backup Schedules -->
-        <x-card :title="__('Backup Schedules')" :subtitle="__('Define cron schedules that database servers can use for automated backups.')" shadow class="min-w-0">
-            <div class="divide-y divide-base-200/80">
-                @forelse ($backupSchedules as $schedule)
-                    <x-config-row wire:key="schedule-{{ $schedule->id }}">
-                        <x-slot:label>
-                            <span class="inline-flex flex-wrap items-center gap-2">
-                                {{ $schedule->name }}
-                                @if ($schedule->backups_count > 0)
-                                    <x-popover>
-                                        <x-slot:trigger>
-                                            <span class="badge badge-outline badge-info cursor-default">
-                                                <x-icon name="o-server-stack" class="w-3 h-3" />
-                                                {{ trans_choice(':count server|:count servers', $schedule->backups_count) }}
-                                            </span>
-                                        </x-slot:trigger>
-                                        <x-slot:content>
-                                            {{ $schedule->backups->pluck('databaseServer.name')->join(', ') }}
-                                        </x-slot:content>
-                                    </x-popover>
-                                @endif
-                                @if ($schedule->scheduled_restores_count > 0)
-                                    <x-popover>
-                                        <x-slot:trigger>
-                                            <span class="badge badge-outline badge-info cursor-default">
-                                                <x-icon name="o-calendar" class="w-3 h-3" />
-                                                {{ trans_choice(':count scheduled restore|:count scheduled restores', $schedule->scheduled_restores_count) }}
-                                            </span>
-                                        </x-slot:trigger>
-                                        <x-slot:content>
-                                            {{ $schedule->scheduledRestores->pluck('name')->join(', ') }}
-                                        </x-slot:content>
-                                    </x-popover>
-                                @endif
-                            </span>
-                        </x-slot:label>
-                        <div class="flex flex-wrap items-center gap-3">
-                            <span class="badge badge-neutral shrink-0">
-                                <x-icon name="o-calendar-days" class="w-3 h-3" />
-                                {{ $schedule->expression }}
-                            </span>
-                            <span class="text-sm text-base-content/60 min-w-0">{{ \App\Support\Formatters::cronTranslation($schedule->expression) }}</span>
-                            @if ($this->canManage)
-                                <div class="flex items-center gap-0.5 shrink-0 ml-auto">
-                                    <x-button icon="o-pencil-square" class="btn-ghost btn-sm" wire:click="openScheduleModal('{{ $schedule->id }}')" :tooltip-left="__('Edit')" />
-                                    @if ($schedule->total_backups_count > 0 || $schedule->scheduled_restores_count > 0)
-                                        <x-popover>
-                                            <x-slot:trigger>
-                                                <x-button icon="o-trash" class="btn-ghost btn-sm opacity-40" disabled />
-                                            </x-slot:trigger>
-                                            <x-slot:content>
-                                                @if ($schedule->total_backups_count > 0 && $schedule->scheduled_restores_count > 0)
-                                                    {{ __('In use by servers and scheduled restores') }}
-                                                @elseif ($schedule->total_backups_count > 0)
-                                                    {{ __('In use by servers') }}
-                                                @else
-                                                    {{ __('In use by scheduled restores') }}
-                                                @endif
-                                            </x-slot:content>
-                                        </x-popover>
-                                    @else
-                                        <x-button icon="o-trash" class="btn-ghost btn-sm text-error hover:bg-error/10" wire:click="confirmDeleteSchedule('{{ $schedule->id }}')" :tooltip-left="__('Delete')" />
-                                    @endif
-                                </div>
-                            @endif
-                        </div>
-                    </x-config-row>
-                @empty
-                    <p class="text-sm text-base-content/50 py-4 text-center">{{ __('No backup schedules defined.') }}</p>
-                @endforelse
-            </div>
-
-            @if ($this->canManage)
-                <div class="flex items-center justify-end border-t border-base-200/60 pt-4 mt-4">
+        <x-card shadow class="min-w-0">
+            <x-card-heading :title="__('Backup Schedules')" :subtitle="__('Define cron schedules that database servers can use for automated backups.')">
+                @if ($this->canManage)
                     <x-button
                         :label="__('Add Schedule')"
                         icon="o-plus"
                         class="btn-primary btn-sm"
                         wire:click="openScheduleModal"
                     />
-                </div>
-            @endif
+                @endif
+            </x-card-heading>
+
+            <x-table :headers="$scheduleHeaders" :rows="$backupSchedules" show-empty-text :empty-text="__('No backup schedules defined.')">
+                @scope('cell_name', $schedule)
+                    <span class="font-medium">{{ $schedule->name }}</span>
+                @endscope
+
+                @scope('cell_expression', $schedule)
+                    <div class="flex flex-wrap items-center gap-2">
+                        <span class="badge badge-neutral shrink-0 whitespace-nowrap font-mono">
+                            <x-icon name="o-calendar-days" class="w-3 h-3" />
+                            {{ $schedule->expression }}
+                        </span>
+                        <span class="text-sm text-base-content/60 whitespace-nowrap">{{ \App\Support\Formatters::cronTranslation($schedule->expression) }}</span>
+                    </div>
+                @endscope
+
+                @scope('cell_usage', $schedule)
+                    <div class="flex flex-wrap items-center gap-2">
+                        @if ($schedule->backups_count > 0)
+                            <x-popover>
+                                <x-slot:trigger>
+                                    <span class="badge badge-outline badge-info cursor-default whitespace-nowrap">
+                                        <x-icon name="o-server-stack" class="w-3 h-3" />
+                                        {{ trans_choice(':count server|:count servers', $schedule->backups_count) }}
+                                    </span>
+                                </x-slot:trigger>
+                                <x-slot:content class="max-w-64">
+                                    {{ \App\Support\Formatters::truncatedList($schedule->backups->pluck('databaseServer.name')) }}
+                                </x-slot:content>
+                            </x-popover>
+                        @endif
+                        @if ($schedule->scheduled_restores_count > 0)
+                            <x-popover>
+                                <x-slot:trigger>
+                                    <span class="badge badge-outline badge-info cursor-default whitespace-nowrap">
+                                        <x-icon name="o-calendar" class="w-3 h-3" />
+                                        {{ trans_choice(':count scheduled restore|:count scheduled restores', $schedule->scheduled_restores_count) }}
+                                    </span>
+                                </x-slot:trigger>
+                                <x-slot:content class="max-w-64">
+                                    {{ \App\Support\Formatters::truncatedList($schedule->scheduledRestores->pluck('name')) }}
+                                </x-slot:content>
+                            </x-popover>
+                        @endif
+                    </div>
+                @endscope
+
+                @scope('cell_actions', $schedule)
+                    @if ($this->canManage)
+                        <div class="flex justify-end flex-nowrap gap-1">
+                            <x-button icon="o-pencil-square" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openScheduleModal('{{ $schedule->id }}')" :tooltip-left="__('Edit')" />
+                            @if ($schedule->total_backups_count > 0 || $schedule->scheduled_restores_count > 0)
+                                <x-popover>
+                                    <x-slot:trigger>
+                                        <x-button icon="o-trash" class="btn-ghost btn-xs opacity-40" disabled />
+                                    </x-slot:trigger>
+                                    <x-slot:content>
+                                        @if ($schedule->total_backups_count > 0 && $schedule->scheduled_restores_count > 0)
+                                            {{ __('In use by servers and scheduled restores') }}
+                                        @elseif ($schedule->total_backups_count > 0)
+                                            {{ __('In use by servers') }}
+                                        @else
+                                            {{ __('In use by scheduled restores') }}
+                                        @endif
+                                    </x-slot:content>
+                                </x-popover>
+                            @else
+                                <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDeleteSchedule('{{ $schedule->id }}')" :tooltip-left="__('Delete')" />
+                            @endif
+                        </div>
+                    @endif
+                @endscope
+            </x-table>
         </x-card>
 
         <!-- Backup Configuration (editable) -->
-        <x-card :title="__('Backup')" :subtitle="__('Backup and restore operation settings.')" shadow class="min-w-0">
-            <x-slot:menu>
+        <x-card shadow class="min-w-0">
+            <x-card-heading :title="__('Backup')" :subtitle="__('Backup and restore operation settings.')">
                 <x-button
                     :label="__('Documentation')"
                     icon="o-book-open"
@@ -108,7 +111,7 @@
                     external
                     class="btn-ghost btn-sm"
                 />
-            </x-slot:menu>
+            </x-card-heading>
 
             <form wire:submit="saveBackupConfig">
                 <div class="divide-y divide-base-200/80">

--- a/resources/views/livewire/configuration/notification.blade.php
+++ b/resources/views/livewire/configuration/notification.blade.php
@@ -7,8 +7,8 @@
 
     @include('livewire.configuration._tabs', ['active' => 'notification'])
 
-    <x-card :title="__('Notification Channels')" :subtitle="__('Assign channels per database server to receive alerts on backup and restore events.')" shadow class="min-w-0">
-        <x-slot:menu>
+    <x-card shadow class="min-w-0">
+        <x-card-heading :title="__('Notification Channels')" :subtitle="__('Assign channels per database server to receive alerts on backup and restore events.')">
             <x-button
                 :label="__('Documentation')"
                 icon="o-book-open"
@@ -16,48 +16,46 @@
                 external
                 class="btn-ghost btn-sm"
             />
-        </x-slot:menu>
-
-        <div class="divide-y divide-base-200/80">
-            @forelse ($notificationChannels as $channel)
-                <x-config-row wire:key="channel-{{ $channel->id }}">
-                    <x-slot:label>
-                        <span class="inline-flex flex-wrap items-center gap-2">
-                            <x-icon :name="$channel->type->icon()" class="w-4 h-4 text-base-content/60" />
-                            {{ $channel->name }}
-                            <span class="badge badge-outline badge-sm">{{ $channel->type->label() }}</span>
-                        </span>
-                    </x-slot:label>
-                    <div class="flex flex-wrap items-center gap-3">
-                        <span class="text-sm text-base-content/60 min-w-0">
-                            @foreach($channel->getConfigSummary() as $label => $value)
-                                {{ $label }}: {{ $value }}{{ !$loop->last ? ' · ' : '' }}
-                            @endforeach
-                        </span>
-                        @if ($this->canManage)
-                            <div class="flex items-center gap-0.5 shrink-0 ml-auto">
-                                <x-button icon="o-paper-airplane" class="btn-ghost btn-sm" wire:click="sendTestNotification('{{ $channel->id }}')" spinner="sendTestNotification('{{ $channel->id }}')" :tooltip-left="__('Test')" />
-                                <x-button icon="o-pencil-square" class="btn-ghost btn-sm" wire:click="openChannelModal('{{ $channel->id }}')" :tooltip-left="__('Edit')" />
-                                <x-button icon="o-trash" class="btn-ghost btn-sm text-error hover:bg-error/10" wire:click="confirmDeleteChannel('{{ $channel->id }}')" :tooltip-left="__('Delete')" />
-                            </div>
-                        @endif
-                    </div>
-                </x-config-row>
-            @empty
-                <p class="text-sm text-base-content/50 py-4 text-center">{{ __('No notification channels configured.') }}</p>
-            @endforelse
-        </div>
-
-        @if ($this->canManage)
-            <div class="flex items-center justify-end border-t border-base-200/60 pt-4 mt-4">
+            @if ($this->canManage)
                 <x-button
                     :label="__('Add Channel')"
                     icon="o-plus"
                     class="btn-primary btn-sm"
                     wire:click="openChannelModal"
                 />
-            </div>
-        @endif
+            @endif
+        </x-card-heading>
+
+        <x-table :headers="$headers" :rows="$notificationChannels" show-empty-text :empty-text="__('No notification channels configured.')">
+            @scope('cell_name', $channel)
+                <span class="font-medium">{{ $channel->name }}</span>
+            @endscope
+
+            @scope('cell_type', $channel)
+                <span class="badge badge-outline badge-sm whitespace-nowrap">
+                    <x-icon :name="$channel->type->icon()" class="w-3 h-3" />
+                    {{ $channel->type->label() }}
+                </span>
+            @endscope
+
+            @scope('cell_config', $channel)
+                <span class="text-sm text-base-content/60">
+                    @foreach($channel->getConfigSummary() as $label => $value)
+                        {{ $label }}: {{ $value }}{{ !$loop->last ? ' · ' : '' }}
+                    @endforeach
+                </span>
+            @endscope
+
+            @scope('cell_actions', $channel)
+                @if ($this->canManage)
+                    <div class="flex justify-end flex-nowrap gap-1">
+                        <x-button icon="o-paper-airplane" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="sendTestNotification('{{ $channel->id }}')" spinner="sendTestNotification('{{ $channel->id }}')" :tooltip-left="__('Test')" />
+                        <x-button icon="o-pencil-square" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openChannelModal('{{ $channel->id }}')" :tooltip-left="__('Edit')" />
+                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDeleteChannel('{{ $channel->id }}')" :tooltip-left="__('Delete')" />
+                    </div>
+                @endif
+            @endscope
+        </x-table>
     </x-card>
 
     <!-- Add/Edit Notification Channel Modal -->

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -7,30 +7,24 @@
 
     @include('livewire.configuration._tabs', ['active' => 'organizations'])
 
-    <x-alert icon="o-information-circle" class="alert-info mb-4">
-        {{ __('Organizations let you group users, servers, and volumes into isolated workspaces.') }}
-        <x-slot:actions>
+    <x-card shadow class="min-w-0">
+        <x-card-heading :title="__('Organizations')" :subtitle="__('Organizations let you group users, servers, and volumes into isolated workspaces.')">
             <x-button
-                :label="__('Learn more')"
+                :label="__('Documentation')"
+                icon="o-book-open"
                 link="https://david-crty.github.io/databasement/user-guide/organizations"
                 external
-                icon="o-book-open"
-                class="btn-sm"
+                class="btn-ghost btn-sm"
             />
-        </x-slot:actions>
-    </x-alert>
+            @can('create', \App\Models\Organization::class)
+                <x-button :label="__('New Organization')" icon="o-plus" class="btn-primary btn-sm" wire:click="openCreateModal" />
+            @endcan
+        </x-card-heading>
 
-    @can('create', \App\Models\Organization::class)
-        <div class="flex justify-end mb-4">
-            <x-button :label="__('New Organization')" icon="o-plus" class="btn-primary" wire:click="openCreateModal" />
-        </div>
-    @endcan
-
-    <x-card shadow>
-        <x-table :headers="$headers" :rows="$organizations">
+        <x-table :headers="$headers" :rows="$organizations" show-empty-text :empty-text="__('No organizations yet.')">
             @scope('cell_name', $org)
                 <div class="flex items-center gap-2">
-                    {{ $org->name }}
+                    <span class="font-medium">{{ $org->name }}</span>
                     @if($org->is_default)
                         <x-popover>
                             <x-slot:trigger>
@@ -52,9 +46,9 @@
                 {{-- update/delete policies already return false for the default org and non-super-admins --}}
                 @can('update', $org)
                     <div class="flex justify-end flex-nowrap gap-1">
-                        <x-button icon="o-pencil" class="btn-ghost btn-xs" wire:click="openEditModal('{{ $org->id }}')" :tooltip="__('Edit')" />
-                        <x-button icon="o-arrows-pointing-in" class="btn-ghost btn-xs" wire:click="openMergeModal('{{ $org->id }}')" :tooltip="__('Merge')" />
-                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error" wire:click="confirmDelete('{{ $org->id }}')" :tooltip="__('Delete')" />
+                        <x-button icon="o-pencil" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openEditModal('{{ $org->id }}')" :tooltip-left="__('Edit')" />
+                        <x-button icon="o-arrows-pointing-in" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openMergeModal('{{ $org->id }}')" :tooltip-left="__('Merge')" />
+                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDelete('{{ $org->id }}')" :tooltip-left="__('Delete')" />
                     </div>
                 @endcan
             @endscope

--- a/resources/views/livewire/configuration/roles.blade.php
+++ b/resources/views/livewire/configuration/roles.blade.php
@@ -7,71 +7,50 @@
 
     @include('livewire.configuration._tabs', ['active' => 'roles'])
 
-    <x-alert icon="o-information-circle" class="alert-info mb-4">
-        {{ __('Roles bundle abilities that control what users can do in each organization.') }}
-        <x-slot:actions>
+    <x-card shadow class="min-w-0">
+        <x-card-heading :title="__('Roles')" :subtitle="__('Roles bundle abilities that control what users can do.')">
             <x-button
-                :label="__('Learn more')"
+                :label="__('Documentation')"
+                icon="o-book-open"
                 link="https://david-crty.github.io/databasement/user-guide/permissions"
                 external
-                icon="o-book-open"
-                class="btn-sm"
+                class="btn-ghost btn-sm"
             />
-        </x-slot:actions>
-    </x-alert>
+            @can('create', \Silber\Bouncer\Database\Role::class)
+                <x-button :label="__('New role')" icon="o-plus" wire:click="openCreate" class="btn-primary btn-sm" />
+            @endcan
+        </x-card-heading>
 
-    @can('create', \Silber\Bouncer\Database\Role::class)
-        <div class="flex justify-end mb-4">
-            <x-button :label="__('New role')" icon="o-plus" wire:click="openCreate" class="btn-primary btn-sm" />
-        </div>
-    @endcan
+        <x-table :headers="$headers" :rows="$roles" show-empty-text :empty-text="__('No roles yet.')">
+            @scope('cell_name', $role)
+                <div class="font-medium">{{ $role->title ?: $role->name }}</div>
+                <div class="text-sm text-base-content/60 flex items-center gap-1">
+                    <code>{{ $role->name }}</code>
+                    @if($role->built_in)
+                        <x-badge :value="__('Built-in')" class="badge-ghost badge-xs whitespace-nowrap" />
+                    @endif
+                </div>
+            @endscope
 
-    <x-card shadow>
-        <div class="overflow-x-auto">
-            <table class="table table-default">
-                <thead>
-                    <tr>
-                        <th>{{ __('Role') }}</th>
-                        <th>{{ __('Abilities') }}</th>
-                        <th class="text-center w-28">{{ __('Members') }}</th>
-                        <th class="text-right w-28">{{ __('Actions') }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @forelse($roles as $role)
-                        <tr wire:key="role-{{ $role->id }}">
-                            <td>
-                                <div class="font-medium">{{ $role->title ?: $role->name }}</div>
-                                <div class="text-sm text-base-content/60 flex items-center gap-1">
-                                    <code>{{ $role->name }}</code>
-                                    @if($role->built_in)
-                                        <x-badge :value="__('Built-in')" class="badge-ghost badge-xs whitespace-nowrap" />
-                                    @endif
-                                </div>
-                            </td>
-                            <td>
-                                <x-ability-badges :abilities="$role->abilities->pluck('name')->all()" />
-                            </td>
-                            <td class="text-center">{{ $memberCounts[$role->id] ?? 0 }}</td>
-                            <td>
-                                <div class="flex gap-2 justify-end">
-                                    @can('update', $role)
-                                        <x-button icon="o-pencil" wire:click="openEdit({{ $role->id }})" :tooltip="__('Edit')" class="btn-ghost btn-sm" />
-                                    @endcan
-                                    @can('delete', $role)
-                                        <x-button icon="o-trash" wire:click="confirmDelete({{ $role->id }})" :tooltip="__('Delete')" class="btn-ghost btn-sm text-error" />
-                                    @endcan
-                                </div>
-                            </td>
-                        </tr>
-                    @empty
-                        <tr>
-                            <td colspan="4" class="text-center text-base-content/50 py-8">{{ __('No roles yet.') }}</td>
-                        </tr>
-                    @endforelse
-                </tbody>
-            </table>
-        </div>
+            @scope('cell_abilities', $role)
+                <x-ability-badges :abilities="$role->abilities->pluck('name')->all()" />
+            @endscope
+
+            @scope('cell_members', $role, $memberCounts)
+                {{ $memberCounts[$role->id] ?? 0 }}
+            @endscope
+
+            @scope('cell_actions', $role)
+                <div class="flex justify-end flex-nowrap gap-1">
+                    @can('update', $role)
+                        <x-button icon="o-pencil" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openEdit({{ $role->id }})" :tooltip-left="__('Edit')" />
+                    @endcan
+                    @can('delete', $role)
+                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDelete({{ $role->id }})" :tooltip-left="__('Delete')" />
+                    @endcan
+                </div>
+            @endscope
+        </x-table>
     </x-card>
 
     <!-- CREATE / EDIT MODAL -->

--- a/tests/Feature/BackupDisplayLabelTest.php
+++ b/tests/Feature/BackupDisplayLabelTest.php
@@ -52,7 +52,7 @@ test('display label truncates many selected databases', function () {
         'retention_days' => 14,
     ]);
 
-    expect($backup->getDisplayLabel())->toBe('Daily → S3 Prod · app_db, +2 · 14d');
+    expect($backup->getDisplayLabel())->toBe('Daily → S3 Prod · app_db, users_db +1 more · 14d');
 });
 
 test('display label with pattern selection', function () {
@@ -109,5 +109,5 @@ test('display label truncates many sqlite paths', function () {
         'retention_days' => 7,
     ]);
 
-    expect($backup->getDisplayLabel())->toBe('Daily → S3 Prod · app.sqlite, +2 · 7d');
+    expect($backup->getDisplayLabel())->toBe('Daily → S3 Prod · app.sqlite, cache.sqlite +1 more · 7d');
 });

--- a/tests/Feature/Support/FormattersTest.php
+++ b/tests/Feature/Support/FormattersTest.php
@@ -83,6 +83,29 @@ test('humanDate renders in the configured display timezone', function () {
     expect(Formatters::humanDate($date))->toBe('Dec 20, 2025, 01:44');
 });
 
+test('truncatedList returns an empty string for no names', function () {
+    expect(Formatters::truncatedList([]))->toBe('');
+});
+
+test('truncatedList joins names without a suffix when at or under the limit', function () {
+    expect(Formatters::truncatedList(['alpha', 'beta', 'gamma']))
+        ->toBe('alpha, beta, gamma')
+        ->and(Formatters::truncatedList(['a', 'b', 'c', 'd', 'e']))
+        ->toBe('a, b, c, d, e');
+});
+
+test('truncatedList appends a "+N more" suffix when over the limit', function () {
+    expect(Formatters::truncatedList(['a', 'b', 'c', 'd', 'e', 'f']))
+        ->toBe('a, b, c, d, e +1 '.__('more'))
+        ->and(Formatters::truncatedList(['a', 'b', 'c'], 1))
+        ->toBe('a +2 '.__('more'));
+});
+
+test('truncatedList accepts a Collection', function () {
+    expect(Formatters::truncatedList(collect(['a', 'b', 'c']), 2))
+        ->toBe('a, b +1 '.__('more'));
+});
+
 test('resolveDatePlaceholders replaces year, month and day tokens zero-padded', function () {
     $date = \Carbon\Carbon::create(2026, 3, 5);
 

--- a/tests/Feature/Support/FormattersTest.php
+++ b/tests/Feature/Support/FormattersTest.php
@@ -96,14 +96,14 @@ test('truncatedList joins names without a suffix when at or under the limit', fu
 
 test('truncatedList appends a "+N more" suffix when over the limit', function () {
     expect(Formatters::truncatedList(['a', 'b', 'c', 'd', 'e', 'f']))
-        ->toBe('a, b, c, d, e +1 '.__('more'))
+        ->toBe('a, b, c, d, e +1 more')
         ->and(Formatters::truncatedList(['a', 'b', 'c'], 1))
-        ->toBe('a +2 '.__('more'));
+        ->toBe('a +2 more');
 });
 
 test('truncatedList accepts a Collection', function () {
     expect(Formatters::truncatedList(collect(['a', 'b', 'c']), 2))
-        ->toBe('a, b +1 '.__('more'));
+        ->toBe('a, b +1 more');
 });
 
 test('resolveDatePlaceholders replaces year, month and day tokens zero-padded', function () {


### PR DESCRIPTION
## Summary

Normalizes the **Configuration** screens so every tab looks and behaves the same, and fixes the mobile rendering issues that started this work.

- **New `<x-card-heading>` component** — Mary's `x-card` renders its title + menu as a no-wrap flex row, so action buttons never drop below the title on narrow screens (and squeezed the title). The new heading stacks title/subtitle over the actions below the `sm` breakpoint, and right-aligns the actions when they wrap. Applied to all six Configuration cards (Application, Authentication, Backup ×2, Notification, Roles, Organizations).
- **`<x-table>` everywhere** — Roles, Backup Schedules and Notification Channels now use `x-table` with `@scope` cells, matching the existing Organizations screen (consistent headers, `min-w-0` card, `font-medium` name cells, `btn-xs` action groups, `show-empty-text`).
- **Fix duplicated title** — the Organizations card title was literally `OrganizationsOrganizations`.
- **Notification icon** — moved from the Name cell into the Type badge.
- **In-table button tooltips** — Mary hardcodes `lg:tooltip`, disabling button tooltips below 1024px. Added unprefixed `tooltip tooltip-left` classes so the Edit/Delete/Test tooltips work at every width.
- **Popover truncation** — long server/scheduled-restore lists are truncated via a new `Formatters::truncatedList()` helper (5 items + "+N more") so they no longer get clipped by the table's `overflow-x-auto` scroll container.

## Notes

- Translations for the handful of new strings (Roles, Organizations, Used by, Abilities, Members, more, …) are intentionally left for a separate translation pass.

## Testing

- `make lint-fix`, `make phpstan`, `make test` all pass via the pre-commit hook (1267 tests, 3520 assertions).
- Manually verified in Chrome at 420px: card headings stack, buttons right-align, button tooltips fire, and popovers render fully without clipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable card heading component with optional title/subtitle and support for inline actions.
  * Added `truncatedList` formatting to generate localized “+N more” strings for long lists.
* **Improvements**
  * Refreshed configuration UIs (backup schedules, notification channels, roles, and organizations) with table-based layouts, updated header action placement, and improved empty-state/table presentation.
  * Enhanced backup database summary rendering to use consistent truncation; improved tooltip styling and action affordances.
* **Tests**
  * Updated backup label truncation expectations and added coverage for the new formatter behavior.
* **Localization**
  * Added translations for the “shown + N more” label (Greek, Spanish, French).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->