### PR TITLE
feat(volume): add storage limit with fail-before-upload enforcement

### DIFF
--- a/app/Exceptions/Backup/StorageQuotaExceededException.php
+++ b/app/Exceptions/Backup/StorageQuotaExceededException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Exceptions\Backup;
+
+/**
+ * Thrown when uploading a freshly-created backup would push a volume past its
+ * configured storage limit. The backup is aborted before the file is uploaded
+ * and the job is failed without retry — pruning old snapshots is left to the
+ * user.
+ */
+class StorageQuotaExceededException extends BackupException {}

--- a/app/Jobs/ProcessBackupJob.php
+++ b/app/Jobs/ProcessBackupJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Exceptions\Backup\StorageQuotaExceededException;
 use App\Facades\AppConfig;
 use App\Models\Snapshot;
 use App\Services\Backup\BackupTask;
@@ -72,6 +73,7 @@ class ProcessBackupJob implements ShouldQueue
                 workingDirectory: FilesystemSupport::createWorkingDirectory('backup', $snapshot->id),
                 backupPath: $backupPath,
                 postBackupScript: AppConfig::get('backup.post_backup_script'),
+                volumeUsedBytes: $snapshot->volume->usedStorageBytes(),
             );
 
             $result = $backupTask->execute($config, $job);
@@ -99,6 +101,16 @@ class ProcessBackupJob implements ShouldQueue
                 'database_server_id' => $databaseServer->id,
                 'method' => $snapshot->method,
             ]);
