### PR TITLE
feat(restore): apply multithreaded decompression for zstd and 7z

### DIFF
--- a/app/Services/Backup/Compressors/EncryptedCompressor.php
+++ b/app/Services/Backup/Compressors/EncryptedCompressor.php
@@ -63,6 +63,11 @@ class EncryptedCompressor extends BaseCompressor
         // -y: assume Yes on all queries (overwrite files)
         $command = sprintf('7z x -y -o%s', escapeshellarg($outputDir));
 
+        // -mmt=on spreads decompression across all available CPU cores
+        if ($this->isMultithreaded()) {
+            $command .= ' -mmt=on';
+        }
+
         if ($this->password !== null) {
             $command .= sprintf(' -p%s', escapeshellarg($this->password));
         }

--- a/app/Services/Backup/Compressors/ZstdCompressor.php
+++ b/app/Services/Backup/Compressors/ZstdCompressor.php
@@ -29,6 +29,9 @@ class ZstdCompressor extends BaseCompressor
     public function getDecompressCommandLine(string $outputPath): string
     {
         // -d decompress, --rm removes the compressed file after decompression
-        return sprintf('zstd -d --rm %s', escapeshellarg($outputPath));
+        // -T0 spreads decompression across all available CPU cores
+        $threads = $this->isMultithreaded() ? ' -T0' : '';
+
+        return sprintf('zstd -d%s --rm %s', $threads, escapeshellarg($outputPath));
     }
 }

--- a/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
+++ b/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
@@ -21,7 +21,8 @@ test('encrypted command generation', function () {
 test('encrypted multithreading adds -mmt=on flag', function () {
     $compressor = new EncryptedCompressor($this->shellProcessor, 6, 'secret123', multithread: true);
 
-    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("7z a -t7z -mx=6 -mhe=on -mmt=on -p'secret123' '/path/to/dump.sql.7z' '/path/to/dump.sql'");
+    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("7z a -t7z -mx=6 -mhe=on -mmt=on -p'secret123' '/path/to/dump.sql.7z' '/path/to/dump.sql'")
+        ->and($compressor->getDecompressCommandLine('/path/to/dump.sql.7z'))->toBe("7z x -y -o'/path/to' -mmt=on -p'secret123' '/path/to/dump.sql.7z'");
 });
 
 test('encrypted compression level is clamped to valid range', function (int $inputLevel, int $expectedLevel) {

--- a/tests/Feature/Services/Backup/Compressors/ZstdCompressorTest.php
+++ b/tests/Feature/Services/Backup/Compressors/ZstdCompressorTest.php
@@ -20,7 +20,8 @@ test('zstd command generation', function () {
 test('zstd multithreading adds -T0 flag', function () {
     $compressor = new ZstdCompressor($this->shellProcessor, 6, multithread: true);
 
-    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("zstd -6 -T0 --rm '/path/to/dump.sql'");
+    expect($compressor->getCompressCommandLine('/path/to/dump.sql'))->toBe("zstd -6 -T0 --rm '/path/to/dump.sql'")
+        ->and($compressor->getDecompressCommandLine('/path/to/dump.sql.zst'))->toBe("zstd -d -T0 --rm '/path/to/dump.sql.zst'");
 });
 
 test('zstd compression level is clamped to valid range', function (int $inputLevel, int $expectedLevel) {


### PR DESCRIPTION
## Summary

Follow-up to #436, which added the `backup.compression_multithread` setting for **compression** (zstd `-T0`, 7z `-mmt=on`). This PR applies the **same config to decompression**, so restores spread work across CPU cores the same way backups do.

- `ZstdCompressor::getDecompressCommandLine()` — adds `-T0` when multithreaded → `zstd -d -T0 --rm …`
- `EncryptedCompressor::getDecompressCommandLine()` — adds `-mmt=on` when multithreaded → `7z x -y -o… -mmt=on …`

No factory or config plumbing was needed: `RestoreTask` calls `compressorFactory->make($config->snapshotCompressionType)` with `level`/`multithread` left null, so `CompressorFactory` already falls back to `AppConfig::get('backup.compression_multithread')`. The compressor built for restore was already carrying the flag — the decompress command lines just weren't reading it. Now they do. Default remains off, so decompress commands are unchanged unless the setting is enabled.

## Testing

- Extended the existing multithreading unit tests to assert the decompress command lines.
- Validated both flags end-to-end with a local compress→decompress round-trip in the container (`zstd -d -T0`, `7z x -mmt=on`) — content restored correctly.
- Full suite green (1267 passed), PHPStan clean, Pint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved multithreaded backup decompression for supported compression formats.
  * Decompression now uses available CPU resources when multithreading is enabled, matching compression behavior.

* **Tests**
  * Added coverage confirming multithreading options are applied during both compression and decompression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->