### PR TITLE
feat(auth): add user:reset-password artisan command

### DIFF
--- a/app/Console/Commands/ResetUserPassword.php
+++ b/app/Console/Commands/ResetUserPassword.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+
+use function Laravel\Prompts\password;
+use function Laravel\Prompts\text;
+
+class ResetUserPassword extends Command
+{
+    protected $signature = 'user:reset-password {email? : The email address of the user}';
+
+    protected $description = 'Reset a user password from the command line';
+
+    public function handle(): int
+    {
+        $email = $this->argument('email') ?? text(
+            label: 'What is the email address of the user?',
+            required: true,
+        );
+
+        $user = User::where('email', $email)->first();
+
+        if ($user === null) {
+            $this->error("No user found with email [{$email}].");
+
+            return self::FAILURE;
+        }
+
+        $newPassword = password(
+            label: 'Enter the new password',
+            required: true,
+            validate: fn (string $value): ?string => Validator::make(
+                ['password' => $value],
+                ['password' => ['string', Password::default()]],
+            )->errors()->first('password') ?: null,
+        );
+
+        $user->update(['password' => $newPassword]);
+
+        $this->info("Password reset for {$user->email}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/docs/docs/self-hosting/configuration/application.md
+++ b/docs/docs/self-hosting/configuration/application.md
@@ -191,6 +191,16 @@ php artisan migrate:status # Check database migrations
 php artisan config:show database # View database configuration
 ```
 
+### Reset a User Password
+
+If you lose access to an account and email delivery is not configured (so the **Forgot password?** link cannot send a reset email), reset the password directly from the container. Run this from the directory that holds your `docker-compose.yml`:
+
+```bash
+docker compose exec app php artisan user:reset-password you@example.com
+```
+
+The command prompts for the new password (hidden input) and validates it against the app's password rules. Omit the email to be prompted for it as well.
+
 ### Get Help
 
 - Check the logs: `docker compose logs app`

--- a/tests/Feature/Console/ResetUserPasswordTest.php
+++ b/tests/Feature/Console/ResetUserPasswordTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+test('resets the password for the given user', function () {
+    $user = User::factory()->create(['email' => 'jane@example.com']);
+
+    $this->artisan('user:reset-password', ['email' => 'jane@example.com'])
+        ->expectsQuestion('Enter the new password', 'new-secure-password')
+        ->expectsOutput('Password reset for jane@example.com.')
+        ->assertExitCode(0);
+
+    expect(Hash::check('new-secure-password', $user->refresh()->password))->toBeTrue();
+});
+
+test('fails when no user matches the email', function () {
+    $this->artisan('user:reset-password', ['email' => 'missing@example.com'])
+        ->expectsOutput('No user found with email [missing@example.com].')
+        ->assertExitCode(1);
+});


### PR DESCRIPTION
## What

Adds a `user:reset-password` artisan command so self-hosters can recover an account from the CLI.

```bash
docker compose exec app php artisan user:reset-password you@example.com
```

Prompts for the new password with hidden input, validates it against the app's password rules (`Password::default()`), and relies on the `password => hashed` cast. Fails cleanly if no user matches the email.

## Why

Closes #430. Fortify's **Forgot password?** flow needs SMTP; without mail configured (common for self-hosters) the reset link is a dead end. There was no offline recovery path short of hand-editing the DB / tinker.

## Docs

Documents it under **Self-hosting > Configuration > Application > Reset a User Password**, framed as the fallback when email delivery isn't set up.

## Tests

`tests/Feature/Console/ResetUserPasswordTest.php` — happy path (hash verifies) + unknown-email failure. Full suite, Pint, and PHPStan pass via pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to reset a user’s password by email, with interactive prompts and password validation.
  * Displays clear success or error messages when resetting passwords.

* **Documentation**
  * Added self-hosting instructions for resetting passwords when email-based recovery is unavailable.

* **Tests**
  * Added coverage for successful password resets and missing-user errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->