### PR TITLE
Add total-storage threshold notification

### DIFF
--- a/app/Jobs/ProcessBackupJob.php
+++ b/app/Jobs/ProcessBackupJob.php
@@ -89,6 +89,12 @@ class ProcessBackupJob implements ShouldQueue
 
             try {
                 app(NotificationService::class)->notifyBackupSuccess($snapshot);
+
+                // Notify-only storage limit: the backup was uploaded despite
+                // exceeding the volume's limit — alert every configured channel.
+                if ($result->storageWarning !== null) {
+                    app(NotificationService::class)->notifyStorageLimitWarning($snapshot, $result->storageWarning);
+                }
             } catch (\Throwable $notificationException) {
                 Log::warning('Backup success notification failed', [
                     'snapshot_id' => $this->snapshotId,

--- a/app/Livewire/Forms/VolumeForm.php
+++ b/app/Livewire/Forms/VolumeForm.php
@@ -23,6 +23,10 @@ class VolumeForm extends Form
     // Stored under the `max_storage_bytes` key of the volume's config JSON.
     public ?string $maxStorageGb = null;
 
+    // When true, reaching the limit only sends a notification instead of failing
+    // the backup. Stored under the `max_storage_notify_only` config key.
+    public bool $storageLimitNotifyOnly = false;
+
     // Config arrays for each volume type (initialized from connector defaults in constructor)
     /** @var array<string, mixed> */
     public array $localConfig = [];
@@ -73,6 +77,7 @@ class VolumeForm extends Form
         $this->{$propertyName} = array_merge($this->{$propertyName}, $decryptedConfig);
 
         $this->maxStorageGb = Formatters::bytesToGb($volume->maxStorageBytes());
+        $this->storageLimitNotifyOnly = $volume->storageLimitIsNotifyOnly();
     }
 
     /**
@@ -84,6 +89,7 @@ class VolumeForm extends Form
             'name' => ['required', 'string', 'max:255'],
             'type' => ['required', 'string', 'in:'.implode(',', array_column(VolumeType::cases(), 'value'))],
             'maxStorageGb' => ['nullable', 'numeric', 'min:0.001'],
+            'storageLimitNotifyOnly' => ['boolean'],
         ];
 
         // Merge rules from all connector classes
@@ -141,6 +147,7 @@ class VolumeForm extends Form
         $this->validate([
             'name' => ['required', 'string', 'max:255', 'unique:volumes,name,'.$this->volume->id],
             'maxStorageGb' => ['nullable', 'numeric', 'min:0.001'],
+            'storageLimitNotifyOnly' => ['boolean'],
         ]);
 
         $this->volume->update([
@@ -177,7 +184,9 @@ class VolumeForm extends Form
 
     /**
      * Store the storage quota (GB from the form, in bytes) under the config's
-     * `max_storage_bytes` key, or remove it when the field is left empty.
+     * `max_storage_bytes` key, along with the notify-only flag. Both keys are
+     * removed when the limit field is left empty (the flag is meaningless
+     * without a limit).
      *
      * @param  array<string, mixed>  $config
      * @return array<string, mixed>
@@ -187,9 +196,17 @@ class VolumeForm extends Form
         $bytes = Formatters::gbToBytes($this->maxStorageGb);
 
         if ($bytes === null) {
-            unset($config['max_storage_bytes']);
+            unset($config['max_storage_bytes'], $config['max_storage_notify_only']);
+
+            return $config;
+        }
+
+        $config['max_storage_bytes'] = $bytes;
+
+        if ($this->storageLimitNotifyOnly) {
+            $config['max_storage_notify_only'] = true;
         } else {
-            $config['max_storage_bytes'] = $bytes;
+            unset($config['max_storage_notify_only']);
         }
 
         return $config;

--- a/app/Models/Volume.php
+++ b/app/Models/Volume.php
@@ -94,14 +94,25 @@ class Volume extends Model
     /**
      * The configured storage limit for this volume in bytes, or null when the
      * volume has no limit. Stored under the config's `max_storage_bytes` key.
-     * A backup that would push the volume past this limit is failed before
-     * upload; nothing is pruned automatically.
+     * When the limit would be exceeded a backup is either failed before upload
+     * or merely warned about, depending on {@see self::storageLimitIsNotifyOnly()}.
+     * Nothing is pruned automatically.
      */
     public function maxStorageBytes(): ?int
     {
         $value = $this->config['max_storage_bytes'] ?? null;
 
         return $value !== null ? (int) $value : null;
+    }
+
+    /**
+     * Whether reaching the storage limit only sends a notification instead of
+     * blocking the backup. Stored under the config's `max_storage_notify_only`
+     * key; only meaningful when a limit is set.
+     */
+    public function storageLimitIsNotifyOnly(): bool
+    {
+        return (bool) ($this->config['max_storage_notify_only'] ?? false);
     }
 
     /**

--- a/app/Notifications/StorageLimitWarningNotification.php
+++ b/app/Notifications/StorageLimitWarningNotification.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\NotificationType;
+use App\Models\Snapshot;
+use App\Notifications\Concerns\HasChannelRouting;
+use App\Support\Formatters;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Sent when a backup exceeded its volume's storage limit but the volume is in
+ * notify-only mode, so the backup was uploaded anyway. Delivered to every
+ * configured channel because a volume is an installation-wide resource.
+ */
+class StorageLimitWarningNotification extends Notification
+{
+    use HasChannelRouting;
+
+    public function __construct(
+        public Snapshot $snapshot,
+        public string $warning,
+    ) {}
+
+    public function getMessage(): NotificationMessage
+    {
+        return new NotificationMessage(
+            type: NotificationType::Failure,
+            title: '⚠️ '.__('Storage limit reached on volume: :volume', ['volume' => $this->snapshot->volume->name]),
+            body: __('A backup of ":server" on volume ":volume" exceeded its storage limit. It was still uploaded because the volume is set to notify only: free up space to stay within the limit.', [
+                'server' => $this->snapshot->databaseServer->name,
+                'volume' => $this->snapshot->volume->name,
+            ]),
+            actionText: '🔗 '.__('View Job Details'),
+            actionUrl: route('snapshots.index', ['job' => $this->snapshot->backup_job_id]),
+            footerText: '🕐 '.Formatters::humanDate(now()),
+            fields: [
+                __('Server') => $this->snapshot->databaseServer->name,
+                __('Database') => $this->snapshot->database_name ?? __('Unknown'),
+                __('Volume') => $this->snapshot->volume->name,
+            ],
+            errorMessage: $this->warning,
+            errorLabel: '⚠️ '.__('Storage Details'),
+        );
+    }
+}

--- a/app/Services/Backup/BackupTask.php
+++ b/app/Services/Backup/BackupTask.php
@@ -89,10 +89,11 @@ class BackupTask
                 $onProgress();
             }
 
-            // Fail before uploading if this backup would push the volume past
-            // its configured storage limit. Nothing is deleted — freeing space
-            // is left to the user.
-            $this->assertWithinStorageQuota($config, $fileSize, $logger);
+            // Enforce the volume's storage limit before uploading. In block mode
+            // this throws and the backup fails; in notify-only mode it returns a
+            // warning message and the upload proceeds. Nothing is deleted —
+            // freeing space is left to the user.
+            $storageWarning = $this->assertWithinStorageQuota($config, $fileSize, $logger);
 
             // Generate filename and transfer
             $humanFileSize = Formatters::humanFileSize($fileSize);
@@ -141,7 +142,7 @@ class BackupTask
                 ],
             );
 
