### PR TITLE
fix(mysql): drop --complete-insert to avoid dump bloat

### DIFF
--- a/app/Services/Backup/Databases/MysqlDatabase.php
+++ b/app/Services/Backup/Databases/MysqlDatabase.php
@@ -22,7 +22,6 @@ class MysqlDatabase implements DatabaseInterface
         '--single-transaction', // Consistent snapshot for InnoDB without locking
         '--routines',           // Include stored procedures and functions
         '--add-drop-table',     // Add DROP TABLE before each CREATE TABLE
-        '--complete-insert',    // Use complete INSERT statements with column names
         '--hex-blob',           // Encode binary data as hex for safer transport
         '--quote-names',        // Quote identifiers with backticks
     ];

--- a/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
@@ -19,7 +19,7 @@ test('dump builds correct command with skip_ssl by default', function () {
     $result = $this->db->dump('/tmp/dump.sql');
 
     expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
-        ->and($result->command)->toBe("mariadb-dump --single-transaction --routines --add-drop-table --complete-insert --hex-blob --quote-names --skip_ssl --host='db.local' --port='3306' --user='root' --password='secret' 'myapp' > '/tmp/dump.sql'");
+        ->and($result->command)->toBe("mariadb-dump --single-transaction --routines --add-drop-table --hex-blob --quote-names --skip_ssl --host='db.local' --port='3306' --user='root' --password='secret' 'myapp' > '/tmp/dump.sql'");
 });
 
 test('dump uses ssl-verify-server-cert=0 when ssl_enabled is true', function () {


### PR DESCRIPTION
## Summary

Removes `--complete-insert` from the MySQL/MariaDB dump options. This flag writes the full column list on **every** INSERT row, inflating dumps considerably on tables with many rows.

## Why it's safe to remove

`--complete-insert` only earns its keep when INSERTs land in a table whose column order was defined *elsewhere* and might differ from the source. That can't happen in this tool:

- Dumps carry `--add-drop-table`, so each table is dropped and recreated (`CREATE TABLE`) from the snapshot immediately before its rows are inserted.
- Restores additionally `DROP DATABASE` / `CREATE DATABASE` before piping the dump in (`MysqlDatabase::restore()`).

Either mechanism guarantees the target schema is rebuilt from the snapshot right before the positional INSERTs run — column order can never drift. The named columns are therefore pure redundant bloat here, even for cross-server (prod → staging) restores, where the target schema is dropped and rebuilt too.

This also aligns with the `mysqldump`/`mariadb-dump` default, which omits the flag.

## Changes

- Remove `--complete-insert` from `DUMP_OPTIONS` in `MysqlDatabase.php`
- Update the expected command string in `MysqlDatabaseTest`

Closes #448

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved MySQL/MariaDB database backups by encoding binary data safely and quoting database identifiers.
  - Removed the complete-insert format from generated dump commands, helping maintain compatibility during backup and restore operations.
  - Updated automated coverage to verify the revised dump command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->