+        } catch (StorageQuotaExceededException $e) {
+            // The volume is over its storage limit. Retrying cannot help — the
+            // limit won't move on its own — so fail immediately (no retry). The
+            // custom message reaches the user via the failure notification.
+            $job->log("Backup failed: {$e->getMessage()}", 'error', [
+                'exception' => get_class($e),
+            ]);
+            $job->markFailed($e);
+
+            $this->fail($e);
         } catch (\Throwable $e) {
             $job->log("Backup failed: {$e->getMessage()}", 'error', [
                 'exception' => get_class($e),

--- a/app/Livewire/Forms/VolumeForm.php
+++ b/app/Livewire/Forms/VolumeForm.php
@@ -6,6 +6,7 @@ use App\Enums\VolumeType;
 use App\Models\Volume;
 use App\Services\CurrentOrganization;
 use App\Services\VolumeConnectionTester;
+use App\Support\Formatters;
 use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 use Livewire\Form;
@@ -71,10 +72,7 @@ class VolumeForm extends Form
         $propertyName = $volumeType->configPropertyName();
         $this->{$propertyName} = array_merge($this->{$propertyName}, $decryptedConfig);
 
-        $maxStorageBytes = $volume->maxStorageBytes();
-        $this->maxStorageGb = $maxStorageBytes !== null
-            ? rtrim(rtrim(number_format($maxStorageBytes / (1024 ** 3), 4, '.', ''), '0'), '.')
-            : null;
+        $this->maxStorageGb = Formatters::bytesToGb($volume->maxStorageBytes());
     }
 
     /**
@@ -133,16 +131,18 @@ class VolumeForm extends Form
         ]);
     }
 
-    public function updateNameOnly(): void
+    /**
+     * Update a volume that is locked by existing snapshots: only the name and
+     * storage limit stay editable — the connector config is frozen because
+     * stored snapshots already depend on it.
+     */
+    public function updateLockedVolume(): void
     {
         $this->validate([
             'name' => ['required', 'string', 'max:255', 'unique:volumes,name,'.$this->volume->id],
             'maxStorageGb' => ['nullable', 'numeric', 'min:0.001'],
         ]);
 
-        // The storage quota stays editable even when the volume is otherwise
-        // locked (has snapshots) — it only affects future pruning, not the
-        // stored connector config.
         $this->volume->update([
             'name' => $this->name,
             'config' => $this->applyMaxStorageToConfig($this->volume->config),
@@ -184,13 +184,13 @@ class VolumeForm extends Form
      */
     protected function applyMaxStorageToConfig(array $config): array
     {
-        if ($this->maxStorageGb === null || $this->maxStorageGb === '') {
+        $bytes = Formatters::gbToBytes($this->maxStorageGb);
+
+        if ($bytes === null) {
             unset($config['max_storage_bytes']);
-
-            return $config;
+        } else {
+            $config['max_storage_bytes'] = $bytes;
         }
-
-        $config['max_storage_bytes'] = (int) round((float) $this->maxStorageGb * (1024 ** 3));
 
         return $config;
     }

--- a/app/Livewire/Forms/VolumeForm.php
+++ b/app/Livewire/Forms/VolumeForm.php
@@ -18,6 +18,10 @@ class VolumeForm extends Form
 
     public string $type = 'local';
 
+    // Optional storage quota for the volume, entered in GB. Empty = no limit.
+    // Stored under the `max_storage_bytes` key of the volume's config JSON.
+    public ?string $maxStorageGb = null;
+
     // Config arrays for each volume type (initialized from connector defaults in constructor)
     /** @var array<string, mixed> */
     public array $localConfig = [];
@@ -66,6 +70,11 @@ class VolumeForm extends Form
         $decryptedConfig = $volumeType->maskSensitiveFields($volume->getDecryptedConfig());
         $propertyName = $volumeType->configPropertyName();
         $this->{$propertyName} = array_merge($this->{$propertyName}, $decryptedConfig);
+
+        $maxStorageBytes = $volume->maxStorageBytes();
+        $this->maxStorageGb = $maxStorageBytes !== null
+            ? rtrim(rtrim(number_format($maxStorageBytes / (1024 ** 3), 4, '.', ''), '0'), '.')
+            : null;
     }
 
     /**
@@ -76,6 +85,7 @@ class VolumeForm extends Form
         $rules = [
             'name' => ['required', 'string', 'max:255'],
             'type' => ['required', 'string', 'in:'.implode(',', array_column(VolumeType::cases(), 'value'))],
+            'maxStorageGb' => ['nullable', 'numeric', 'min:0.001'],
         ];
 
         // Merge rules from all connector classes
@@ -127,10 +137,15 @@ class VolumeForm extends Form
     {
         $this->validate([
             'name' => ['required', 'string', 'max:255', 'unique:volumes,name,'.$this->volume->id],
+            'maxStorageGb' => ['nullable', 'numeric', 'min:0.001'],
         ]);
 
+        // The storage quota stays editable even when the volume is otherwise
+        // locked (has snapshots) — it only affects future pruning, not the
+        // stored connector config.
         $this->volume->update([
             'name' => $this->name,
+            'config' => $this->applyMaxStorageToConfig($this->volume->config),
         ]);
     }
 
@@ -155,7 +170,29 @@ class VolumeForm extends Form
         $volumeType = VolumeType::from($this->type);
         $persistedConfig = $this->volume !== null ? $this->volume->config : [];
 
-        return $volumeType->encryptSensitiveFields($this->getActiveConfig(), $persistedConfig);
+        $config = $volumeType->encryptSensitiveFields($this->getActiveConfig(), $persistedConfig);
+
+        return $this->applyMaxStorageToConfig($config);
+    }
+
+    /**
+     * Store the storage quota (GB from the form, in bytes) under the config's
+     * `max_storage_bytes` key, or remove it when the field is left empty.
+     *
+     * @param  array<string, mixed>  $config
+     * @return array<string, mixed>
+     */
+    protected function applyMaxStorageToConfig(array $config): array
+    {
+        if ($this->maxStorageGb === null || $this->maxStorageGb === '') {
+            unset($config['max_storage_bytes']);
+
+            return $config;
+        }
+
+        $config['max_storage_bytes'] = (int) round((float) $this->maxStorageGb * (1024 ** 3));
+
+        return $config;
     }
 
     public function testConnection(): void

--- a/app/Livewire/Volume/Edit.php
+++ b/app/Livewire/Volume/Edit.php
@@ -37,7 +37,7 @@ class Edit extends Component
         $this->authorize('update', $this->form->volume);
 
         if ($this->hasSnapshots) {
-            $this->form->updateNameOnly();
+            $this->form->updateLockedVolume();
         } else {
             $this->form->update();
         }

--- a/app/Livewire/Volume/Index.php
+++ b/app/Livewire/Volume/Index.php
@@ -64,6 +64,7 @@ class Index extends Component
             ['key' => 'name', 'label' => __('Name'), 'class' => 'w-64'],
             ['key' => 'type', 'label' => __('Type'), 'class' => 'w-32'],
             ['key' => 'config', 'label' => __('Configuration'), 'sortable' => false],
+            ['key' => 'usage', 'label' => __('Usage'), 'sortable' => false, 'class' => 'w-40'],
             ['key' => 'created_at', 'label' => __('Created'), 'class' => 'w-40'],
         ];
     }

--- a/app/Models/Volume.php
+++ b/app/Models/Volume.php
@@ -92,6 +92,28 @@ class Volume extends Model
     }
 
     /**
+     * The configured storage limit for this volume in bytes, or null when the
+     * volume has no limit. Stored under the config's `max_storage_bytes` key.
+     * A backup that would push the volume past this limit is failed before
+     * upload; nothing is pruned automatically.
+     */
+    public function maxStorageBytes(): ?int
+    {
+        $value = $this->config['max_storage_bytes'] ?? null;
+
+        return $value !== null ? (int) $value : null;
+    }
+
+    /**
+     * Total size in bytes of the completed snapshots currently stored on this
+     * volume — the baseline a new backup is added to when checking the limit.
+     */
+    public function usedStorageBytes(): int
+    {
+        return (int) $this->snapshots()->completed()->sum('file_size');
+    }
+
+    /**
      * Get the volume type enum.
      */
     public function getVolumeType(): VolumeType

--- a/app/Models/Volume.php
+++ b/app/Models/Volume.php
@@ -110,6 +110,13 @@ class Volume extends Model
      */
     public function usedStorageBytes(): int
     {
+        // Prefer the aggregate eagerly loaded by VolumeQuery::buildFromParams so
+        // listing many volumes stays a single query instead of N+1; fall back to
+        // a direct sum when it wasn't loaded (e.g. a single volume in a job).
+        if (array_key_exists('used_storage_bytes', $this->attributes)) {
+            return (int) $this->attributes['used_storage_bytes'];
+        }
+
         return (int) $this->snapshots()->completed()->sum('file_size');
     }
 

--- a/app/Queries/VolumeQuery.php
+++ b/app/Queries/VolumeQuery.php
@@ -2,6 +2,7 @@
 
 namespace App\Queries;
 
+use App\Models\Snapshot;
 use App\Models\Volume;
 use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
@@ -51,6 +52,11 @@ class VolumeQuery
         $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
 
         return Volume::query()
+            // Eager-load each volume's used storage
+            ->withSum(['snapshots as used_storage_bytes' => function (Builder $query): void {
+                /** @var Builder<Snapshot> $query */
+                $query->completed();
+            }], 'file_size')
             ->when($search, function (Builder $query) use ($search) {
                 self::applySearch($query, $search);
             })

--- a/app/Services/Backup/BackupTask.php
+++ b/app/Services/Backup/BackupTask.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup;
 
 use App\Contracts\BackupLogger;
+use App\Exceptions\Backup\StorageQuotaExceededException;
 use App\Services\Backup\Compressors\CompressorFactory;
 use App\Services\Backup\Compressors\CompressorInterface;
 use App\Services\Backup\Concerns\UsesSshTunnel;
@@ -88,6 +89,11 @@ class BackupTask
                 $onProgress();
             }
 
+            // Fail before uploading if this backup would push the volume past
+            // its configured storage limit. Nothing is deleted — freeing space
+            // is left to the user.
+            $this->assertWithinStorageQuota($config, $fileSize, $logger);
+
             // Generate filename and transfer
             $humanFileSize = Formatters::humanFileSize($fileSize);
             $filename = $this->generateFilename($db->serverName, $config->databaseName, $db->databaseType->dumpExtension($dumpFormat), $compressor, $config->backupPath);
@@ -144,6 +150,45 @@ class BackupTask
                 FilesystemSupport::cleanupDirectory($config->workingDirectory);
             }
         }
