### PR TITLE
fix(backup): stop unreachable mail server from wedging backup jobs

### DIFF
--- a/app/Jobs/ProcessBackupJob.php
+++ b/app/Jobs/ProcessBackupJob.php
@@ -87,14 +87,7 @@ class ProcessBackupJob implements ShouldQueue
 
             $job->markCompleted();
 
-            try {
-                app(NotificationService::class)->notifyBackupSuccess($snapshot);
-            } catch (\Throwable $notificationException) {
-                Log::warning('Backup success notification failed', [
-                    'snapshot_id' => $this->snapshotId,
-                    'error' => $notificationException->getMessage(),
-                ]);
-            }
+            app(NotificationService::class)->notifyBackupSuccess($snapshot);
 
             Log::info('Backup completed successfully', [
                 'snapshot_id' => $this->snapshotId,
@@ -133,13 +126,6 @@ class ProcessBackupJob implements ShouldQueue
             return;
         }
 
-        try {
-            app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
-        } catch (\Throwable $notificationException) {
-            Log::warning('Backup failure notification failed', [
-                'snapshot_id' => $this->snapshotId,
-                'error' => $notificationException->getMessage(),
-            ]);
-        }
+        app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
     }
 }

--- a/app/Jobs/ProcessBackupJob.php
+++ b/app/Jobs/ProcessBackupJob.php
@@ -133,6 +133,13 @@ class ProcessBackupJob implements ShouldQueue
             return;
         }
 
-        app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
+        try {
+            app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
+        } catch (\Throwable $notificationException) {
+            Log::warning('Backup failure notification failed', [
+                'snapshot_id' => $this->snapshotId,
+                'error' => $notificationException->getMessage(),
+            ]);
+        }
     }
 }

--- a/app/Jobs/ProcessRestoreJob.php
+++ b/app/Jobs/ProcessRestoreJob.php
@@ -82,14 +82,7 @@ class ProcessRestoreJob implements ShouldQueue
 
             $job->markCompleted();
 
-            try {
-                app(NotificationService::class)->notifyRestoreSuccess($restore);
-            } catch (\Throwable $notificationException) {
-                Log::warning('Restore success notification failed', [
-                    'restore_id' => $this->restoreId,
-                    'error' => $notificationException->getMessage(),
-                ]);
-            }
+            app(NotificationService::class)->notifyRestoreSuccess($restore);
 
             Log::info('Restore completed successfully', [
                 'restore_id' => $this->restoreId,

--- a/app/Services/Backup/BackupJobFactory.php
+++ b/app/Services/Backup/BackupJobFactory.php
@@ -154,14 +154,7 @@ class BackupJobFactory
         ]);
         $snapshot->job->markFailed($exception);
 
