### PR TITLE
feat(volume): add Azure Blob Storage volume type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,100 +225,15 @@ make test-filter FILTER=test_can_create_database_server
 make test-filter FILTER=DatabaseServerTest
 ```
 
-### Adding a New Database Type
+### Extending the App (new database type, volume type, or notification channel)
 
-All database types implement `DatabaseInterface` and are resolved via `DatabaseProvider`. The provider centralizes type dispatch, so `BackupTask`, `RestoreTask`, and connection testing require no changes.
+These are rare, cross-cutting tasks with a fixed file-by-file checklist each. The step-by-step playbooks live in **[`docs/development/extending.md`](docs/development/extending.md)** to keep this file focused. **Read the matching section there before starting** — each lists every file to touch (core, UI, infrastructure, tests) plus architecture gotchas:
 
-#### Files to Update
+- **Adding a New Database Type** — `DatabaseInterface` + `DatabaseProvider`, dump/restore handlers, Docker/CI services, fixtures.
+- **Adding a New Volume Type** — `BaseConfig` connector + `FilesystemInterface`, `VolumeForm` property, Flysystem adapter, connection-test dataset. (`azure` / Azure Blob Storage is the newest worked example.)
+- **Adding a New Notification Channel** — `NotificationMessage` + `HasChannelRouting` delegation, `AppConfigService` keys, Configuration UI.
 
-**Core:**
-- `app/Enums/DatabaseType.php` - Add enum case, label, default port, `dumpExtension()`, DSN format in `buildDsn()`
-- `app/Services/Backup/Databases/{Type}Database.php` - Create handler implementing `DatabaseInterface` (`setConfig`, `dump`, `restore`, `prepareForRestore`, `listDatabases`, `testConnection`)
-- `app/Services/Backup/Databases/DatabaseProvider.php` - Add case to `make()` and config handling in `makeForServer()`
-- `app/Services/Backup/BackupJobFactory.php` - Add snapshot creation logic if different from default (e.g., instance-level types like Redis/SQLite)
-- `app/Livewire/Forms/DatabaseServerForm.php` - Validation rules, type helpers, UI behavior
-
-**UI:**
-- `resources/views/livewire/database-server/_form.blade.php` - Conditional fields for the type
-- `resources/views/livewire/database-server/restore-modal.blade.php` - If restore behavior differs
-
-**Infrastructure:**
-- `docker/php/Dockerfile` - Add extensions and CLI tools
-- `docker-compose.yml` - Add test database service
-- `.github/workflows/tests.yml` - Add CI service + system dependencies
-- `config/testing.php` - Add test database config with defaults
-
-**Tests & Fixtures:**
-- `database/factories/DatabaseServerFactory.php` - Add factory state
-- `database/seeders/DatabaseSeeder.php` - Add seeder entry
-- `tests/Feature/Services/Backup/Databases/{Type}DatabaseTest.php` - Handler unit tests
-- `tests/Integration/BackupRestoreTest.php` - Add to test dataset
-- `tests/Support/IntegrationTestHelpers.php` - Add config and helpers
-- `tests/Integration/fixtures/{type}-init.*` - Test fixture
-- `tests/Pest.php` - Update global datasets
-
-#### Architecture Notes
-
-- Types without PDO support (e.g., Redis) must throw in `buildDsn()`/`createPdo()` and handle connection testing via CLI in their `testConnection()` method
-- Types that backup the whole instance (e.g., Redis, SQLite) should short-circuit in `BackupJobFactory.createSnapshots()` to create a single snapshot
-
-### Adding a New Volume Type
-
-The volume system uses dynamic class resolution based on the type value. Use existing implementations (e.g., `SftpConfig`, `SftpFilesystem`) as templates.
-
-#### Files to Update
-
-**Core:**
-- `app/Enums/VolumeType.php` - Add enum case, update `label()`, `icon()`, `sensitiveFields()`, `configSummary()`
-- `app/Livewire/Volume/Connectors/{Type}Config.php` - Create class extending `BaseConfig` with `defaultConfig()`, `rules()`, `viewName()`
-- `resources/views/livewire/volume/connectors/{type}-config.blade.php` - Create form view (use `$readonly`, `$isEditing`)
-- `app/Services/Backup/Filesystems/{Type}Filesystem.php` - Create class implementing `FilesystemInterface`
-- `app/Providers/AppServiceProvider.php` - Register filesystem in `FilesystemProvider`
-
-**Tests:**
-- `database/factories/VolumeFactory.php` - Add factory state for the new type
-- `tests/Feature/Volume/VolumeTest.php` - Add to `volume types` dataset
-
-**Optional:**
-- `composer.json` - Add Flysystem adapter package if needed
-- `docker/php/Dockerfile` - Add PHP extensions if needed
-
-#### Architecture Notes
-
-- **Dynamic Resolution**: `VolumeType::configPropertyName()` returns `{type}Config` and `configClass()` resolves the class dynamically - no explicit mappings needed in `VolumeForm`
-- **Sensitive Fields**: Fields in `sensitiveFields()` are automatically encrypted in the database and masked in the browser
-- **Connection Testing**: Works automatically via `FilesystemProvider` if your filesystem implements `FilesystemInterface`
-- **BaseConfig**: All config components extend `BaseConfig` which handles mounting, validation, and rendering
-
-### Adding a New Notification Channel
-
-The notification system uses a delegation pattern: concrete notifications extend `BaseFailedNotification` or `BaseSuccessNotification` and inherit all channel support via the `HasChannelRouting` trait. A single `NotificationMessage` (driven by a `NotificationType` enum) renders every channel for both success and failure. Adding a new channel requires no changes to concrete notification classes.
-
-#### Files to Update
-
-**Core:**
-- `app/Notifications/NotificationMessage.php` - Add `to{Channel}()` rendering method (success/failure differences key off `$this->type` and `$this->hasError()`)
-- `app/Notifications/Concerns/HasChannelRouting.php` - Add `to{Channel}()` delegation method, add entry to `CHANNEL_MAP`
-- `app/Services/FailureNotificationService.php` - Add route to `getNotificationRoutes()`
-- `app/Services/AppConfigService.php` - Add keys to `AppConfigService::CONFIG` (each key defines its default, type, and sensitivity)
-
-**Custom Channels** (if not using an existing package):
-- `app/Notifications/Channels/{Channel}Channel.php` - Create class with `send()` method
-
-**Configuration UI:**
-- `app/Livewire/Forms/ConfigurationForm.php` - Add properties, load/save/rules logic
-- `app/Livewire/Configuration/Index.php` - Add to `getChannelOptions()`
-- `resources/views/livewire/configuration/index.blade.php` - Add conditional field section
-
-**Boot-time config** (if package reads from `config/services.php`):
-- `app/Providers/AppServiceProvider.php` - Register config from AppConfig at boot
-
-**Tests:**
-- `tests/Feature/Notifications/FailureNotificationTest.php` - Add rendering and routing tests
-- `tests/Feature/ConfigurationTest.php` - Add save/deselect/pre-select tests
-
-**Optional:**
-- `composer.json` - Add notification channel package if needed
+Adding a new **locale** is covered by the Localization section below (kept inline — that guidance applies to any translation work, not just new locales).
 
 ### Authorization (Roles & Abilities)
 

--- a/app/Enums/VolumeType.php
+++ b/app/Enums/VolumeType.php
@@ -8,6 +8,7 @@ enum VolumeType: string
     case S3 = 's3';
     case SFTP = 'sftp';
     case FTP = 'ftp';
+    case AZURE = 'azure';
 
     public function label(): string
     {
@@ -16,6 +17,7 @@ enum VolumeType: string
             self::S3 => 'Amazon S3',
             self::SFTP => 'SFTP / SSH',
             self::FTP => 'FTP',
+            self::AZURE => 'Azure Blob Storage',
         };
     }
 
@@ -29,6 +31,7 @@ enum VolumeType: string
             self::S3 => 'o-cloud',
             self::SFTP => 'o-lock-closed',
             self::FTP => 'o-arrow-up-tray',
+            self::AZURE => 'o-server-stack',
         };
     }
 
@@ -71,6 +74,7 @@ enum VolumeType: string
             self::LOCAL => [],
             self::S3 => ['secret_access_key'],
             self::SFTP, self::FTP => ['password'],
+            self::AZURE => ['account_key'],
         };
     }
 
@@ -179,6 +183,11 @@ enum VolumeType: string
                 'User' => $config['username'] ?? '',
                 'Root' => $config['root'] ?? '/',
                 'SSL' => ! empty($config['ssl']) ? 'Yes' : null,
+            ]),
+            self::AZURE => array_filter([
+                'Account' => $config['account_name'] ?? '',
+                'Container' => $config['container'] ?? '',
+                'Prefix' => $config['prefix'] ?? null,
             ]),
         };
     }

--- a/app/Livewire/Forms/VolumeForm.php
+++ b/app/Livewire/Forms/VolumeForm.php
@@ -31,6 +31,9 @@ class VolumeForm extends Form
     /** @var array<string, mixed> */
     public array $ftpConfig = [];
 
+    /** @var array<string, mixed> */
+    public array $azureConfig = [];
+
     // Connection test state
     public ?string $connectionTestMessage = null;
 

--- a/app/Livewire/Volume/Connectors/AzureConfig.php
+++ b/app/Livewire/Volume/Connectors/AzureConfig.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Livewire\Volume\Connectors;
+
+use App\Rules\SafePath;
+
+class AzureConfig extends BaseConfig
+{
+    /**
+     * @return array{account_name: string, account_key: string, container: string, prefix: string, endpoint_suffix: string, endpoint: string}
+     */
+    public static function defaultConfig(): array
+    {
+        return [
+            'account_name' => '',
+            'account_key' => '',
+            'container' => '',
+            'prefix' => '',
+            'endpoint_suffix' => 'core.windows.net',
+            'endpoint' => '',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function rules(string $prefix): array
+    {
+        return [
+            "{$prefix}.account_name" => ['required_if:type,azure', 'string', 'max:255'],
+            "{$prefix}.account_key" => ['required_if:type,azure', 'string', 'max:1000'],
+            "{$prefix}.container" => ['required_if:type,azure', 'string', 'max:255'],
+            "{$prefix}.prefix" => ['nullable', 'string', 'max:255', new SafePath],
+            "{$prefix}.endpoint_suffix" => ['nullable', 'string', 'max:255'],
+            "{$prefix}.endpoint" => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Services\AppConfigService;
 use App\Services\Backup\Compressors\CompressorFactory;
 use App\Services\Backup\Compressors\CompressorInterface;
 use App\Services\Backup\Filesystems\Awss3Filesystem;
+use App\Services\Backup\Filesystems\AzureFilesystem;
 use App\Services\Backup\Filesystems\FilesystemProvider;
 use App\Services\Backup\Filesystems\FtpFilesystem;
 use App\Services\Backup\Filesystems\LocalFilesystem;
@@ -57,6 +58,7 @@ class AppServiceProvider extends ServiceProvider
             $provider->add(new Awss3Filesystem);
             $provider->add(new SftpFilesystem);
             $provider->add(new FtpFilesystem);
+            $provider->add(new AzureFilesystem);
 
             return $provider;
         });

--- a/app/Services/Backup/Filesystems/AzureFilesystem.php
+++ b/app/Services/Backup/Filesystems/AzureFilesystem.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Services\Backup\Filesystems;
+
+use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter;
+use League\Flysystem\Filesystem;
+use MicrosoftAzure\Storage\Blob\BlobRestProxy;
+
+class AzureFilesystem implements FilesystemInterface
+{
+    public function handles(?string $type): bool
+    {
+        return strtolower($type ?? '') === 'azure';
+    }
+
+    /**
+     * @param  array{account_name: string, account_key: string, container: string, prefix?: string, endpoint_suffix?: string, root?: string}  $config
+     */
+    public function get(array $config): Filesystem
+    {
+        $client = BlobRestProxy::createBlobService($this->buildConnectionString($config));
+
+        // Support both 'root' (from config/backup.php) and 'prefix' (from Volume database)
+        $prefix = $config['root'] ?? $config['prefix'] ?? '';
+
+        return new Filesystem(new AzureBlobStorageAdapter($client, $config['container'], $prefix));
+    }
+
+    /**
+     * @param  array{account_name: string, account_key: string, endpoint_suffix?: string, endpoint?: string}  $config
+     */
+    protected function buildConnectionString(array $config): string
+    {
+        $parts = [
+            'AccountName='.$config['account_name'],
+            'AccountKey='.$config['account_key'],
+        ];
+
+        // A custom blob endpoint (Azurite, sovereign clouds, self-hosted gateways)
+        // overrides the account-derived *.blob.{suffix} URL. Protocol follows its scheme.
+        if (! empty($config['endpoint'])) {
+            $scheme = str_starts_with($config['endpoint'], 'http://') ? 'http' : 'https';
+            array_unshift($parts, 'DefaultEndpointsProtocol='.$scheme);
+            $parts[] = 'BlobEndpoint='.$config['endpoint'];
+        } else {
+            $endpointSuffix = ! empty($config['endpoint_suffix']) ? $config['endpoint_suffix'] : 'core.windows.net';
+            array_unshift($parts, 'DefaultEndpointsProtocol=https');
+            $parts[] = 'EndpointSuffix='.$endpointSuffix;
+        }
+
+        return implode(';', $parts);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "laravel/socialite": "^5.24",
         "laravel/tinker": "^3.0",
         "league/flysystem-aws-s3-v3": "^3.0",
+        "league/flysystem-azure-blob-storage": "^3.0",
         "league/flysystem-ftp": "^3.31",
         "league/flysystem-sftp-v3": "^3.31",
         "livewire/livewire": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c0c2699f17c2b0453ad5cb9888f765a",
+    "content-hash": "56c0444982ebba9f7386234845263401",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3481,6 +3481,47 @@
             "time": "2026-05-04T08:24:00+00:00"
         },
         {
+            "name": "league/flysystem-azure-blob-storage",
+            "version": "3.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-azure-blob-storage.git",
+                "reference": "1d1cf31cab62bd85cfbab91687d35e668423401f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-azure-blob-storage/zipball/1d1cf31cab62bd85cfbab91687d35e668423401f",
+                "reference": "1d1cf31cab62bd85cfbab91687d35e668423401f",
+                "shasum": ""
+            },
+            "require": {
+                "league/flysystem": "^3.10.0",
+                "microsoft/azure-storage-blob": "^1.1",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AzureBlobStorage\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-azure-blob-storage/tree/3.31.0"
+            },
+            "abandoned": "azure-oss/storage-blob-flysystem",
+            "time": "2026-01-23T15:30:45+00:00"
+        },
+        {
             "name": "league/flysystem-ftp",
             "version": "3.31.0",
             "source": {
@@ -4073,6 +4114,103 @@
                 }
             ],
             "time": "2026-03-27T10:08:36+00:00"
+        },
+        {
+            "name": "microsoft/azure-storage-blob",
+            "version": "1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Azure/azure-storage-blob-php.git",
+                "reference": "1023ce1dbf062351a32ca5ec72ad1fd4a504f1bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Azure/azure-storage-blob-php/zipball/1023ce1dbf062351a32ca5ec72ad1fd4a504f1bf",
+                "reference": "1023ce1dbf062351a32ca5ec72ad1fd4a504f1bf",
+                "shasum": ""
+            },
+            "require": {
+                "microsoft/azure-storage-common": "~1.5",
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MicrosoftAzure\\Storage\\Blob\\": "src/Blob"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Azure Storage PHP Client Library",
+                    "email": "dmsh@microsoft.com"
+                }
+            ],
+            "description": "This project provides a set of PHP client libraries that make it easy to access Microsoft Azure Storage Blob APIs.",
+            "keywords": [
+                "azure",
+                "blob",
+                "php",
+                "sdk",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/Azure/azure-storage-blob-php/issues",
+                "source": "https://github.com/Azure/azure-storage-blob-php/tree/v1.5.4"
+            },
+            "abandoned": true,
+            "time": "2022-09-02T02:13:06+00:00"
+        },
+        {
+            "name": "microsoft/azure-storage-common",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Azure/azure-storage-common-php.git",
+                "reference": "8ca7b1bf4c9ca7c663e75a02a0035b05b37196a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Azure/azure-storage-common-php/zipball/8ca7b1bf4c9ca7c663e75a02a0035b05b37196a0",
+                "reference": "8ca7b1bf4c9ca7c663e75a02a0035b05b37196a0",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "~6.0|^7.0",
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MicrosoftAzure\\Storage\\Common\\": "src/Common"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Azure Storage PHP Client Library",
+                    "email": "dmsh@microsoft.com"
+                }
+            ],
+            "description": "This project provides a set of common code shared by Azure Storage Blob, Table, Queue and File PHP client libraries.",
+            "keywords": [
+                "azure",
+                "common",
+                "php",
+                "sdk",
+                "storage"
+            ],
+            "support": {
+                "issues": "https://github.com/Azure/azure-storage-common-php/issues",
+                "source": "https://github.com/Azure/azure-storage-common-php/tree/v1.5.2"
+            },
+            "time": "2021-10-09T03:03:47+00:00"
         },
         {
             "name": "mongodb/mongodb",

--- a/database/factories/VolumeFactory.php
+++ b/database/factories/VolumeFactory.php
@@ -112,4 +112,22 @@ class VolumeFactory extends Factory
             ],
         ]);
     }
+
+    /**
+     * Indicate that the volume is an Azure Blob Storage type.
+     */
+    public function azure(): static
+    {
+        return $this->state(fn () => [
+            'type' => 'azure',
+            'config' => [
+                'account_name' => 'teststorageaccount',
+                'account_key' => 'test-account-key-'.fake()->slug(),
+                'container' => 'backup-'.fake()->slug(),
+                'prefix' => fake()->optional()->slug(),
+                'endpoint_suffix' => 'core.windows.net',
+                'endpoint' => '',
+            ],
+        ]);
+    }
 }

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -1,0 +1,112 @@
+# Extending Databasement
+
+Step-by-step playbooks for the rare, cross-cutting tasks of adding a new **database type**, **volume (storage) type**, or **notification channel**. These live here (rather than in `CLAUDE.md`) because they are only relevant when doing that specific task. When you start one of these tasks, read the matching section in full before editing.
+
+For adding a new **locale**, see the Localization section in `CLAUDE.md` — that guidance (technical terms, HTML-encoding artifacts, typographic apostrophes) is relevant to any translation work, so it stays inline.
+
+---
+
+## Adding a New Database Type
+
+All database types implement `DatabaseInterface` and are resolved via `DatabaseProvider`. The provider centralizes type dispatch, so `BackupTask`, `RestoreTask`, and connection testing require no changes.
+
+### Files to Update
+
+**Core:**
+- `app/Enums/DatabaseType.php` - Add enum case, label, default port, `dumpExtension()`, DSN format in `buildDsn()`
+- `app/Services/Backup/Databases/{Type}Database.php` - Create handler implementing `DatabaseInterface` (`setConfig`, `dump`, `restore`, `prepareForRestore`, `listDatabases`, `testConnection`)
+- `app/Services/Backup/Databases/DatabaseProvider.php` - Add case to `make()` and config handling in `makeForServer()`
+- `app/Services/Backup/BackupJobFactory.php` - Add snapshot creation logic if different from default (e.g., instance-level types like Redis/SQLite)
+- `app/Livewire/Forms/DatabaseServerForm.php` - Validation rules, type helpers, UI behavior
+
+**UI:**
+- `resources/views/livewire/database-server/_form.blade.php` - Conditional fields for the type
+- `resources/views/livewire/database-server/restore-modal.blade.php` - If restore behavior differs
+
+**Infrastructure:**
+- `docker/php/Dockerfile` - Add extensions and CLI tools
+- `docker-compose.yml` - Add test database service
+- `.github/workflows/tests.yml` - Add CI service + system dependencies
+- `config/testing.php` - Add test database config with defaults
+
+**Tests & Fixtures:**
+- `database/factories/DatabaseServerFactory.php` - Add factory state
+- `database/seeders/DatabaseSeeder.php` - Add seeder entry
+- `tests/Feature/Services/Backup/Databases/{Type}DatabaseTest.php` - Handler unit tests
+- `tests/Integration/BackupRestoreTest.php` - Add to test dataset
+- `tests/Support/IntegrationTestHelpers.php` - Add config and helpers
+- `tests/Integration/fixtures/{type}-init.*` - Test fixture
+- `tests/Pest.php` - Update global datasets
+
+### Architecture Notes
+
+- Types without PDO support (e.g., Redis) must throw in `buildDsn()`/`createPdo()` and handle connection testing via CLI in their `testConnection()` method
+- Types that backup the whole instance (e.g., Redis, SQLite) should short-circuit in `BackupJobFactory::createSnapshots()` to create a single snapshot
+
+---
+
+## Adding a New Volume Type
+
+The volume system uses dynamic class resolution based on the type value. Use existing implementations (e.g., `S3Config`/`Awss3Filesystem`, `SftpConfig`/`SftpFilesystem`) as templates. The `azure` type (Azure Blob Storage) is the newest end-to-end example touching every file below.
+
+### Files to Update
+
+**Core:**
+- `app/Enums/VolumeType.php` - Add enum case, update `label()`, `icon()`, `sensitiveFields()`, and the `configSummary()` match. All four `match ($this)` expressions have no `default` arm, so a missing case raises an `UnhandledMatchError` at runtime (and PHPStan flags it) — a useful checklist.
+- `app/Livewire/Volume/Connectors/{Type}Config.php` - Create class extending `BaseConfig`. `BaseConfig` is a thin abstract with only two static methods to implement: `defaultConfig()` (the initial config array) and `rules(string $prefix)` (validation, keyed `{$prefix}.{field}`, using `required_if:type,{value}` for required fields).
+- `app/Livewire/Forms/VolumeForm.php` - Add a `public array ${type}Config = [];` property. **Required** — the constructor seeds every type's config from `defaultConfig()` by looping over `VolumeType::cases()`, but Livewire only binds a property that is explicitly declared. Class resolution is dynamic; the property declaration is not.
+- `resources/views/livewire/volume/connectors/{type}-config.blade.php` - Create the form view. Resolved by convention from `{$form->type}-config` in `_form.blade.php` (there is no `viewName()`). Available vars: `$configPrefix`, `$readonly`, `$isEditing`. Use `<x-password>` with `:placeholder="$isEditing ? __('Leave blank to keep current') : ''"` for sensitive fields.
+- `app/Services/Backup/Filesystems/{Type}Filesystem.php` - Create class implementing `FilesystemInterface` (`handles(?string $type)` + `get(array $config)` returning a Flysystem `Filesystem`). Support both `root` (config/backup.php) and `prefix` (Volume DB) keys for the path prefix.
+- `app/Providers/AppServiceProvider.php` - Register the filesystem via `$provider->add(new {Type}Filesystem)` in the `FilesystemProvider` singleton.
+
+**Download flow** (only if the type needs special handling):
+- `app/Http/Controllers/Web/SnapshotDownloadController.php` - Remote types stream through the `default` arm (Flysystem `readStream`) with no change. Only add a `match` arm for a type that downloads differently (e.g. S3 redirects to a presigned URL). Azure uses the default streaming arm.
+
+**Tests & i18n:**
+- `database/factories/VolumeFactory.php` - Add a factory state method for the new type.
+- `tests/Feature/Volume/VolumeTest.php` - Add an entry to the `volume types` dataset (create/edit coverage).
+- `tests/Feature/Services/VolumeConnectionTesterTest.php` - Add to the `remote volume types` dataset for remote types (the filesystem is mocked, so no live connection).
+- `lang/{fr,es,el}.json` - Add translations for every new `__()` string in the connector view (see the Localization section in `CLAUDE.md`; keep Backup/Restore/Snapshot in English, use typographic apostrophes). Enum `label()` values are intentionally **not** translated.
+
+**Optional:**
+- `composer.json` - Add the Flysystem adapter package if needed (`docker compose exec --user application -T app composer require league/flysystem-{adapter}`).
+- `docker/php/Dockerfile` - Add PHP extensions if the adapter needs them.
+
+### Architecture Notes
+
+- **Dynamic Resolution**: `VolumeType::configPropertyName()` returns `{type}Config` and `configClass()` resolves `{Type}Config` from the enum value via `ucfirst()` — no explicit class mappings needed. The one non-dynamic piece is the matching public property on `VolumeForm` (above).
+- **Sensitive Fields**: Fields in `sensitiveFields()` are automatically encrypted in the database, masked before browser serialization, and made optional on edit (blank = keep existing). Azure's `account_key` is an example.
+- **Connection Testing**: Works automatically via `FilesystemProvider`/`VolumeConnectionTester` (writes, reads back, deletes a temp file) once the filesystem implements `FilesystemInterface`.
+- **BaseConfig**: A minimal abstract declaring only `defaultConfig()` and `rules()`. It does not handle mounting or rendering; those live in `VolumeForm` and `_form.blade.php`.
+
+---
+
+## Adding a New Notification Channel
+
+The notification system uses a delegation pattern: concrete notifications extend `BaseFailedNotification` or `BaseSuccessNotification` and inherit all channel support via the `HasChannelRouting` trait. A single `NotificationMessage` (driven by a `NotificationType` enum) renders every channel for both success and failure. Adding a new channel requires no changes to concrete notification classes.
+
+### Files to Update
+
+**Core:**
+- `app/Notifications/NotificationMessage.php` - Add `to{Channel}()` rendering method (success/failure differences key off `$this->type` and `$this->hasError()`)
+- `app/Notifications/Concerns/HasChannelRouting.php` - Add `to{Channel}()` delegation method, add entry to `CHANNEL_MAP`
+- `app/Services/FailureNotificationService.php` - Add route to `getNotificationRoutes()`
+- `app/Services/AppConfigService.php` - Add keys to `AppConfigService::CONFIG` (each key defines its default, type, and sensitivity)
+
+**Custom Channels** (if not using an existing package):
+- `app/Notifications/Channels/{Channel}Channel.php` - Create class with `send()` method
+
+**Configuration UI:**
+- `app/Livewire/Forms/ConfigurationForm.php` - Add properties, load/save/rules logic
+- `app/Livewire/Configuration/Index.php` - Add to `getChannelOptions()`
+- `resources/views/livewire/configuration/index.blade.php` - Add conditional field section
+
+**Boot-time config** (if package reads from `config/services.php`):
+- `app/Providers/AppServiceProvider.php` - Register config from AppConfig at boot
+
+**Tests:**
+- `tests/Feature/Notifications/FailureNotificationTest.php` - Add rendering and routing tests
+- `tests/Feature/ConfigurationTest.php` - Add save/deselect/pre-select tests
+
+**Optional:**
+- `composer.json` - Add notification channel package if needed

--- a/lang/el.json
+++ b/lang/el.json
@@ -766,5 +766,16 @@
   "Original database name in the snapshot": "Αρχικό όνομα βάσης δεδομένων στο snapshot",
   "Snapshot file restored from the volume": "Αρχείο snapshot που αποκαταστάθηκε από τον τόμο",
   "Source volume name": "Όνομα τόμου προέλευσης",
-  "Copy ID": "Αντιγραφή ID"
+  "Copy ID": "Αντιγραφή ID",
+  "Storage Account Name": "Όνομα λογαριασμού αποθήκευσης",
+  "e.g., mystorageaccount": "π.χ., mystorageaccount",
+  "Account Key": "Κλειδί λογαριασμού",
+  "Container Name": "Όνομα container",
+  "e.g., backups": "π.χ., backups",
+  "The prefix is prepended to all backup file paths in the container.": "Το πρόθεμα προτάσσεται σε όλες τις διαδρομές αρχείων Backup στο container.",
+  "Endpoint Suffix": "Κατάληξη endpoint",
+  "Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).": "Αλλάξτε το μόνο για κυρίαρχα cloud (π.χ., core.usgovcloudapi.net, core.chinacloudapi.cn).",
+  "Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.": "Τα Backups θα αποθηκεύονται ως blobs στο καθορισμένο container. Το κλειδί λογαριασμού βρίσκεται στα «Κλειδιά πρόσβασης» του λογαριασμού Azure Storage σας.",
+  "Custom Blob Endpoint": "Προσαρμοσμένο Blob endpoint",
+  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Για αποθήκευση συμβατή με Azure (εξομοιωτής Azurite, self-hosted gateways). Υπερισχύει της κατάληξης endpoint."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -769,5 +769,16 @@
   "Original database name in the snapshot": "Nombre de la base de datos original en el snapshot",
   "Snapshot file restored from the volume": "Archivo snapshot restaurado desde el volumen",
   "Source volume name": "Nombre del volumen de origen",
-  "Copy ID": "Copiar ID"
+  "Copy ID": "Copiar ID",
+  "Storage Account Name": "Nombre de la cuenta de almacenamiento",
+  "e.g., mystorageaccount": "ej.: micuentaalmacenamiento",
+  "Account Key": "Clave de cuenta",
+  "Container Name": "Nombre del contenedor",
+  "e.g., backups": "ej.: backups",
+  "The prefix is prepended to all backup file paths in the container.": "El prefijo se antepone a todas las rutas de archivos de Backup en el contenedor.",
+  "Endpoint Suffix": "Sufijo del endpoint",
+  "Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).": "Cámbialo solo para nubes soberanas (ej.: core.usgovcloudapi.net, core.chinacloudapi.cn).",
+  "Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.": "Los Backups se almacenarán como blobs en el contenedor especificado. La clave de cuenta se encuentra en «Claves de acceso» de tu cuenta de Azure Storage.",
+  "Custom Blob Endpoint": "Endpoint de Blob personalizado",
+  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Para almacenamiento compatible con Azure (emulador Azurite, pasarelas autoalojadas). Sustituye al sufijo del endpoint."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -771,5 +771,16 @@
   "Original database name in the snapshot": "Nom de la base de données d’origine dans le snapshot",
   "Snapshot file restored from the volume": "Fichier snapshot restauré depuis le volume",
   "Source volume name": "Nom du volume source",
-  "Copy ID": "Copier l’ID"
+  "Copy ID": "Copier l’ID",
+  "Storage Account Name": "Nom du compte de stockage",
+  "e.g., mystorageaccount": "ex. : moncomptestockage",
+  "Account Key": "Clé de compte",
+  "Container Name": "Nom du conteneur",
+  "e.g., backups": "ex. : backups",
+  "The prefix is prepended to all backup file paths in the container.": "Le préfixe est ajouté à tous les chemins de fichiers de Backup dans le conteneur.",
+  "Endpoint Suffix": "Suffixe du point de terminaison",
+  "Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).": "À modifier uniquement pour les clouds souverains (ex. : core.usgovcloudapi.net, core.chinacloudapi.cn).",
+  "Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.": "Les Backups seront stockés sous forme de blobs dans le conteneur spécifié. La clé de compte se trouve dans « Clés d’accès » de votre compte de stockage Azure.",
+  "Custom Blob Endpoint": "Point de terminaison Blob personnalisé",
+  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Pour le stockage compatible Azure (émulateur Azurite, passerelles auto-hébergées). Remplace le suffixe du point de terminaison."
 }

--- a/resources/views/livewire/volume/_form.blade.php
+++ b/resources/views/livewire/volume/_form.blade.php
@@ -21,7 +21,7 @@ use App\Enums\VolumeType;
         @php $typeDisabled = $readonly || $form->volume !== null; @endphp
         <div>
             <label class="label label-text font-semibold mb-2">{{ __('Storage Type') }}</label>
-            <x-radio-card-group class="grid-cols-2 sm:grid-cols-4" :label="__('Storage Type')">
+            <x-radio-card-group class="grid-cols-2 sm:grid-cols-3 lg:grid-cols-5" :label="__('Storage Type')">
                 @foreach(VolumeType::cases() as $volumeType)
                     <x-radio-card
                         :active="$form->type === $volumeType->value"

--- a/resources/views/livewire/volume/connectors/azure-config.blade.php
+++ b/resources/views/livewire/volume/connectors/azure-config.blade.php
@@ -1,0 +1,62 @@
+<div class="space-y-4">
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <x-input
+            wire:model="{{ $configPrefix }}.account_name"
+            :label="__('Storage Account Name')"
+            :placeholder="__('e.g., mystorageaccount')"
+            type="text"
+            :disabled="$readonly"
+            required
+        />
+
+        <x-password
+            wire:model="{{ $configPrefix }}.account_key"
+            :label="__('Account Key')"
+            :placeholder="$isEditing ? __('Leave blank to keep current') : ''"
+            :disabled="$readonly"
+            :required="!$isEditing"
+        />
+    </div>
+
+    <x-input
+        wire:model="{{ $configPrefix }}.container"
+        :label="__('Container Name')"
+        :placeholder="__('e.g., backups')"
+        type="text"
+        :disabled="$readonly"
+        required
+    />
+
+    <x-input
+        wire:model="{{ $configPrefix }}.prefix"
+        :label="__('Prefix (Optional)')"
+        :placeholder="__('e.g., backups/production/')"
+        :hint="__('The prefix is prepended to all backup file paths in the container.')"
+        type="text"
+        :disabled="$readonly"
+    />
+
+    <x-input
+        wire:model="{{ $configPrefix }}.endpoint_suffix"
+        :label="__('Endpoint Suffix')"
+        placeholder="core.windows.net"
+        :hint="__('Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).')"
+        type="text"
+        :disabled="$readonly"
+    />
+
+    <x-input
+        wire:model="{{ $configPrefix }}.endpoint"
+        :label="__('Custom Blob Endpoint')"
+        placeholder="https://gateway.example.com/account"
+        :hint="__('For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.')"
+        type="text"
+        :disabled="$readonly"
+    />
+
+    @unless($readonly)
+        <p class="text-sm opacity-70">
+            {{ __('Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.') }}
+        </p>
+    @endunless
+</div>

--- a/tests/Feature/Services/Backup/Filesystems/AzureFilesystemTest.php
+++ b/tests/Feature/Services/Backup/Filesystems/AzureFilesystemTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Services\Backup\Filesystems\AzureFilesystem;
+use League\Flysystem\Filesystem;
+
+function azureFilesystemWithExposedConnectionString(): AzureFilesystem
+{
+    return new class extends AzureFilesystem
+    {
+        /** @param  array<string, mixed>  $config */
+        public function exposeConnectionString(array $config): string
+        {
+            return $this->buildConnectionString($config);
+        }
+    };
+}
+
+test('handles only the azure type', function () {
+    $filesystem = new AzureFilesystem;
+
+    expect($filesystem->handles('azure'))->toBeTrue()
+        ->and($filesystem->handles('AZURE'))->toBeTrue()
+        ->and($filesystem->handles('s3'))->toBeFalse()
+        ->and($filesystem->handles(null))->toBeFalse();
+});
+
+test('builds a public connection string from the account and endpoint suffix', function () {
+    $connectionString = azureFilesystemWithExposedConnectionString()->exposeConnectionString([
+        'account_name' => 'myaccount',
+        'account_key' => 'secret-key',
+        'endpoint_suffix' => 'core.usgovcloudapi.net',
+    ]);
+
+    expect($connectionString)->toBe(
+        'DefaultEndpointsProtocol=https;AccountName=myaccount;AccountKey=secret-key;EndpointSuffix=core.usgovcloudapi.net'
+    );
+});
+
+test('defaults the endpoint suffix when none is provided', function () {
+    $connectionString = azureFilesystemWithExposedConnectionString()->exposeConnectionString([
+        'account_name' => 'myaccount',
+        'account_key' => 'secret-key',
+    ]);
+
+    expect($connectionString)->toContain('EndpointSuffix=core.windows.net');
+});
+
+test('a custom endpoint overrides the suffix and derives the protocol from its scheme', function () {
+    $connectionString = azureFilesystemWithExposedConnectionString()->exposeConnectionString([
+        'account_name' => 'devstoreaccount1',
+        'account_key' => 'secret-key',
+        'endpoint_suffix' => 'core.windows.net',
+        'endpoint' => 'http://azurite:10000/devstoreaccount1',
+    ]);
+
+    expect($connectionString)->toBe(
+        'DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=secret-key;BlobEndpoint=http://azurite:10000/devstoreaccount1'
+    )->and($connectionString)->not->toContain('EndpointSuffix');
+});
+
+test('an https custom endpoint keeps the https protocol', function () {
+    $connectionString = azureFilesystemWithExposedConnectionString()->exposeConnectionString([
+        'account_name' => 'myaccount',
+        'account_key' => 'secret-key',
+        'endpoint' => 'https://gateway.example.com/myaccount',
+    ]);
+
+    expect($connectionString)->toStartWith('DefaultEndpointsProtocol=https;')
+        ->and($connectionString)->toContain('BlobEndpoint=https://gateway.example.com/myaccount');
+});
+
+test('get builds a Flysystem filesystem for a public-cloud config', function () {
+    $filesystem = (new AzureFilesystem)->get([
+        'account_name' => 'myaccount',
+        'account_key' => base64_encode('secret'),
+        'container' => 'backups',
+        'prefix' => 'production/',
+        'endpoint_suffix' => 'core.windows.net',
+    ]);
+
+    expect($filesystem)->toBeInstanceOf(Filesystem::class);
+});
+
+test('get builds a Flysystem filesystem when a custom endpoint is set', function () {
+    $filesystem = (new AzureFilesystem)->get([
+        'account_name' => 'devstoreaccount1',
+        'account_key' => base64_encode('secret'),
+        'container' => 'backups',
+        'endpoint' => 'http://azurite:10000/devstoreaccount1',
+    ]);
+
+    expect($filesystem)->toBeInstanceOf(Filesystem::class);
+});
+
+test('get accepts the root key as an alias for prefix', function () {
+    $filesystem = (new AzureFilesystem)->get([
+        'account_name' => 'myaccount',
+        'account_key' => base64_encode('secret'),
+        'container' => 'backups',
+        'root' => 'from-backup-config/',
+    ]);
+
+    expect($filesystem)->toBeInstanceOf(Filesystem::class);
+});

--- a/tests/Feature/Services/VolumeConnectionTesterTest.php
+++ b/tests/Feature/Services/VolumeConnectionTesterTest.php
@@ -101,6 +101,18 @@ dataset('remote volume types', function () {
             'identifierField' => 'host',
             'identifierValue' => 'ftp.example.com',
         ],
+        'azure' => [
+            'type' => VolumeType::AZURE,
+            'config' => [
+                'account_name' => 'teststorageaccount',
+                'account_key' => 'test-account-key',
+                'container' => 'test-container',
+                'prefix' => '',
+                'endpoint_suffix' => 'core.windows.net',
+            ],
+            'identifierField' => 'container',
+            'identifierValue' => 'test-container',
+        ],
     ];
 });
 

--- a/tests/Feature/Volume/VolumeTest.php
+++ b/tests/Feature/Volume/VolumeTest.php
@@ -91,6 +91,27 @@ dataset('volume types', function () {
             'expectedField' => 'host',
             'expectedValue' => 'new-ftp.example.com',
         ],
+        'azure' => [
+            'type' => VolumeType::AZURE,
+            'formData' => [
+                'account_name' => 'mystorageaccount',
+                'account_key' => 'fake-account-key',
+                'container' => 'backups',
+                'prefix' => 'production/',
+                'endpoint_suffix' => 'core.windows.net',
+                'endpoint' => 'https://gateway.example.com/mystorageaccount',
+            ],
+            'expectedConfig' => [
+                'account_name' => 'mystorageaccount',
+                'container' => 'backups',
+                'prefix' => 'production/',
+                'endpoint_suffix' => 'core.windows.net',
+                'endpoint' => 'https://gateway.example.com/mystorageaccount',
+            ],
+            'updateData' => ['container' => 'new-container', 'prefix' => 'staging/'],
+            'expectedField' => 'container',
+            'expectedValue' => 'new-container',
+        ],
     ];
 });
 


### PR DESCRIPTION
Closes #435

Adds **Azure Blob Storage** as a backup destination, alongside Local / S3 / SFTP / FTP. Built on [`league/flysystem-azure-blob-storage`](https://flysystem.thephpleague.com/docs/adapter/azure-blob-storage/), following the existing volume-type architecture — no changes to `BackupTask`/`RestoreTask`.

## What
- `AzureConfig` connector + `AzureFilesystem` (builds a `BlobRestProxy` from a connection string), form partial, registered in `FilesystemProvider`.
- `account_key` is a sensitive field (encrypted, masked, kept-on-blank on edit).
- Optional **custom blob endpoint** (mirrors S3's `custom_endpoint`) — switches to `BlobEndpoint` and derives protocol from the scheme, enabling sovereign clouds, self-hosted gateways, and the Azurite emulator.
- Downloads reuse the default Flysystem streaming path — no controller change.

## Testing
- `AzureFilesystemTest` covers `handles()`, the connection-string builder (public/suffix/custom-endpoint paths), and `get()`.
- Azure added to the volume + connection-tester datasets; `fr`/`es`/`el` translations added (Backup/Snapshot kept in English).
- Validated **end-to-end against Azurite** locally (connection test + backup/restore transfer round-trip). Full suite: **1284 passing**, Pint + PHPStan clean.

## Docs
Extracted the rare "Adding a New X" playbooks (database type, volume type, notification channel) out of `CLAUDE.md` into `docs/development/extending.md` with a pointer, so they no longer weigh on every session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Azure Blob Storage as a supported volume type, including new configuration options (account/key, container, prefix, endpoint suffix, and custom blob endpoint override).
  - Registered Azure-backed filesystem support for backups and added end-to-end volume creation/editing coverage.

- **Documentation**
  - Added step-by-step development playbooks for extending database types, volume types, and notification channels, and simplified the existing extending guidance.

- **Tests**
  - Expanded volume connection and filesystem test suites to include Azure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->