+    }
+
+    /**
+     * Abort the backup before upload when the target volume has a storage limit
+     * and this backup would exceed it. Skipped when no limit is set or the
+     * current usage is unknown (remote agents).
+     *
+     * @throws StorageQuotaExceededException
+     */
+    private function assertWithinStorageQuota(BackupConfig $config, int $fileSize, BackupLogger $logger): void
+    {
+        $limit = $config->volume->config['max_storage_bytes'] ?? null;
+
+        if ($limit === null || $config->volumeUsedBytes === null) {
+            return;
+        }
+
+        $limit = (int) $limit;
+        $projected = $config->volumeUsedBytes + $fileSize;
+
+        if ($projected <= $limit) {
+            return;
+        }
+
+        $message = __('Storage limit reached for volume ":volume". This backup (:size) would bring total usage to :projected, over the :limit limit. The file was not uploaded — free up space by deleting old snapshots.', [
+            'volume' => $config->volume->name,
+            'size' => Formatters::humanFileSize($fileSize),
+            'projected' => Formatters::humanFileSize($projected),
+            'limit' => Formatters::humanFileSize($limit),
+        ]);
+
+        $logger->log($message, 'error', [
+            'volume' => $config->volume->name,
+            'used_bytes' => $config->volumeUsedBytes,
+            'file_size' => $fileSize,
+            'limit_bytes' => $limit,
+        ]);
+
+        throw new StorageQuotaExceededException($message);
     }
 
     /**

--- a/app/Services/Backup/DTO/BackupConfig.php
+++ b/app/Services/Backup/DTO/BackupConfig.php
@@ -16,6 +16,11 @@ readonly class BackupConfig
         public ?int $compressionLevel = null,
         public ?bool $compressionMultithread = null,
         public ?string $postBackupScript = null,
+        // Bytes currently stored on the target volume. Set app-side so the
+        // upload can be pre-checked against the volume's storage limit. Null
+        // (e.g. remote agents, which cannot read the app database) skips the
+        // check.
+        public ?int $volumeUsedBytes = null,
     ) {}
 
     /**

--- a/app/Support/Formatters.php
+++ b/app/Support/Formatters.php
@@ -52,6 +52,32 @@ class Formatters
     }
 
     /**
+     * Convert a byte count into a trimmed GB string for storage-limit form
+     * fields (e.g. 10737418240 => "10", 2684354560 => "2.5"). Null passes through.
+     */
+    public static function bytesToGb(?int $bytes): ?string
+    {
+        if ($bytes === null) {
+            return null;
+        }
+
+        return rtrim(rtrim(number_format($bytes / (1024 ** 3), 4, '.', ''), '0'), '.');
+    }
+
+    /**
+     * Convert a GB value (as entered in a form) into whole bytes. A blank or
+     * null value returns null (no limit).
+     */
+    public static function gbToBytes(int|float|string|null $gb): ?int
+    {
+        if ($gb === null || $gb === '') {
+            return null;
+        }
+
+        return (int) round((float) $gb * (1024 ** 3));
+    }
+
+    /**
      * Format a date/datetime into human-readable format
      * Output format: Dec 19, 2025, 16:44
      */

--- a/lang/el.json
+++ b/lang/el.json
@@ -617,7 +617,7 @@
   "This is a secure area of the application. Please confirm your password before continuing.": "Αυτή είναι μια ασφαλής περιοχή της εφαρμογής. Παρακαλώ επιβεβαιώστε τον κωδικό σας πριν συνεχίσετε.",
   "This is the only administrator. The role cannot be changed.": "Αυτός είναι ο μόνος διαχειριστής. Ο ρόλος δεν μπορεί να αλλαχθεί.",
   "This is the only time the public key will be shown. It is not stored — copy it before leaving this page.": "Αυτή είναι η μοναδική φορά που θα εμφανιστεί το δημόσιο κλειδί. Δεν αποθηκεύεται — αντιγράψτε το πριν φύγετε από αυτή τη σελίδα.",