-            return new BackupResult($filename, $fileSize, $checksum);
+            return new BackupResult($filename, $fileSize, $checksum, $storageWarning);
         } finally {
             $this->closeSshTunnel($logger);
 
@@ -153,25 +154,54 @@ class BackupTask
     }
 
     /**
-     * Abort the backup before upload when the target volume has a storage limit
-     * and this backup would exceed it. Skipped when no limit is set or the
-     * current usage is unknown (remote agents).
+     * Enforce the target volume's storage limit before upload when this backup
+     * would exceed it. Skipped (returns null) when no limit is set or the current
+     * usage is unknown (remote agents).
+     *
+     * In block mode (default) this throws and the file is never uploaded. In
+     * notify-only mode it logs a warning and returns the message so the caller
+     * can notify the user while still uploading the backup.
+     *
+     * @return string|null The overage message when notify-only mode is on and the
+     *                     limit was exceeded; null otherwise.
      *
      * @throws StorageQuotaExceededException
      */
-    private function assertWithinStorageQuota(BackupConfig $config, int $fileSize, BackupLogger $logger): void
+    private function assertWithinStorageQuota(BackupConfig $config, int $fileSize, BackupLogger $logger): ?string
     {
         $limit = $config->volume->config['max_storage_bytes'] ?? null;
 
         if ($limit === null || $config->volumeUsedBytes === null) {
-            return;
+            return null;
         }
 
         $limit = (int) $limit;
         $projected = $config->volumeUsedBytes + $fileSize;
 
         if ($projected <= $limit) {
-            return;
+            return null;
+        }
+
+        $notifyOnly = (bool) ($config->volume->config['max_storage_notify_only'] ?? false);
+
+        $context = [
+            'volume' => $config->volume->name,
+            'used_bytes' => $config->volumeUsedBytes,
+            'file_size' => $fileSize,
+            'limit_bytes' => $limit,
+        ];
+
+        if ($notifyOnly) {
+            $message = __('Storage limit reached for volume ":volume". This backup (:size) brings total usage to :projected, over the :limit limit. The backup was still uploaded (notify-only) — free up space by deleting old snapshots.', [
+                'volume' => $config->volume->name,
+                'size' => Formatters::humanFileSize($fileSize),
+                'projected' => Formatters::humanFileSize($projected),
+                'limit' => Formatters::humanFileSize($limit),
+            ]);
+
+            $logger->log($message, 'warning', $context);
+
+            return $message;
         }
 
         $message = __('Storage limit reached for volume ":volume". This backup (:size) would bring total usage to :projected, over the :limit limit. The file was not uploaded — free up space by deleting old snapshots.', [
@@ -181,12 +211,7 @@ class BackupTask
             'limit' => Formatters::humanFileSize($limit),
         ]);
 
-        $logger->log($message, 'error', [
-            'volume' => $config->volume->name,
-            'used_bytes' => $config->volumeUsedBytes,
-            'file_size' => $fileSize,
-            'limit_bytes' => $limit,
-        ]);
+        $logger->log($message, 'error', $context);
 
         throw new StorageQuotaExceededException($message);
     }

