### PR TITLE
fix(ui): repair invisible tab content by upgrading Mary UI to 2.9

### DIFF
--- a/app/Livewire/Concerns/HasAgentToken.php
+++ b/app/Livewire/Concerns/HasAgentToken.php
@@ -8,6 +8,8 @@ trait HasAgentToken
 {
     public bool $showTokenModal = false;
 
+    public string $tokenModalTab = 'docker-tab';
+
     #[Locked]
     public ?string $newToken = null;
 

--- a/app/Livewire/VersionStatus.php
+++ b/app/Livewire/VersionStatus.php
@@ -17,6 +17,8 @@ class VersionStatus extends Component
 
     public bool $showModal = false;
 
+    public string $updateInstructionsTab = 'docker-compose-tab';
+
     public string $dockerComposeCommand = "docker compose pull\ndocker compose up -d";
 
     public string $helmCommand = "helm repo update\nhelm upgrade databasement databasement/databasement";

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,6 +25,7 @@ use Dedoc\Scramble\Support\Generator\Schema;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
 use Dedoc\Scramble\Support\Generator\Types\StringType;
 use Illuminate\Routing\Route;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
@@ -103,6 +104,14 @@ class AppServiceProvider extends ServiceProvider
         $this->registerOidcSocialiteProvider();
         $this->validateOAuthConfiguration();
         $this->registerBouncer();
+
+        // Mary UI 2.9's <x-tab> references <x-mary-badge> internally, but its
+        // service provider only registers the `mary-` internal alias for a fixed
+        // subset of components (button/icon/modal/…) and omits badge. Because
+        // Blade resolves component tags at compile time, that unregistered alias
+        // breaks compilation of every <x-tab> when no component prefix is set (as
+        // here). Register the missing alias ourselves. Remove once Mary ships it.
+        Blade::component('mary-badge', \Mary\View\Components\Badge::class);
 
         Gate::policy(ScheduledRestore::class, RestorePolicy::class);
         Gate::policy(\Silber\Bouncer\Database\Role::class, RolePolicy::class);

--- a/composer.lock
+++ b/composer.lock
@@ -1884,16 +1884,16 @@
         },
         {
             "name": "jfcherng/php-diff",
-            "version": "6.16.2",
+            "version": "6.16.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jfcherng/php-diff.git",
-                "reference": "7f46bcfc582e81769237d0b3f6b8a548efe8799d"
+                "reference": "6d7332b6080cdd50011a364b58f24c8d0cdeb5da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jfcherng/php-diff/zipball/7f46bcfc582e81769237d0b3f6b8a548efe8799d",
-                "reference": "7f46bcfc582e81769237d0b3f6b8a548efe8799d",
+                "url": "https://api.github.com/repos/jfcherng/php-diff/zipball/6d7332b6080cdd50011a364b58f24c8d0cdeb5da",
+                "reference": "6d7332b6080cdd50011a364b58f24c8d0cdeb5da",
                 "shasum": ""
             },
             "require": {
@@ -1938,7 +1938,7 @@
             ],
             "support": {
                 "issues": "https://github.com/jfcherng/php-diff/issues",
-                "source": "https://github.com/jfcherng/php-diff/tree/6.16.2"
+                "source": "https://github.com/jfcherng/php-diff/tree/6.16.3"
             },
             "funding": [
                 {
@@ -1946,7 +1946,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-10T17:40:29+00:00"
+            "time": "2026-06-22T13:08:56+00:00"
         },
         {
             "name": "jfcherng/php-mb-string",
@@ -6192,16 +6192,16 @@
         },
         {
             "name": "robsontenorio/mary",
-            "version": "2.8.3",
+            "version": "2.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/robsontenorio/mary.git",
-                "reference": "e32a3ba1be5f1d86e4b7181004d7b606c025fbfc"
+                "reference": "a2e25107ca4a165394c7903b42cd955d3ef4925f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/e32a3ba1be5f1d86e4b7181004d7b606c025fbfc",
-                "reference": "e32a3ba1be5f1d86e4b7181004d7b606c025fbfc",
+                "url": "https://api.github.com/repos/robsontenorio/mary/zipball/a2e25107ca4a165394c7903b42cd955d3ef4925f",
+                "reference": "a2e25107ca4a165394c7903b42cd955d3ef4925f",
                 "shasum": ""
             },
             "require": {
@@ -6266,7 +6266,7 @@
             ],
             "support": {
                 "issues": "https://github.com/robsontenorio/mary/issues",
-                "source": "https://github.com/robsontenorio/mary/tree/2.8.3"
+                "source": "https://github.com/robsontenorio/mary/tree/2.9.3"
             },
             "funding": [
                 {
@@ -6274,7 +6274,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T18:42:50+00:00"
+            "time": "2026-07-10T15:57:52+00:00"
         },
         {
             "name": "silber/bouncer",

--- a/resources/views/livewire/agent/_token-modal.blade.php
+++ b/resources/views/livewire/agent/_token-modal.blade.php
@@ -9,7 +9,7 @@
         </div>
     </x-alert>
 
-    <x-tabs selected="docker-tab" label-class="tabs-sm">
+    <x-tabs wire:model="tokenModalTab" label-class="tabs-sm">
 
 
 

--- a/resources/views/livewire/version-status.blade.php
+++ b/resources/views/livewire/version-status.blade.php
@@ -89,7 +89,7 @@
             </x-alert>
         @endif
 
-        <x-tabs selected="docker-compose-tab" label-class="tabs-sm">
+        <x-tabs wire:model="updateInstructionsTab" label-class="tabs-sm">
 
             {{-- Docker Compose tab --}}
             <x-tab name="docker-compose-tab" :label="__('Docker Compose')" icon="devicon.docker">


### PR DESCRIPTION
## Problem

Tab content rendered **invisibly in production** while working fine in local dev — e.g. the "How to update?" modal commands and the agent token instructions showed empty panels below the tab bar. The elements were present in the DOM but collapsed to 0×0.

## Root cause

daisyUI **5.6** changed its CSS-nesting output so a standalone `.tab-content` now resolves to `display: none`. Mary UI **2.8**'s Alpine `x-show`-based tabs can't override that (x-show's "show" just clears its inline style, falling back to the class default).

**Why only production broke:** local `node_modules` was never reinstalled after Dependabot bumped daisyUI 5.5.20 → 5.6.10 (#426), so dev kept the old, working 5.5.x. The Docker build's `npm ci` installs the locked **5.6.10** → broken CSS. Same commit, different compiled CSS.

## Fix

Upgrade **Mary UI 2.8.3 → 2.9.3**, which fixes this natively (its `<x-tab>` now carries a `block` utility class that outranks daisyUI's component-layer `display:none`) — a version-independent fix.

2.9.0 is a **breaking rewrite** of `<x-tabs>`, so this migrates the app:

- **`selected` prop removed** → the active tab is now driven by `wire:model`. Both usages (`version-status`, agent token modal) bind to a backing Livewire property initialised to the default tab.
- **`mary-badge` registration bug** — 2.9's `<x-tab>` references `<x-mary-badge>` internally, but Mary's provider omits `badge` from its internal `mary-` alias list. Since Blade resolves component tags at compile time, that unregistered alias crashes **every** `<x-tab>` (even ones passing no badge). Registered the missing alias in `AppServiceProvider` with a note to remove once Mary ships it.

## Verification

- ✅ 1284/1284 tests pass · Pint clean · PHPStan clean
- ✅ Browser-verified: default tab shows on open, switching swaps panels correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved tab selection in token and update-instructions modals, allowing the active tab to update dynamically.
  - Ensured Docker and Docker Compose tabs open with the appropriate default selection.
  - Improved compatibility and rendering for tab components in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->