-  "This volume has existing snapshots. Only the name can be modified. Configuration changes are locked to protect backup integrity.": "Αυτό το volume έχει υπάρχοντα snapshots. Μόνο το όνομα μπορεί να τροποποιηθεί. Οι αλλαγές ρύθμισης είναι κλειδωμένες για προστασία της ακεραιότητας backup.",
+  "This volume has existing snapshots. Only the name and storage limit can be modified. Configuration changes are locked to protect backup integrity.": "Αυτό το volume έχει υπάρχοντα snapshots. Μόνο το όνομα και το όριο αποθήκευσης μπορούν να τροποποιηθούν. Οι αλλαγές ρύθμισης είναι κλειδωμένες για προστασία της ακεραιότητας backup.",
   "Tiered retention": "Ιεραρχική διατήρηση",
   "To customise the encryption key, check the": "Για προσαρμογή του κλειδιού κρυπτογράφησης, ελέγξτε το",
   "To finish enabling two-factor authentication, scan the QR code or enter the setup key in your authenticator app.": "Για να ολοκληρώσετε την ενεργοποίηση ελέγχου ταυτότητας δύο παραγόντων, σαρώστε τον κωδικό QR ή εισάγετε το κλειδί εγκατάστασης στην εφαρμογή πιστοποίησης.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -620,7 +620,7 @@
   "This is a secure area of the application. Please confirm your password before continuing.": "Esta es un área segura de la aplicación. Por favor, confirme su contraseña antes de continuar.",
   "This is the only administrator. The role cannot be changed.": "Este es el único administrador. El rol no se puede cambiar.",
   "This is the only time the public key will be shown. It is not stored — copy it before leaving this page.": "Esta es la única vez que se mostrará la clave pública. No se almacena — cópiala antes de salir de esta página.",
-  "This volume has existing snapshots. Only the name can be modified. Configuration changes are locked to protect backup integrity.": "Este volumen tiene snapshots existentes. Solo se puede modificar el nombre. Los cambios de configuración están bloqueados para proteger la integridad de los backups.",
+  "This volume has existing snapshots. Only the name and storage limit can be modified. Configuration changes are locked to protect backup integrity.": "Este volumen tiene snapshots existentes. Solo se pueden modificar el nombre y el límite de almacenamiento. Los cambios de configuración están bloqueados para proteger la integridad de los backups.",
   "Tiered retention": "Retención escalonada",
   "To customise the encryption key, check the": "Para personalizar la clave de cifrado, consulte la",
   "To finish enabling two-factor authentication, scan the QR code or enter the setup key in your authenticator app.": "Para terminar de habilitar la autenticación de dos factores, escanee el código QR o introduzca la clave de configuración en su aplicación de autenticación.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -622,7 +622,7 @@
   "This is a secure area of the application. Please confirm your password before continuing.": "Ceci est une zone sécurisée de l’application. Veuillez confirmer votre mot de passe avant de continuer.",
   "This is the only administrator. The role cannot be changed.": "C’est le seul administrateur. Le rôle ne peut pas être modifié.",
   "This is the only time the public key will be shown. It is not stored — copy it before leaving this page.": "C’est la seule fois où la clé publique sera affichée. Elle n’est pas conservée — copiez-la avant de quitter cette page.",
-  "This volume has existing snapshots. Only the name can be modified. Configuration changes are locked to protect backup integrity.": "Ce volume contient des snapshots existants. Seul le nom peut être modifié. Les modifications de configuration sont verrouillées pour protéger l’intégrité des sauvegardes.",
+  "This volume has existing snapshots. Only the name and storage limit can be modified. Configuration changes are locked to protect backup integrity.": "Ce volume contient des snapshots existants. Seuls le nom et la limite de stockage peuvent être modifiés. Les modifications de configuration sont verrouillées pour protéger l’intégrité des sauvegardes.",
   "Tiered retention": "Rétention hiérarchisée",
   "To customise the encryption key, check the": "Pour personnaliser la clé de chiffrement, consultez la",
   "To finish enabling two-factor authentication, scan the QR code or enter the setup key in your authenticator app.": "Pour finaliser l’activation de l’authentification à deux facteurs, scannez le QR code ou entrez la clé de configuration dans votre application d’authentification.",

--- a/resources/views/livewire/volume/_form.blade.php
+++ b/resources/views/livewire/volume/_form.blade.php
@@ -87,6 +87,24 @@ use App\Enums\VolumeType;
         @endif
     </div>
 
+    <!-- Storage Limit -->
+    <x-hr />
+
+    <div class="space-y-4">
+        <h3 class="text-lg font-semibold">{{ __('Storage Limit') }}</h3>
+
+        <x-input
+            wire:model="form.maxStorageGb"
+            label="{{ __('Maximum storage (GB)') }}"
+            hint="{{ __('Optional. A backup that would push this volume’s total size over the limit fails before uploading — no snapshots are deleted automatically. Free up space by removing old snapshots. Leave empty for no limit.') }}"
+            placeholder="{{ __('e.g., 10') }}"
+            type="number"
+            step="0.001"
+            min="0"
+            suffix="GB"
+        />
+    </div>
+
     <!-- Submit Button -->
     <div class="flex items-center justify-end gap-3 pt-4">
         <x-button class="btn-ghost" link="{{ route($cancelRoute) }}" wire:navigate>

--- a/resources/views/livewire/volume/_form.blade.php
+++ b/resources/views/livewire/volume/_form.blade.php
@@ -17,6 +17,17 @@ use App\Enums\VolumeType;
             required
         />
 
+        <x-input
+            wire:model="form.maxStorageGb"
+            :label="__('Maximum storage (GB)')"
+            :hint="__('Optional. A backup that would push this volume’s total size over the limit fails before uploading — no snapshots are deleted automatically. Free up space by removing old snapshots. Leave empty for no limit.')"
+            :placeholder="__('e.g., 10')"
+            type="number"
+            step="0.1"
+            min="0"
+            suffix="GB"
+        />
+
         <!-- Storage Type Selection (immutable after creation) -->
         @php $typeDisabled = $readonly || $form->volume !== null; @endphp
         <div>