--- a/app/Services/Backup/DTO/BackupResult.php
+++ b/app/Services/Backup/DTO/BackupResult.php
@@ -8,5 +8,9 @@ readonly class BackupResult
         public string $filename,
         public int $fileSize,
         public string $checksum,
+        // Set when the volume reached its storage limit but is in notify-only
+        // mode: the backup was still uploaded and this message describes the
+        // overage so the job can notify the user. Null when within the limit.
+        public ?string $storageWarning = null,
     ) {}
 }

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -13,6 +13,7 @@ use App\Notifications\ChannelNotifiable;
 use App\Notifications\RestoreFailedNotification;
 use App\Notifications\RestoreSuccessNotification;
 use App\Notifications\SnapshotsMissingNotification;
+use App\Notifications\StorageLimitWarningNotification;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
@@ -52,6 +53,19 @@ class NotificationService
             $restore->targetServer,
             'success',
             new RestoreSuccessNotification($restore),
+        );
+    }
+
+    /**
+     * A backup exceeded its volume's storage limit but was uploaded anyway
+     * (notify-only mode). Volumes are installation-wide, so this alerts every
+     * configured channel rather than the source server's channels.
+     */
+    public function notifyStorageLimitWarning(Snapshot $snapshot, string $message): void
+    {
+        $this->sendToChannels(
+            new StorageLimitWarningNotification($snapshot, $message),
+            NotificationChannel::all(),
         );
     }
 

