### PR TITLE
fix(ui): respect APP_URL subpath in logo link

### DIFF
--- a/resources/views/components/app-brand.blade.php
+++ b/resources/views/components/app-brand.blade.php
@@ -1,4 +1,4 @@
-<a href="/" wire:navigate>
+<a href="{{ url('/') }}" wire:navigate>
     <!-- Hidden when collapsed -->
     <div {{ $attributes->class(["hidden-when-collapsed"]) }}>
         <div class="flex items-center gap-3 w-fit">


### PR DESCRIPTION
## Problem

Closes #457.

The brand logo linked to a hardcoded `href="/"`, which the browser always resolves against the domain root. When Databasement is hosted behind a reverse proxy under a subpath (e.g. `APP_URL=https://example.com/databasement`, with the proxy stripping the `/databasement` prefix), clicking the logo dropped users at `https://example.com/` instead of the app — even though the rest of the app correctly honors `APP_URL` / `TRUSTED_PROXIES`.

## Fix

Use Laravel's `url('/')` helper so the link resolves against the configured `APP_URL`, including any subpath.

```diff
-<a href="/" wire:navigate>
+<a href="{{ url('/') }}" wire:navigate>
```

This was the only hardcoded root `href` in the Blade views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the application logo link to reliably navigate to the correct base URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->