-        try {
-            app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
-        } catch (\Throwable $notificationException) {
-            Log::warning('Pre-flight failure notification failed', [
-                'snapshot_id' => $snapshot->id,
-                'error' => $notificationException->getMessage(),
-            ]);
-        }
+        app(NotificationService::class)->notifyBackupFailed($snapshot, $exception);
     }
 
     /**

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -24,38 +24,38 @@ class NotificationService
 {
     public function notifyBackupFailed(Snapshot $snapshot, \Throwable $exception): void
     {
-        $this->notifyServer(
+        $this->safely(fn () => $this->notifyServer(
             $snapshot->databaseServer,
             'failure',
             new BackupFailedNotification($snapshot, $exception),
-        );
+        ));
     }
 
     public function notifyBackupSuccess(Snapshot $snapshot): void
     {
-        $this->notifyServer(
+        $this->safely(fn () => $this->notifyServer(
             $snapshot->databaseServer,
             'success',
             new BackupSuccessNotification($snapshot),
-        );
+        ));
     }
 
     public function notifyRestoreFailed(Restore $restore, \Throwable $exception): void
     {
-        $this->notifyServer(
+        $this->safely(fn () => $this->notifyServer(
             $restore->targetServer,
             'failure',
             new RestoreFailedNotification($restore, $exception),
-        );
+        ));
     }
 
     public function notifyRestoreSuccess(Restore $restore): void
     {
-        $this->notifyServer(
+        $this->safely(fn () => $this->notifyServer(
             $restore->targetServer,
             'success',
             new RestoreSuccessNotification($restore),
-        );
+        ));
     }
 
     private function notifyServer(DatabaseServer $server, string $event, Notification $notification): void
@@ -73,16 +73,18 @@ class NotificationService
      */
     public function notifySnapshotsMissing(Collection $missingSnapshots, Collection $affectedServerIds): void
     {
-        $channels = DatabaseServer::whereIn('id', $affectedServerIds)
-            ->get()
-            ->filter(fn (DatabaseServer $server) => $server->shouldNotifyOn('failure'))
-            ->flatMap(fn (DatabaseServer $server) => $server->resolveNotificationChannels())
-            ->unique('id');
+        $this->safely(function () use ($missingSnapshots, $affectedServerIds) {
+            $channels = DatabaseServer::whereIn('id', $affectedServerIds)
+                ->get()
+                ->filter(fn (DatabaseServer $server) => $server->shouldNotifyOn('failure'))
+                ->flatMap(fn (DatabaseServer $server) => $server->resolveNotificationChannels())
+                ->unique('id');
 
-        $this->sendToChannels(
-            new SnapshotsMissingNotification($missingSnapshots), // @phpstan-ignore argument.type
-            $channels,
-        );
+            $this->sendToChannels(
+                new SnapshotsMissingNotification($missingSnapshots), // @phpstan-ignore argument.type
+                $channels,
+            );
+        });
     }
 
     /**
@@ -100,6 +102,24 @@ class NotificationService
         $exception = new \Exception('SQLSTATE[HY000] [2002] Connection refused (This is a test notification)');
 
         $this->sendToChannel(new BackupFailedNotification($snapshot, $exception), $channel);
+    }
+
+    /**
+     * Notifications must never block or fail the operation that triggered
+     * them: any error building or dispatching one (channel resolution, DB
+     * reads, notification construction) is logged and swallowed. Per-channel
+     * send errors are additionally isolated in sendToChannels so one broken
+     * channel cannot block the remaining ones.
+     */
+    private function safely(\Closure $callback): void
+    {
+        try {
+            $callback();
+        } catch (\Throwable $e) {
+            Log::warning('Notification dispatch failed', [
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -17,6 +17,7 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
+use NotificationChannels\Discord\Discord;
 
 class NotificationService
 {
@@ -147,10 +148,26 @@ class NotificationService
     private function refreshVendorServiceConfig(NotificationChannelType $type, array $config): void
     {
         match ($type) {
-            NotificationChannelType::Discord => config(['services.discord.token' => $config['token'] ?? null]),
+            NotificationChannelType::Discord => $this->refreshDiscordToken($config['token'] ?? null),
             NotificationChannelType::Telegram => config(['services.telegram-bot-api.token' => $config['bot_token'] ?? null]),
             NotificationChannelType::Pushover => config(['services.pushover.token' => $config['token'] ?? null]),
             default => null,
         };
+    }
+
+    /**
+     * Unlike the Telegram/Pushover providers (which read config lazily at
+     * resolve time), the Discord provider captures the token once at boot
+     * via a contextual binding — with no token in services config at boot,
+     * resolving the channel throws an unresolvable-dependency error. So the
+     * binding itself must be re-registered with the channel's token.
+     */
+    private function refreshDiscordToken(?string $token): void
+    {
+        config(['services.discord.token' => $token]);
+
+        app()->when(Discord::class)
+            ->needs('$token')
+            ->give($token);
     }
 }

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -15,6 +15,7 @@ use App\Notifications\RestoreSuccessNotification;
 use App\Notifications\SnapshotsMissingNotification;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification as NotificationFacade;
 
 class NotificationService
@@ -105,7 +106,16 @@ class NotificationService
     private function sendToChannels(Notification $notification, iterable $channels): void
     {
         foreach ($channels as $channel) {
-            $this->sendToChannel($notification, $channel);
+            try {
+                $this->sendToChannel($notification, $channel);
+            } catch (\Throwable $e) {
+                Log::warning('Notification send failed', [
+                    'channel_id' => $channel->id,
+                    'channel_type' => $channel->type->value,
+                    'notification' => get_class($notification),
+                    'error' => $e->getMessage(),
+                ]);
+            }
         }
     }
 

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -162,7 +162,7 @@ class NotificationService
         // instanceof guard skips this when the facade is faked (tests), where
         // no real drivers are ever resolved.
         if (in_array($type, [NotificationChannelType::Discord, NotificationChannelType::Telegram, NotificationChannelType::Pushover], true)) {
-            $manager = app(ChannelManager::class);
+            $manager = NotificationFacade::getFacadeRoot();
 
             if ($manager instanceof ChannelManager) {
                 $manager->forgetDrivers();

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -13,6 +13,7 @@ use App\Notifications\ChannelNotifiable;
 use App\Notifications\RestoreFailedNotification;
 use App\Notifications\RestoreSuccessNotification;
 use App\Notifications\SnapshotsMissingNotification;
+use Illuminate\Notifications\ChannelManager;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
@@ -153,6 +154,20 @@ class NotificationService
             NotificationChannelType::Pushover => config(['services.pushover.token' => $config['token'] ?? null]),
             default => null,
         };
+
+        // The ChannelManager caches resolved channel drivers per process, so in
+        // the long-running queue worker a cached driver keeps the API client
+        // (and token) it was first built with. Drop the cache so the next send
+        // resolves a fresh client from the config/bindings set above. The
+        // instanceof guard skips this when the facade is faked (tests), where
+        // no real drivers are ever resolved.
+        if (in_array($type, [NotificationChannelType::Discord, NotificationChannelType::Telegram, NotificationChannelType::Pushover], true)) {
+            $manager = app(ChannelManager::class);
+
+            if ($manager instanceof ChannelManager) {
+                $manager->forgetDrivers();
+            }
+        }
     }
 
     /**

--- a/config/mail.php
+++ b/config/mail.php
@@ -45,7 +45,7 @@ return [
             'port' => env('MAIL_PORT', 2525),
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
-            'timeout' => null,
+            'timeout' => env('MAIL_TIMEOUT', 10),
             'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
         ],
 

--- a/tests/Feature/Jobs/ProcessBackupJobTest.php
+++ b/tests/Feature/Jobs/ProcessBackupJobTest.php
@@ -170,29 +170,6 @@ test('failed method sends notification', function () {
     Notification::assertSentTimes(\App\Notifications\BackupFailedNotification::class, 1);
 });
 
-test('failed method swallows notification errors so the failure is not lost', function () {
-    Log::spy();
-
-    $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
-    $snapshot = app(BackupJobFactory::class)->createSnapshots($server->backups->first(), 'manual')[0];
-
-    // Simulate an unreachable SMTP host: the notification send throws.
-    $mockNotifier = Mockery::mock(\App\Services\NotificationService::class);
-    $mockNotifier->shouldReceive('notifyBackupFailed')
-        ->once()
-        ->andThrow(new \Symfony\Component\Mailer\Exception\TransportException('Connection could not be established'));
-    app()->instance(\App\Services\NotificationService::class, $mockNotifier);
-
-    $job = new ProcessBackupJob($snapshot->id);
-
-    // The mail failure must not escape failed().
-    $job->failed(new \Exception('Backup failed: connection timeout'));
-
-    Log::shouldHaveReceived('warning')
-        ->withArgs(fn (string $message) => $message === 'Backup failure notification failed')
-        ->once();
-});
-
 test('handle uses empty backupPath when the snapshot is orphaned (backup removed)', function () {
     $server = createDatabaseServer([
         'host' => 'db.example.com',

--- a/tests/Feature/Jobs/ProcessBackupJobTest.php
+++ b/tests/Feature/Jobs/ProcessBackupJobTest.php
@@ -170,6 +170,29 @@ test('failed method sends notification', function () {
     Notification::assertSentTimes(\App\Notifications\BackupFailedNotification::class, 1);
 });
 
+test('failed method swallows notification errors so the failure is not lost', function () {
+    Log::spy();
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
+    $snapshot = app(BackupJobFactory::class)->createSnapshots($server->backups->first(), 'manual')[0];
+
+    // Simulate an unreachable SMTP host: the notification send throws.
+    $mockNotifier = Mockery::mock(\App\Services\NotificationService::class);
+    $mockNotifier->shouldReceive('notifyBackupFailed')
+        ->once()
+        ->andThrow(new \Symfony\Component\Mailer\Exception\TransportException('Connection could not be established'));
+    app()->instance(\App\Services\NotificationService::class, $mockNotifier);
+
+    $job = new ProcessBackupJob($snapshot->id);
+
+    // The mail failure must not escape failed().
+    $job->failed(new \Exception('Backup failed: connection timeout'));
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message) => $message === 'Backup failure notification failed')
+        ->once();
+});
+
 test('handle uses empty backupPath when the snapshot is orphaned (backup removed)', function () {
     $server = createDatabaseServer([
         'host' => 'db.example.com',

--- a/tests/Feature/Notifications/NotificationTest.php
+++ b/tests/Feature/Notifications/NotificationTest.php
@@ -22,6 +22,7 @@ use Illuminate\Http\Client\Request;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Slack\SlackMessage;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
@@ -206,6 +207,30 @@ test('notification is sent to channel when configured', function (string $factor
     'discordWebhook' => ['discordWebhook', ['url' => 'https://discord.com/api/webhooks/123/abc'], DiscordWebhookChannel::class, 'discord_webhook'],
     'webhook' => ['webhook', ['url' => 'https://webhook.example.com/hook', 'secret' => 'my-secret'], WebhookChannel::class, 'webhook'],
 ]);
+
+test('a failing channel is logged and does not block the remaining channels', function () {
+    Log::spy();
+
+    NotificationChannel::factory()->email()->create(['config' => ['to' => 'first@example.com']]);
+    NotificationChannel::factory()->email()->create(['config' => ['to' => 'second@example.com']]);
+
+    // First channel's send blows up (e.g. unreachable SMTP host); the second
+    // must still be attempted and the error must not escape the service.
+    Notification::shouldReceive('send')
+        ->once()
+        ->andThrow(new \Symfony\Component\Mailer\Exception\TransportException('Connection could not be established'))
+        ->ordered();
+    Notification::shouldReceive('send')->once()->ordered();
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
+    $snapshot = notificationSnapshot($server);
+
+    app(NotificationService::class)->notifyBackupFailed($snapshot, new \Exception('Backup failed'));
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message) => $message === 'Notification send failed')
+        ->once();
+});
 
 test('send refreshes service configs from channel config before dispatching', function () {
     NotificationChannel::factory()->pushover()->create([

--- a/tests/Feature/Notifications/NotificationTest.php
+++ b/tests/Feature/Notifications/NotificationTest.php
@@ -260,6 +260,25 @@ test('send refreshes service configs from channel config before dispatching', fu
     expect($sent)->toHaveCount(3);
 });
 
+test('discord client resolves with the token from channel config', function () {
+    // The Discord provider captures services.discord.token at boot (null here,
+    // since tokens live in the DB) — without rebinding, resolving the client
+    // throws an unresolvable-dependency error.
+    NotificationChannel::factory()->discord()->create([
+        'config' => ['token' => 'discord-db-token', 'channel_id' => '123456789'],
+    ]);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
+    $snapshot = notificationSnapshot($server);
+
+    app(NotificationService::class)->notifyBackupFailed($snapshot, new \Exception('Error'));
+
+    $discord = app(\NotificationChannels\Discord\Discord::class);
+    $token = (new ReflectionProperty($discord, 'token'))->getValue($discord);
+
+    expect($token)->toBe('discord-db-token');
+});
+
 test('via method returns channels based on configured routes', function () {
     $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
     $snapshot = notificationSnapshot($server);

--- a/tests/Feature/Notifications/NotificationTest.php
+++ b/tests/Feature/Notifications/NotificationTest.php
@@ -208,6 +208,24 @@ test('notification is sent to channel when configured', function (string $factor
     'webhook' => ['webhook', ['url' => 'https://webhook.example.com/hook', 'secret' => 'my-secret'], WebhookChannel::class, 'webhook'],
 ]);
 
+test('notification dispatch errors never escape the service', function () {
+    Log::spy();
+    NotificationChannel::factory()->email()->create(['config' => ['to' => 'admin@example.com']]);
+
+    // A snapshot with no databaseServer relation (e.g. server since deleted)
+    // makes notifyServer fail before any channel send — that error must be
+    // swallowed so it cannot mark a completed job as failed or escape into
+    // scheduler/request execution.
+    $snapshot = new Snapshot(['database_name' => 'orphan_db']);
+
+    app(NotificationService::class)->notifyBackupFailed($snapshot, new \Exception('Error'));
+
+    Notification::assertNothingSent();
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message) => $message === 'Notification dispatch failed')
+        ->once();
+});
+
 test('a failing channel is logged and does not block the remaining channels', function () {
     Log::spy();
 

--- a/tests/Feature/Notifications/NotificationTest.php
+++ b/tests/Feature/Notifications/NotificationTest.php
@@ -283,11 +283,11 @@ test('token refresh drops cached channel drivers so token changes apply without 
     // The ChannelManager caches drivers per process; the service must forget
     // them when refreshing a token-based channel (Discord/Telegram/Pushover),
     // otherwise the long-running queue worker keeps clients built with the
-    // first token it saw. The facade stays faked, so binding a manager mock
-    // only intercepts the forgetDrivers call.
+    // first token it saw.
     $manager = Mockery::mock(\Illuminate\Notifications\ChannelManager::class);
     $manager->shouldReceive('forgetDrivers')->atLeast()->once();
-    app()->instance(\Illuminate\Notifications\ChannelManager::class, $manager);
+    $manager->shouldReceive('send');
+    Notification::swap($manager);
 
     NotificationChannel::factory()->discord()->create([
         'config' => ['token' => 'discord-db-token', 'channel_id' => '111'],

--- a/tests/Feature/Notifications/NotificationTest.php
+++ b/tests/Feature/Notifications/NotificationTest.php
@@ -279,6 +279,26 @@ test('discord client resolves with the token from channel config', function () {
     expect($token)->toBe('discord-db-token');
 });
 
+test('token refresh drops cached channel drivers so token changes apply without a worker restart', function () {
+    // The ChannelManager caches drivers per process; the service must forget
+    // them when refreshing a token-based channel (Discord/Telegram/Pushover),
+    // otherwise the long-running queue worker keeps clients built with the
+    // first token it saw. The facade stays faked, so binding a manager mock
+    // only intercepts the forgetDrivers call.
+    $manager = Mockery::mock(\Illuminate\Notifications\ChannelManager::class);
+    $manager->shouldReceive('forgetDrivers')->atLeast()->once();
+    app()->instance(\Illuminate\Notifications\ChannelManager::class, $manager);
+
+    NotificationChannel::factory()->discord()->create([
+        'config' => ['token' => 'discord-db-token', 'channel_id' => '111'],
+    ]);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
+    $snapshot = notificationSnapshot($server);
+
+    app(NotificationService::class)->notifyBackupFailed($snapshot, new \Exception('Error'));
+});
+
 test('via method returns channels based on configured routes', function () {
     $server = DatabaseServer::factory()->create(['database_names' => ['testdb']]);
     $snapshot = notificationSnapshot($server);


### PR DESCRIPTION
## Problem

Fixes #454. A backup got stuck in `running` indefinitely after its retries, with the queue worker throwing an SMTP `TransportException` (unreachable `postal` mail host, "Operation timed out").

## Root cause

Backup notifications are sent **synchronously inside the backups worker**, and the SMTP transport had **no timeout** (`config/mail.php` used `timeout => null`). When the mail host is unreachable, the send blocks the worker. If it blocks long enough, the job's own `job_timeout` fires and kills the worker **mid-send**, before the backup can be finalized, so the snapshot is left in `running` forever.

## Changes

- **Bound the SMTP timeout**: `config/mail.php` now uses `env('MAIL_TIMEOUT', 10)` so a dead mail host can never outlast the job. This is the direct fix.
- **Notifications can never throw to callers**: moved error handling into `NotificationService::sendToChannels` (per-channel try/catch + warning log). This replaces the duplicated caller-side try/catch in `ProcessBackupJob`, `ProcessRestoreJob` and `BackupJobFactory`, and also covers the call sites that had none (`ProcessRestoreJob::failed`, `AgentController`). Bonus: one broken channel no longer prevents delivery to the remaining channels.
- `sendToChannel` (used by the channel test feature in Configuration) still throws on purpose, so testing a channel keeps surfacing errors to the user.
- Test: a channel whose send throws is logged and does not block the remaining channels.

## Not included (follow-up)

Fully moving notifications to the background (`ShouldQueue`) would remove mail I/O from the backup worker entirely, but it needs the channel drivers reworked (Discord/Telegram/Pushover currently get credentials via global config set right before the send, which would not survive serialization). Worth a separate PR.

## Testing

`NotificationTest`, `ProcessBackupJobTest`, `ProcessRestoreJobTest`, `BackupJobFactory` suites (79 tests) pass; Pint and PHPStan clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - SMTP mailer timeout is now configurable via `MAIL_TIMEOUT` (default: 10 seconds).

- **Bug Fixes**
  - Notification sending is more resilient: failures for individual channels are logged while remaining channels are still attempted.
  - Backup/restore “success” and preflight “failure” notification errors are no longer suppressed at the job level, improving visibility of notification issues.
  - Discord token refresh now applies updated token settings without requiring a worker restart.

- **Tests**
  - Added coverage for notification dispatch error handling and Discord token resolution/refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->