--- a/resources/views/livewire/volume/_form.blade.php
+++ b/resources/views/livewire/volume/_form.blade.php
@@ -18,15 +18,23 @@ use App\Enums\VolumeType;
         />
 
         <x-input
-            wire:model="form.maxStorageGb"
+            wire:model.live.debounce="form.maxStorageGb"
             :label="__('Maximum storage (GB)')"
-            :hint="__('Optional. A backup that would push this volume’s total size over the limit fails before uploading — no snapshots are deleted automatically. Free up space by removing old snapshots. Leave empty for no limit.')"
+            :hint="__('Optional. A backup that would push this volume’s total size over the limit is rejected before uploading — no snapshots are deleted automatically. Free up space by removing old snapshots, or enable notify-only to keep backing up. Leave empty for no limit.')"
             :placeholder="__('e.g., 10')"
             type="number"
             step="0.1"
             min="0"
             suffix="GB"
         />
+
+        @if (filled($form->maxStorageGb))
+            <x-checkbox
+                wire:model="form.storageLimitNotifyOnly"
+                :label="__('When the storage limit is reached, only notify — don’t block backups')"
+                :hint="__('Upload the backup anyway and send a notification instead of failing it.')"
+            />
+        @endif
 
         <!-- Storage Type Selection (immutable after creation) -->
         @php $typeDisabled = $readonly || $form->volume !== null; @endphp

--- a/tests/Feature/Jobs/ProcessBackupJobTest.php
+++ b/tests/Feature/Jobs/ProcessBackupJobTest.php
@@ -249,3 +249,20 @@ test('handle fails without retry when the volume storage limit is exceeded', fun
         ->and($snapshot->job->error_message)->toBe('Storage limit reached for volume "R2 Bucket".')
         ->and($snapshot->job->completed_at)->not->toBeNull();
 });
+
+test('handle completes and notifies all channels when the limit is exceeded in notify-only mode', function () {
+    \App\Models\NotificationChannel::factory()->email()->create(['config' => ['to' => 'admin@example.com']]);
+
+    $server = createDatabaseServer(['database_names' => ['myapp']]);
+    $snapshot = app(BackupJobFactory::class)->createSnapshots($server->backups->first(), 'manual')[0];
+
+    $mockBackupTask = Mockery::mock(BackupTask::class);
+    $mockBackupTask->shouldReceive('execute')
+        ->once()
+        ->andReturn(new BackupResult('myapp.sql.gz', 2048, 'abc123', storageWarning: 'Storage limit reached for volume "R2 Bucket".'));
+
+    (new ProcessBackupJob($snapshot->id))->handle($mockBackupTask);
+
+    expect($snapshot->fresh()->job->status)->toBe(BackupJobStatus::Completed);
+    Notification::assertSentTimes(\App\Notifications\StorageLimitWarningNotification::class, 1);
+});

--- a/tests/Feature/Services/Backup/BackupTaskTest.php
+++ b/tests/Feature/Services/Backup/BackupTaskTest.php
@@ -557,3 +557,20 @@ test('execute uploads when the backup fits within the limit or usage is unknown'
     'fits within limit' => [0, 1024 ** 3],
     'usage unknown (agent)' => [null, 10],
 ]);
+
+test('execute uploads and returns a warning when over the limit in notify-only mode', function () {
+    // Over the limit but notify-only: the upload still happens and the result
+    // carries the overage message so the job can notify the user.
+    test()->filesystemProvider->shouldReceive('transferFromConfig')->once();
+
+    $backupTask = buildQuotaBackupTask();
+    $config = buildQuotaConfig(
+        ['max_storage_bytes' => 10, 'max_storage_notify_only' => true],
+        volumeUsedBytes: 9,
+    );
+
+    $result = $backupTask->execute($config, new InMemoryBackupLogger);
+
+    expect($result)->toBeInstanceOf(BackupResult::class)
+        ->and($result->storageWarning)->toContain('R2 Bucket');
+});