@@ -85,24 +96,6 @@ use App\Enums\VolumeType;
                 @endif
             </div>
         @endif
-    </div>
-
-    <!-- Storage Limit -->
-    <x-hr />
-
-    <div class="space-y-4">
-        <h3 class="text-lg font-semibold">{{ __('Storage Limit') }}</h3>
-
-        <x-input
-            wire:model="form.maxStorageGb"
-            label="{{ __('Maximum storage (GB)') }}"
-            hint="{{ __('Optional. A backup that would push this volume’s total size over the limit fails before uploading — no snapshots are deleted automatically. Free up space by removing old snapshots. Leave empty for no limit.') }}"
-            placeholder="{{ __('e.g., 10') }}"
-            type="number"
-            step="0.001"
-            min="0"
-            suffix="GB"
-        />
     </div>
 
     <!-- Submit Button -->

--- a/resources/views/livewire/volume/edit.blade.php
+++ b/resources/views/livewire/volume/edit.blade.php
@@ -8,7 +8,7 @@
 
     @if($hasSnapshots)
         <x-alert class="alert-warning mb-6" icon="o-lock-closed">
-            {{ __('This volume has existing snapshots. Only the name can be modified. Configuration changes are locked to protect backup integrity.') }}
+            {{ __('This volume has existing snapshots. Only the name and storage limit can be modified. Configuration changes are locked to protect backup integrity.') }}
         </x-alert>
     @endif
 

--- a/resources/views/livewire/volume/index.blade.php
+++ b/resources/views/livewire/volume/index.blade.php
@@ -78,6 +78,19 @@
                 @endforeach
             @endscope
 
+            @scope('cell_usage', $volume)
+                @php
+                    $usedBytes = $volume->usedStorageBytes();
+                    $limitBytes = $volume->maxStorageBytes();
+                @endphp
+                <div class="table-cell-primary {{ $limitBytes !== null && $usedBytes >= $limitBytes ? 'text-warning' : '' }}">
+                    {{ \App\Support\Formatters::humanFileSize($usedBytes) }}
+                </div>
+                @if($limitBytes !== null)
+                    <div class="text-sm text-base-content/70">{{ __('Limit') }}: {{ \App\Support\Formatters::bytesToGb($limitBytes) }} GB</div>
+                @endif
+            @endscope
+
             @scope('cell_created_at', $volume)
                 <div class="table-cell-primary">{{ \App\Support\Formatters::humanDate($volume->created_at) }}</div>
                 <div class="text-sm text-base-content/70">{{ $volume->created_at->diffForHumans() }}</div>

--- a/tests/Feature/Jobs/ProcessBackupJobTest.php
+++ b/tests/Feature/Jobs/ProcessBackupJobTest.php
@@ -206,3 +206,41 @@ test('handle uses empty backupPath when the snapshot is orphaned (backup removed
 
     expect($capturedPath)->toBe('');
 });
+
+test('handle passes the current volume usage to the backup config', function () {
+    $server = createDatabaseServer(['database_names' => ['myapp']]);
+    $snapshot = app(BackupJobFactory::class)->createSnapshots($server->backups->first(), 'manual')[0];
+
+    $mockBackupTask = Mockery::mock(BackupTask::class);
+    $mockBackupTask->shouldReceive('execute')
+        ->once()
+        ->with(
+            // No completed snapshots yet, so the volume reports zero usage.
+            Mockery::on(fn (BackupConfig $config) => $config->volumeUsedBytes === 0),
+            Mockery::type(BackupLogger::class),
+        )
+        ->andReturn(new BackupResult('myapp.sql.gz', 2048, 'abc123'));
+
+    (new ProcessBackupJob($snapshot->id))->handle($mockBackupTask);
+
+    expect($snapshot->fresh()->job->status)->toBe(BackupJobStatus::Completed);
+});
+
+test('handle fails without retry when the volume storage limit is exceeded', function () {
+    $server = createDatabaseServer(['database_names' => ['myapp']]);
+    $snapshot = app(BackupJobFactory::class)->createSnapshots($server->backups->first(), 'manual')[0];
+
+    $mockBackupTask = Mockery::mock(BackupTask::class);
+    $mockBackupTask->shouldReceive('execute')
+        ->once()
+        ->andThrow(new \App\Exceptions\Backup\StorageQuotaExceededException('Storage limit reached for volume "R2 Bucket".'));
+
+    // Unlike an ordinary failure, the quota failure is not re-thrown — that is
+    // what stops the queue from retrying a backup that can never fit.
+    (new ProcessBackupJob($snapshot->id))->handle($mockBackupTask);
+
+    $snapshot->refresh();
+    expect($snapshot->job->status)->toBe(BackupJobStatus::Failed)
+        ->and($snapshot->job->error_message)->toBe('Storage limit reached for volume "R2 Bucket".')
+        ->and($snapshot->job->completed_at)->not->toBeNull();
+});

--- a/tests/Feature/Jobs/ProcessBackupJobTest.php
+++ b/tests/Feature/Jobs/ProcessBackupJobTest.php
@@ -5,6 +5,7 @@ use App\Enums\BackupJobStatus;
 use App\Facades\AppConfig;
 use App\Jobs\ProcessBackupJob;
 use App\Models\DatabaseServer;
+use App\Models\Snapshot;
 use App\Services\Backup\BackupJobFactory;
 use App\Services\Backup\BackupTask;
 use App\Services\Backup\DTO\BackupConfig;
@@ -207,16 +208,20 @@ test('handle uses empty backupPath when the snapshot is orphaned (backup removed
     expect($capturedPath)->toBe('');
 });
 