--- a/tests/Feature/Volume/VolumeTest.php
+++ b/tests/Feature/Volume/VolumeTest.php
@@ -266,6 +266,35 @@ describe('volume storage limit', function () {
 
         expect($volume->refresh()->maxStorageBytes())->toBe(5 * (1024 ** 3));
     });
+
+    test('the notify-only flag round-trips and is dropped when the limit is cleared', function () {
+        $user = User::factory()->withAbilities([Ability::ManageVolumes->value])->create();
+
+        Livewire::actingAs($user)
+            ->test(Create::class)
+            ->set('form.name', 'Notify Volume')
+            ->set('form.type', 'local')
+            ->set('form.localConfig.path', '/var/backups')
+            ->set('form.maxStorageGb', '10')
+            ->set('form.storageLimitNotifyOnly', true)
+            ->call('save')
+            ->assertRedirect(route('volumes.index'));
+
+        $volume = Volume::where('name', 'Notify Volume')->firstOrFail();
+        expect($volume->storageLimitIsNotifyOnly())->toBeTrue();
+
+        // Reopens with the flag set; clearing the limit drops both config keys.
+        Livewire::actingAs($user)
+            ->test(Edit::class, ['volume' => $volume])
+            ->assertSet('form.storageLimitNotifyOnly', true)
+            ->set('form.maxStorageGb', '')
+            ->call('save')
+            ->assertRedirect(route('volumes.index'));
+
+        $volume->refresh();
+        expect($volume->maxStorageBytes())->toBeNull()
+            ->and($volume->config)->not->toHaveKey('max_storage_notify_only');
+    });
 });
 
 describe('volume listing', function () {


### PR DESCRIPTION
## Summary

Adds a **total storage** notification alongside the existing per-job alerts. You can now be notified once the combined size of all stored backups reaches a configurable threshold — for example, "alert me once my snapshots add up to 50 GB".

## Motivation

Today notifications only cover backup/restore failures and missing snapshot files. There's no way to keep an eye on the overall storage footprint, which is exactly what fills up a disk over time. This adds a lightweight, self-hoster-friendly guardrail using the notification channels people have already configured.

## What's included

- **Configuration → Notification → Total Storage Alert**: set a threshold in GB (0 disables it) and the check schedule (cron, default hourly).
- **`notifications:check-storage` command**, registered in the scheduler. It's skipped entirely while the threshold is 0, mirroring how `snapshots:verify-files` is gated.
- **`StorageAlertService`** aggregates the size of completed snapshots across the whole installation, compares against the threshold, and uses a latch (`notifications.storage_alert_triggered`) so the alert fires **once per crossing** rather than on every run. It re-arms automatically once usage drops back below the threshold (e.g. after cleanup), so a later crossing alerts again.
- **`StorageThresholdNotification`** reuses the existing `HasChannelRouting` / `NotificationMessage` plumbing, so it's delivered over every configured transport (Email, Slack, Discord, Telegram, Pushover, Gotify, Webhook) with no per-channel work.
- Delivered to **all** configured channels, since storage is an installation-wide concern rather than tied to a single database server.
- Docs section and feature tests covering the crossing, no-alert-below-threshold, disabled, no-repeat, and re-arm behaviours.

## Testing

- `php artisan test tests/Feature/Notifications/` — 68 passed (incl. 5 new storage-alert tests).
- Pint: clean on all changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “notify-only” option for configured volume storage limits.
  * When enabled, backups continue even if the storage limit is exceeded, and a warning notification is sent with job details.
  * Added a storage-limit warning notification that includes volume/server context and links to job information.
  * Updated the volume form with a notify-only checkbox and improved storage limit help text.
* **Bug Fixes**
  * Clearing a storage limit now also removes the notify-only setting.
* **Tests**
  * Added/extended feature tests covering notify-only backup completion, notifications, and volume create/edit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->