-test('handle passes the current volume usage to the backup config', function () {
+test('handle passes the volume used storage (completed snapshots only) to the backup config', function () {
     $server = createDatabaseServer(['database_names' => ['myapp']]);
-    $snapshot = app(BackupJobFactory::class)->createSnapshots($server->backups->first(), 'manual')[0];
+    $backup = $server->backups->first();
+
+    // One completed 500-byte snapshot already sits on the volume; the pending
+    // snapshot being backed up must not count toward usage.
+    Snapshot::factory()->forServer($server)->create(['file_size' => 500]);
+    $snapshot = app(BackupJobFactory::class)->createSnapshots($backup, 'manual')[0];
 
     $mockBackupTask = Mockery::mock(BackupTask::class);
     $mockBackupTask->shouldReceive('execute')
         ->once()
         ->with(
-            // No completed snapshots yet, so the volume reports zero usage.
-            Mockery::on(fn (BackupConfig $config) => $config->volumeUsedBytes === 0),
+            Mockery::on(fn (BackupConfig $config) => $config->volumeUsedBytes === 500),
             Mockery::type(BackupLogger::class),
         )
         ->andReturn(new BackupResult('myapp.sql.gz', 2048, 'abc123'));

--- a/tests/Feature/Services/Backup/BackupTaskTest.php
+++ b/tests/Feature/Services/Backup/BackupTaskTest.php
@@ -503,3 +503,67 @@ test('execute prepends backup path with date variables to filename', function ()
     expect($result->filename)->toStartWith($expectedPrefix)
         ->and($result->filename)->toContain('Test-Server-myapp-');
 });
+
+function buildQuotaBackupTask(): BackupTask
+{
+    return new BackupTask(
+        buildMockDatabaseProvider(),
+        test()->shellProcessor,
+        test()->filesystemProvider,
+        test()->compressorFactory,
+        test()->sshTunnelService,
+        new PostScriptRunner,
+    );
+}
+
+/**
+ * @param  array<string, mixed>  $volumeConfig
+ */
+function buildQuotaConfig(array $volumeConfig, ?int $volumeUsedBytes): BackupConfig
+{
+    $workingDirectory = test()->tempDir.'/quota-test-'.uniqid();
+    mkdir($workingDirectory, 0755, true);
+
+    return new BackupConfig(
+        database: buildDbConfig(),
+        volume: new VolumeConfig(type: 'local', name: 'R2 Bucket', config: $volumeConfig),
+        databaseName: 'myapp',
+        workingDirectory: $workingDirectory,
+        volumeUsedBytes: $volumeUsedBytes,
+    );
+}
+
+test('execute aborts before upload when the backup would exceed the volume storage limit', function () {
+    // The upload must never be attempted once the quota is blown.
+    test()->filesystemProvider->shouldReceive('transferFromConfig')->never();
+
+    $backupTask = buildQuotaBackupTask();
+    $config = buildQuotaConfig(['max_storage_bytes' => 10], volumeUsedBytes: 9);
+
+    expect(fn () => $backupTask->execute($config, new InMemoryBackupLogger))
+        ->toThrow(\App\Exceptions\Backup\StorageQuotaExceededException::class);
+});
+
+test('execute uploads when the backup fits within the volume storage limit', function () {
+    test()->filesystemProvider->shouldReceive('transferFromConfig')->once();
+
+    $backupTask = buildQuotaBackupTask();
+    $config = buildQuotaConfig(['max_storage_bytes' => 1024 ** 3], volumeUsedBytes: 0);
+
+    $result = $backupTask->execute($config, new InMemoryBackupLogger);
+
+    expect($result)->toBeInstanceOf(BackupResult::class);
+});
+
+test('execute skips the storage limit check when the current usage is unknown (agent)', function () {
+    // A remote agent cannot read the app database, so volumeUsedBytes is null
+    // and the limit is not enforced — the upload proceeds.
+    test()->filesystemProvider->shouldReceive('transferFromConfig')->once();
+
+    $backupTask = buildQuotaBackupTask();
+    $config = buildQuotaConfig(['max_storage_bytes' => 10], volumeUsedBytes: null);
+
+    $result = $backupTask->execute($config, new InMemoryBackupLogger);
+
+    expect($result)->toBeInstanceOf(BackupResult::class);
+});

--- a/tests/Feature/Services/Backup/BackupTaskTest.php
+++ b/tests/Feature/Services/Backup/BackupTaskTest.php
@@ -544,26 +544,16 @@ test('execute aborts before upload when the backup would exceed the volume stora
         ->toThrow(\App\Exceptions\Backup\StorageQuotaExceededException::class);
 });
 
-test('execute uploads when the backup fits within the volume storage limit', function () {
+test('execute uploads when the backup fits within the limit or usage is unknown', function (?int $volumeUsedBytes, int $limit) {
+    // Fits under the limit, or (remote agent) usage is unknown — volumeUsedBytes
+    // is null so the limit cannot be enforced. Either way the upload proceeds.
     test()->filesystemProvider->shouldReceive('transferFromConfig')->once();
 
     $backupTask = buildQuotaBackupTask();
-    $config = buildQuotaConfig(['max_storage_bytes' => 1024 ** 3], volumeUsedBytes: 0);
+    $config = buildQuotaConfig(['max_storage_bytes' => $limit], volumeUsedBytes: $volumeUsedBytes);
 
-    $result = $backupTask->execute($config, new InMemoryBackupLogger);
-
-    expect($result)->toBeInstanceOf(BackupResult::class);
-});
-
-test('execute skips the storage limit check when the current usage is unknown (agent)', function () {
-    // A remote agent cannot read the app database, so volumeUsedBytes is null
-    // and the limit is not enforced — the upload proceeds.
-    test()->filesystemProvider->shouldReceive('transferFromConfig')->once();
-
-    $backupTask = buildQuotaBackupTask();
-    $config = buildQuotaConfig(['max_storage_bytes' => 10], volumeUsedBytes: null);
-
-    $result = $backupTask->execute($config, new InMemoryBackupLogger);
-
-    expect($result)->toBeInstanceOf(BackupResult::class);
-});
+    expect($backupTask->execute($config, new InMemoryBackupLogger))->toBeInstanceOf(BackupResult::class);
+})->with([
+    'fits within limit' => [0, 1024 ** 3],
+    'usage unknown (agent)' => [null, 10],
+]);

--- a/tests/Feature/Support/FormattersTest.php
+++ b/tests/Feature/Support/FormattersTest.php
@@ -50,6 +50,28 @@ test('humanFileSize formats megabytes and above', function () {
         ->and(Formatters::humanFileSize(1099511627777))->toBe('1 TB');
 });
 
+test('bytesToGb converts bytes to a trimmed GB string', function (?int $bytes, ?string $expected) {
+    expect(Formatters::bytesToGb($bytes))->toBe($expected);
+})->with([
+    'null passes through' => [null, null],
+    'whole GB' => [10 * (1024 ** 3), '10'],
+    'fractional GB' => [(int) (2.5 * (1024 ** 3)), '2.5'],
+    'sub-GB' => [(int) (0.5 * (1024 ** 3)), '0.5'],
+]);
+
+test('gbToBytes converts a GB value to whole bytes', function (int|float|string|null $gb, ?int $expected) {
+    expect(Formatters::gbToBytes($gb))->toBe($expected);
+})->with([
+    'null is no limit' => [null, null],
+    'blank is no limit' => ['', null],
+    'whole GB string' => ['10', 10 * (1024 ** 3)],
+    'fractional GB float' => [2.5, (int) (2.5 * (1024 ** 3))],
+]);
+
+test('gbToBytes and bytesToGb round-trip a fractional value', function () {
+    expect(Formatters::bytesToGb(Formatters::gbToBytes('7.25')))->toBe('7.25');
+});
+
 test('humanDate returns null for null input', function () {
     expect(Formatters::humanDate(null))->toBeNull();
 });

--- a/tests/Feature/Volume/VolumeTest.php
+++ b/tests/Feature/Volume/VolumeTest.php
@@ -8,6 +8,7 @@ use App\Livewire\Volume\Index;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\Restore;
+use App\Models\Snapshot;
 use App\Models\User;
 use App\Models\Volume;
 use App\Services\Backup\BackupJobFactory;
@@ -221,9 +222,10 @@ describe('volume editing', function () {
 });
 
 describe('volume storage limit', function () {
-    test('storage limit entered in GB is saved as bytes in config', function () {
+    test('storage limit round-trips through the form as GB and clears when emptied', function () {
         $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
 
+        // Entered in GB on create, stored as bytes.
         Livewire::actingAs($user)
             ->test(Create::class)
             ->set('form.name', 'Quota Volume')
@@ -235,16 +237,16 @@ describe('volume storage limit', function () {
 
         $volume = Volume::where('name', 'Quota Volume')->firstOrFail();
         expect($volume->maxStorageBytes())->toBe(10 * (1024 ** 3));
-    });
 
-    test('the stored storage limit is shown back in GB when editing', function () {
-        $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
-        $volume = Volume::factory()->local()->create();
-        $volume->update(['config' => [...$volume->config, 'max_storage_bytes' => 2 * (1024 ** 3)]]);
-
+        // Reopens showing the limit back in GB; clearing it removes the limit.
         Livewire::actingAs($user)
             ->test(Edit::class, ['volume' => $volume])
-            ->assertSet('form.maxStorageGb', '2');
+            ->assertSet('form.maxStorageGb', '10')
+            ->set('form.maxStorageGb', '')
+            ->call('save')
+            ->assertRedirect(route('volumes.index'));
+
+        expect($volume->refresh()->maxStorageBytes())->toBeNull();
     });
 
     test('the storage limit stays editable on a volume locked by its snapshots', function () {
@@ -264,20 +266,6 @@ describe('volume storage limit', function () {
 
         expect($volume->refresh()->maxStorageBytes())->toBe(5 * (1024 ** 3));
     });
-
-    test('clearing the storage limit removes it from config', function () {
-        $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
-        $volume = Volume::factory()->local()->create();
-        $volume->update(['config' => [...$volume->config, 'max_storage_bytes' => 3 * (1024 ** 3)]]);
-
-        Livewire::actingAs($user)
-            ->test(Edit::class, ['volume' => $volume])
-            ->set('form.maxStorageGb', '')
-            ->call('save')
-            ->assertRedirect(route('volumes.index'));
-
-        expect($volume->refresh()->maxStorageBytes())->toBeNull();
-    });
 });
 
 describe('volume listing', function () {
@@ -293,12 +281,21 @@ describe('volume listing', function () {
             'config' => ['bucket' => 'my-bucket', 'prefix' => ''],
         ]);
 
+        // A capped volume with a completed 3 GB snapshot exercises the Usage column.
+        $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
+        $cappedVolume = $server->backups->first()->volume;
+        $cappedVolume->update(['config' => [...$cappedVolume->config, 'max_storage_bytes' => 10 * (1024 ** 3)]]);
+        Snapshot::factory()->forServer($server)->create(['file_size' => 3 * (1024 ** 3)]);
+
         Livewire::actingAs($user)
             ->test(Index::class)
             ->assertSee('Local Volume')
             ->assertSee('S3 Volume')
             ->assertSee('/var/backups')
-            ->assertSee('my-bucket');
+            ->assertSee('my-bucket')
+            ->assertSee('Usage')
+            ->assertSee('3 GB')
+            ->assertSee('10 GB');
     });
 
     test('can search volumes', function () {

--- a/tests/Feature/Volume/VolumeTest.php
+++ b/tests/Feature/Volume/VolumeTest.php
@@ -220,6 +220,66 @@ describe('volume editing', function () {
     });
 });
 
+describe('volume storage limit', function () {
+    test('storage limit entered in GB is saved as bytes in config', function () {
+        $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
+
+        Livewire::actingAs($user)
+            ->test(Create::class)
+            ->set('form.name', 'Quota Volume')
+            ->set('form.type', 'local')
+            ->set('form.localConfig.path', '/var/backups')
+            ->set('form.maxStorageGb', '10')
+            ->call('save')
+            ->assertRedirect(route('volumes.index'));
+
+        $volume = Volume::where('name', 'Quota Volume')->firstOrFail();
+        expect($volume->maxStorageBytes())->toBe(10 * (1024 ** 3));
+    });
+
+    test('the stored storage limit is shown back in GB when editing', function () {
+        $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
+        $volume = Volume::factory()->local()->create();
+        $volume->update(['config' => [...$volume->config, 'max_storage_bytes' => 2 * (1024 ** 3)]]);
+
+        Livewire::actingAs($user)
+            ->test(Edit::class, ['volume' => $volume])
+            ->assertSet('form.maxStorageGb', '2');
+    });
+
+    test('the storage limit stays editable on a volume locked by its snapshots', function () {
+        $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
+        $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
+        $volume = $server->backups->first()->volume;
+        app(BackupJobFactory::class)->createSnapshots($server->backups->first(), 'manual');
+
+        expect($volume->hasSnapshots())->toBeTrue();
+
+        Livewire::actingAs($user)
+            ->test(Edit::class, ['volume' => $volume])
+            ->assertSet('hasSnapshots', true)
+            ->set('form.maxStorageGb', '5')
+            ->call('save')
+            ->assertRedirect(route('volumes.index'));
+
+        expect($volume->refresh()->maxStorageBytes())->toBe(5 * (1024 ** 3));
+    });
+
+    test('clearing the storage limit removes it from config', function () {
+        $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
+        $volume = Volume::factory()->local()->create();
+        $volume->update(['config' => [...$volume->config, 'max_storage_bytes' => 3 * (1024 ** 3)]]);
+
+        Livewire::actingAs($user)
+            ->test(Edit::class, ['volume' => $volume])
+            ->set('form.maxStorageGb', '')
+            ->call('save')
+            ->assertRedirect(route('volumes.index'));
+
+        expect($volume->refresh()->maxStorageBytes())->toBeNull();
+    });
+});
+
 describe('volume listing', function () {
     test('displays volumes in index', function () {
         // Viewing needs no ability — an org member with zero grants can list volumes.


### PR DESCRIPTION
## Summary

Implements an optional **storage limit** per volume (issue #445) to help users on free-tier object storage (e.g. Cloudflare R2) avoid unexpected costs when database sizes fluctuate.

Unlike the existing count/GFS/days retention policies, this is a hard cap enforced **at upload time**, not a pruning policy: **no snapshots are ever deleted automatically** — freeing space stays the user's responsibility (for now).

## How it works

- A volume can define a **Maximum storage (GB)** in its form. It's stored under the `max_storage_bytes` key of the volume's existing `config` JSON (no schema migration). The field stays editable even on volumes locked by existing snapshots, since it only affects future backups.
- During a backup job, **just before the compressed dump is uploaded**, `BackupTask` checks whether `currentUsage + newFileSize` would exceed the limit.
  - `currentUsage` = sum of the *completed* snapshots' sizes on that volume, passed in from `ProcessBackupJob` via `BackupConfig::$volumeUsedBytes`.
  - If it would exceed, it throws `StorageQuotaExceededException` and **the file is never uploaded**.
- `ProcessBackupJob` catches that exception and **fails the job without retry** (retrying can't help — the limit won't move), then sends the standard backup-failure notification whose error details explain the limit was reached.
- **Remote agents** have no DB access, so `volumeUsedBytes` is `null` and the check is skipped for agent-run backups.

## Notably out of scope (deliberate, for now)

- No automatic pruning/deletion of old snapshots.
- No pre-dump estimate — the check uses the *actual* compressed size, so a backup still runs (dump + compress) before being rejected.
- Agent-run backups are not enforced.

## Tests

- `BackupTaskTest`: aborts without uploading when over limit; uploads when it fits; skips the check when usage is unknown (agent).
- `ProcessBackupJobTest`: passes current usage into the config; fails-without-retry and records the custom message on the job.
- `VolumeTest`: limit is saved as bytes, shown back in GB, editable on locked volumes, and clearable.

Full suite green (1308 passed), PHPStan 0 errors, Pint clean.

## Note

New UI/exception strings are not yet added to `lang/*.json`; they fall back to English per the project's localization convention.

Closes #445


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-volume storage limits (GB) with clear UI guidance.
  * Added volume usage visibility, including “Usage” and “Limit: … GB” when set.
* **Bug Fixes**
  * Backup uploads now pre-check projected storage usage before any transfer.
  * Backups that exceed the configured limit now fail immediately and won’t retry.
* **Documentation**
  * Updated edit warnings and translations to reflect that volume name and storage limit can both be modified when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->