### PR TITLE
refactor(database-server): extract per-type connection rules and views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,7 @@ Authorization is built on [silber/bouncer](https://github.com/JosephSilber/bounc
 - Select pattern: Use `:options` prop with array format `[['id' => 'value', 'name' => 'Label']]`
 - Alert pattern: Use `class="alert-success"`, `class="alert-error"`, etc.
 - Form components: `<x-input>`, `<x-password>`, `<x-select>`, `<x-checkbox>`, etc.
+- Translated attributes: always use `:attr` bindings (`:label="__('Host')"`), never `label="{{ __('Host') }}"` — interpolation double-encodes special characters (see "Avoiding HTML Encoding Artifacts" below)
 - Documentation: https://mary-ui.com/docs/components/button
 
 ### Resource Index Pages

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ make test-filter FILTER=DatabaseServerTest
 
 These are rare, cross-cutting tasks with a fixed file-by-file checklist each. The step-by-step playbooks live in **[`docs/development/extending.md`](docs/development/extending.md)** to keep this file focused. **Read the matching section there before starting** — each lists every file to touch (core, UI, infrastructure, tests) plus architecture gotchas:
 
-- **Adding a New Database Type** — `DatabaseInterface` + `DatabaseProvider`, dump/restore handlers, Docker/CI services, fixtures.
+- **Adding a New Database Type** — `DatabaseInterface` + `DatabaseProvider`, dump/restore handlers, a `ConnectionRules` case in `app/Livewire/Forms/Connection/` plus a `connection/{type}.blade.php` partial for the form's connection section, Docker/CI services, fixtures.
 - **Adding a New Volume Type** — `BaseConfig` connector + `FilesystemInterface`, `VolumeForm` property, Flysystem adapter, connection-test dataset. (`azure` / Azure Blob Storage is the newest worked example.)
 - **Adding a New Notification Channel** — `NotificationMessage` + `HasChannelRouting` delegation, `AppConfigService` keys, Configuration UI.
 

--- a/app/Livewire/Forms/Connection/ClientServerConnectionRules.php
+++ b/app/Livewire/Forms/Connection/ClientServerConnectionRules.php
@@ -20,7 +20,7 @@ class ClientServerConnectionRules extends ConnectionRules
         ];
     }
 
-    public function testRules(DatabaseServerForm $form): array
+    public function testConnectionRules(DatabaseServerForm $form): array
     {
         // Same fields as the full validation, but a password is required when
         // creating (an existing server can fall back to its stored password).

--- a/app/Livewire/Forms/Connection/ClientServerConnectionRules.php
+++ b/app/Livewire/Forms/Connection/ClientServerConnectionRules.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Livewire\Forms\Connection;
+
+use App\Livewire\Forms\DatabaseServerForm;
+
+/**
+ * Default rules for networked databases that authenticate with
+ * host/port/username/password (MySQL, PostgreSQL, MSSQL, Firebird, …).
+ */
+class ClientServerConnectionRules extends ConnectionRules
+{
+    public function rules(DatabaseServerForm $form): array
+    {
+        return [
+            'host' => 'required|string|max:255',
+            'port' => 'required|integer|min:1|max:65535',
+            'username' => 'required|string|max:255',
+            'password' => 'nullable',
+        ];
+    }
+
+    public function testRules(DatabaseServerForm $form): array
+    {
+        // Same fields as the full validation, but a password is required when
+        // creating (an existing server can fall back to its stored password).
+        return array_merge($this->rules($form), [
+            'password' => $form->server === null ? 'required|string|max:255' : 'nullable',
+        ]);
+    }
+}

--- a/app/Livewire/Forms/Connection/ConnectionRules.php
+++ b/app/Livewire/Forms/Connection/ConnectionRules.php
@@ -42,7 +42,7 @@ abstract class ConnectionRules
      *
      * @return array<string, mixed>
      */
-    abstract public function testRules(DatabaseServerForm $form): array;
+    abstract public function testConnectionRules(DatabaseServerForm $form): array;
 
     /**
      * Type-specific extra_config payload used for in-memory connection tests.

--- a/app/Livewire/Forms/Connection/ConnectionRules.php
+++ b/app/Livewire/Forms/Connection/ConnectionRules.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Livewire\Forms\Connection;
+
+use App\Enums\DatabaseType;
+use App\Livewire\Forms\DatabaseServerForm;
+
+/**
+ * Per-database-type connection knowledge for {@see DatabaseServerForm}:
+ * validation rules, connection-test rules, extra_config payloads and field
+ * defaults.
+ *
+ * Adding a database type means wiring its case in {@see self::for()} (a new
+ * subclass, or {@see ClientServerConnectionRules} when host/port/credentials
+ * suffice) plus a partial under
+ * resources/views/livewire/database-server/connection/{type}.blade.php.
+ */
+abstract class ConnectionRules
+{
+    public static function for(?DatabaseType $type): self
+    {
+        return match ($type) {
+            DatabaseType::MYSQL => new MysqlConnectionRules,
+            DatabaseType::POSTGRESQL => new PostgresConnectionRules,
+            DatabaseType::SQLITE => new SqliteConnectionRules,
+            DatabaseType::REDIS => new RedisConnectionRules,
+            DatabaseType::MONGODB => new MongodbConnectionRules,
+            DatabaseType::MSSQL, DatabaseType::FIREBIRD, null => new ClientServerConnectionRules,
+        };
+    }
+
+    /**
+     * Validation rules for the connection fields during full-form validation.
+     * Shared rules (SSH tunnel, base fields) stay in DatabaseServerForm.
+     *
+     * @return array<string, mixed>
+     */
+    abstract public function rules(DatabaseServerForm $form): array;
+
+    /**
+     * Validation rules for the standalone "Test Connection" action.
+     *
+     * @return array<string, mixed>
+     */
+    abstract public function testRules(DatabaseServerForm $form): array;
+
+    /**
+     * Type-specific extra_config payload used for in-memory connection tests.
+     *
+     * @return array<string, mixed>
+     */
+    public function extraConfig(DatabaseServerForm $form): array
+    {
+        return [];
+    }
+
+    /**
+     * Type-specific additions to the dump-command preview config.
+     *
+     * @return array<string, mixed>
+     */
+    public function dumpPreviewConfig(DatabaseServerForm $form): array
+    {
+        return [];
+    }
+
+    /**
+     * Field defaults applied when the user switches the form to this type.
+     */
+    public function applyDefaults(DatabaseServerForm $form): void {}
+}

--- a/app/Livewire/Forms/Connection/MongodbConnectionRules.php
+++ b/app/Livewire/Forms/Connection/MongodbConnectionRules.php
@@ -17,7 +17,7 @@ class MongodbConnectionRules extends ClientServerConnectionRules
         ]);
     }
 
-    public function testRules(DatabaseServerForm $form): array
+    public function testConnectionRules(DatabaseServerForm $form): array
     {
         return [
             'host' => 'required|string|max:255',

--- a/app/Livewire/Forms/Connection/MongodbConnectionRules.php
+++ b/app/Livewire/Forms/Connection/MongodbConnectionRules.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Livewire\Forms\Connection;
+
+use App\Livewire\Forms\DatabaseServerForm;
+
+class MongodbConnectionRules extends ClientServerConnectionRules
+{
+    public function rules(DatabaseServerForm $form): array
+    {
+        return array_merge(parent::rules($form), [
+            'port' => $this->portRule($form),
+            'username' => 'nullable|string|max:255',
+            'auth_source' => 'nullable|string|max:255',
+            'srv_enabled' => 'boolean',
+            'connection_options' => 'nullable|string|max:500',
+        ]);
+    }
+
+    public function testRules(DatabaseServerForm $form): array
+    {
+        return [
+            'host' => 'required|string|max:255',
+            'port' => $this->portRule($form),
+        ];
+    }
+
+    /**
+     * SRV connections resolve host/port from DNS, so no port is given.
+     */
+    private function portRule(DatabaseServerForm $form): string
+    {
+        return $form->srv_enabled
+            ? 'nullable|integer|min:1|max:65535'
+            : 'required|integer|min:1|max:65535';
+    }
+
+    public function extraConfig(DatabaseServerForm $form): array
+    {
+        return [
+            'auth_source' => $form->auth_source,
+            'srv_enabled' => $form->srv_enabled,
+            'connection_options' => $form->connection_options,
+        ];
+    }
+
+    public function dumpPreviewConfig(DatabaseServerForm $form): array
+    {
+        return [
+            'auth_source' => $form->auth_source ?: 'admin',
+            'srv' => $form->srv_enabled,
+            'connection_options' => $form->connection_options,
+        ];
+    }
+
+    public function applyDefaults(DatabaseServerForm $form): void
+    {
+        if ($form->auth_source === '') {
+            $form->auth_source = 'admin';
+        }
+    }
+}

--- a/app/Livewire/Forms/Connection/MysqlConnectionRules.php
+++ b/app/Livewire/Forms/Connection/MysqlConnectionRules.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Livewire\Forms\Connection;
+
+use App\Livewire\Forms\DatabaseServerForm;
+
+class MysqlConnectionRules extends ClientServerConnectionRules
+{
+    public function extraConfig(DatabaseServerForm $form): array
+    {
+        return $form->ssl_enabled ? ['ssl_enabled' => true] : [];
+    }
+
+    public function dumpPreviewConfig(DatabaseServerForm $form): array
+    {
+        return ['ssl_enabled' => $form->ssl_enabled];
+    }
+}

--- a/app/Livewire/Forms/Connection/PostgresConnectionRules.php
+++ b/app/Livewire/Forms/Connection/PostgresConnectionRules.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Livewire\Forms\Connection;
+
+use App\Livewire\Forms\DatabaseServerForm;
+
+class PostgresConnectionRules extends ClientServerConnectionRules
+{
+    public function dumpPreviewConfig(DatabaseServerForm $form): array
+    {
+        return [
+            'dump_format' => $form->dump_format,
+            'dump_privileges' => $form->dump_privileges,
+        ];
+    }
+}

--- a/app/Livewire/Forms/Connection/RedisConnectionRules.php
+++ b/app/Livewire/Forms/Connection/RedisConnectionRules.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Livewire\Forms\Connection;
+
+use App\Livewire\Forms\DatabaseServerForm;
+
+/**
+ * Redis servers may run without AUTH, so credentials are optional and the
+ * connection test only needs a reachable host/port.
+ */
+class RedisConnectionRules extends ClientServerConnectionRules
+{
+    public function rules(DatabaseServerForm $form): array
+    {
+        return array_merge(parent::rules($form), [
+            'username' => 'nullable|string|max:255',
+        ]);
+    }
+
+    public function testRules(DatabaseServerForm $form): array
+    {
+        return [
+            'host' => 'required|string|max:255',
+            'port' => 'required|integer|min:1|max:65535',
+        ];
+    }
+}

--- a/app/Livewire/Forms/Connection/RedisConnectionRules.php
+++ b/app/Livewire/Forms/Connection/RedisConnectionRules.php
@@ -17,7 +17,7 @@ class RedisConnectionRules extends ClientServerConnectionRules
         ]);
     }
 
-    public function testRules(DatabaseServerForm $form): array
+    public function testConnectionRules(DatabaseServerForm $form): array
     {
         return [
             'host' => 'required|string|max:255',

--- a/app/Livewire/Forms/Connection/SqliteConnectionRules.php
+++ b/app/Livewire/Forms/Connection/SqliteConnectionRules.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Livewire\Forms\Connection;
+
+use App\Livewire\Forms\DatabaseServerForm;
+
+/**
+ * SQLite has no host/port/credentials — databases are file paths collected on
+ * the backup cards. The connection test only validates the SSH tunnel fields
+ * (when enabled) for remote-file access; the path requirement itself is
+ * enforced generically for path-identified types in DatabaseServerForm.
+ */
+class SqliteConnectionRules extends ConnectionRules
+{
+    public function rules(DatabaseServerForm $form): array
+    {
+        return [];
+    }
+
+    public function testRules(DatabaseServerForm $form): array
+    {
+        return $form->ssh_enabled ? $form->getSshValidationRules() : [];
+    }
+}

--- a/app/Livewire/Forms/Connection/SqliteConnectionRules.php
+++ b/app/Livewire/Forms/Connection/SqliteConnectionRules.php
@@ -17,7 +17,7 @@ class SqliteConnectionRules extends ConnectionRules
         return [];
     }
 
-    public function testRules(DatabaseServerForm $form): array
+    public function testConnectionRules(DatabaseServerForm $form): array
     {
         return $form->ssh_enabled ? $form->getSshValidationRules() : [];
     }

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -1077,7 +1077,7 @@ class DatabaseServerForm extends Form
                 ]);
             }
 
-            $rules = $this->connectionRules()->testRules($this);
+            $rules = $this->connectionRules()->testConnectionRules($this);
             if ($rules !== []) {
                 $this->validate($rules);
             }

--- a/app/Livewire/Forms/DatabaseServerForm.php
+++ b/app/Livewire/Forms/DatabaseServerForm.php
@@ -6,6 +6,7 @@ use App\Enums\DatabaseType;
 use App\Enums\NotificationChannelSelection;
 use App\Enums\NotificationTrigger;
 use App\Exceptions\Backup\EncryptionException;
+use App\Livewire\Forms\Connection\ConnectionRules;
 use App\Models\Agent;
 use App\Models\Backup;
 use App\Models\BackupSchedule;
@@ -257,10 +258,15 @@ class DatabaseServerForm extends Form
             }
         }
 
-        // Pre-fill auth_source for MongoDB
-        if ($value === 'mongodb' && $this->auth_source === '') {
-            $this->auth_source = 'admin';
-        }
+        $this->connectionRules()->applyDefaults($this);
+    }
+
+    /**
+     * Per-type connection rules strategy for the currently selected type.
+     */
+    private function connectionRules(): ConnectionRules
+    {
+        return ConnectionRules::for(DatabaseType::tryFrom($this->database_type));
     }
 
     /**
@@ -627,22 +633,6 @@ class DatabaseServerForm extends Form
     }
 
     /**
-     * Check if current database type is Microsoft SQL Server.
-     */
-    public function isMssql(): bool
-    {
-        return $this->database_type === 'mssql';
-    }
-
-    /**
-     * Check if current database type is MySQL/MariaDB (the only type with the SSL toggle).
-     */
-    public function isMysql(): bool
-    {
-        return $this->database_type === 'mysql';
-    }
-
-    /**
      * Check if current database type is PostgreSQL.
      */
     public function isPostgresql(): bool
@@ -702,20 +692,7 @@ class DatabaseServerForm extends Form
             'pass' => '********',
         ];
 
-        if ($type === DatabaseType::MONGODB) {
-            $config['auth_source'] = $this->auth_source ?: 'admin';
-            $config['srv'] = $this->srv_enabled;
-            $config['connection_options'] = $this->connection_options;
-        }
-
-        if ($type === DatabaseType::MYSQL) {
-            $config['ssl_enabled'] = $this->ssl_enabled;
-        }
-
-        if ($type === DatabaseType::POSTGRESQL) {
-            $config['dump_format'] = $this->dump_format;
-            $config['dump_privileges'] = $this->dump_privileges;
-        }
+        $config = array_merge($config, $this->connectionRules()->dumpPreviewConfig($this));
 
         try {
             $provider = new DatabaseProvider;
@@ -865,14 +842,12 @@ class DatabaseServerForm extends Form
             }
         }
 
-        if ($this->isSqlite()) {
-            $rules = array_merge($rules, $this->getSqliteValidationRules());
-        } elseif ($this->isRedis()) {
-            $rules = array_merge($rules, $this->getRedisValidationRules());
-        } elseif ($this->isMongodb()) {
-            $rules = array_merge($rules, $this->getMongodbValidationRules());
-        } else {
-            $rules = array_merge($rules, $this->getClientServerValidationRules());
+        $rules = array_merge($rules, $this->connectionRules()->rules($this));
+
+        $rules['ssh_enabled'] = 'boolean';
+        if ($this->ssh_enabled) {
+            $rules['ssh_config_mode'] = 'required|string|in:existing,create';
+            $rules = array_merge($rules, $this->getSshValidationRules());
         }
 
         $validated = $this->validate($rules);
@@ -915,96 +890,6 @@ class DatabaseServerForm extends Form
             )],
             'notification_channel_ids.*' => ['string', 'exists:notification_channels,id'],
         ];
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function getSqliteValidationRules(): array
-    {
-        $rules = [
-            'ssh_enabled' => 'boolean',
-        ];
-
-        if ($this->ssh_enabled) {
-            $rules['ssh_config_mode'] = 'required|string|in:existing,create';
-            $rules = array_merge($rules, $this->getSshValidationRules());
-        }
-
-        return $rules;
-    }
-
-    /**
-     * Get client-server database validation rules.
-     *
-     * @return array<string, mixed>
-     */
-    private function getClientServerValidationRules(): array
-    {
-        $rules = [
-            'host' => 'required|string|max:255',
-            'port' => 'required|integer|min:1|max:65535',
-            'username' => 'required|string|max:255',
-            'password' => 'nullable',
-            'ssh_enabled' => 'boolean',
-        ];
-
-        if ($this->ssh_enabled) {
-            $rules['ssh_config_mode'] = 'required|string|in:existing,create';
-            $rules = array_merge($rules, $this->getSshValidationRules());
-        }
-
-        return $rules;
-    }
-
-    /**
-     * Get Redis-specific validation rules.
-     *
-     * @return array<string, mixed>
-     */
-    private function getRedisValidationRules(): array
-    {
-        $rules = [
-            'host' => 'required|string|max:255',
-            'port' => 'required|integer|min:1|max:65535',
-            'username' => 'nullable|string|max:255',
-            'password' => 'nullable',
-            'ssh_enabled' => 'boolean',
-        ];
-
-        if ($this->ssh_enabled) {
-            $rules['ssh_config_mode'] = 'required|string|in:existing,create';
-            $rules = array_merge($rules, $this->getSshValidationRules());
-        }
-
-        return $rules;
-    }
-
-    /**
-     * Get MongoDB-specific validation rules.
-     *
-     * @return array<string, mixed>
-     */
-    private function getMongodbValidationRules(): array
-    {
-        $rules = [
-            'host' => 'required|string|max:255',
-            // SRV connections resolve host/port from DNS, so no port is given.
-            'port' => $this->srv_enabled ? 'nullable|integer|min:1|max:65535' : 'required|integer|min:1|max:65535',
-            'username' => 'nullable|string|max:255',
-            'password' => 'nullable',
-            'auth_source' => 'nullable|string|max:255',
-            'srv_enabled' => 'boolean',
-            'connection_options' => 'nullable|string|max:500',
-            'ssh_enabled' => 'boolean',
-        ];
-
-        if ($this->ssh_enabled) {
-            $rules['ssh_config_mode'] = 'required|string|in:existing,create';
-            $rules = array_merge($rules, $this->getSshValidationRules());
-        }
-
-        return $rules;
     }
 
     public function store(): bool
@@ -1182,37 +1067,19 @@ class DatabaseServerForm extends Form
 
         // Validate only the connection-related fields
         try {
-            if ($this->isSqlite()) {
-                $this->normalizeDatabaseNames();
-                if ($this->collectDatabasePaths() === []) {
-                    throw ValidationException::withMessages([
-                        'form.backups' => __('Add at least one SQLite database path before testing the connection.'),
-                    ]);
-                }
-                if ($this->ssh_enabled) {
-                    $this->validate($this->getSshValidationRules());
-                }
-            } elseif ($this->hasOptionalCredentials()) {
-                $this->validate([
-                    'host' => 'required|string|max:255',
-                    'port' => 'required|integer|min:1|max:65535',
-                ]);
-            } else {
-                $this->validate([
-                    'host' => 'required|string|max:255',
-                    'port' => 'required|integer|min:1|max:65535',
-                    'username' => 'required|string|max:255',
-                    'password' => ($this->server === null ? 'required|string|max:255' : 'nullable'),
-                ]);
+            $this->normalizeDatabaseNames();
 
-                if ($this->isFirebird()) {
-                    $this->normalizeDatabaseNames();
-                    if ($this->collectDatabasePaths() === []) {
-                        throw ValidationException::withMessages([
-                            'form.backups' => __('Add at least one Firebird database path before testing the connection.'),
-                        ]);
-                    }
-                }
+            if ($this->identifiesDatabasesByPath() && $this->collectDatabasePaths() === []) {
+                throw ValidationException::withMessages([
+                    'form.backups' => __('Add at least one :type database path before testing the connection.', [
+                        'type' => DatabaseType::from($this->database_type)->label(),
+                    ]),
+                ]);
+            }
+
+            $rules = $this->connectionRules()->testRules($this);
+            if ($rules !== []) {
+                $this->validate($rules);
             }
         } catch (ValidationException $e) {
             $this->testingConnection = false;
@@ -1326,17 +1193,7 @@ class DatabaseServerForm extends Form
      */
     private function buildExtraConfigForTest(): ?array
     {
-        $extra = [];
-
-        if ($this->isMongodb()) {
-            $extra['auth_source'] = $this->auth_source;
-            $extra['srv_enabled'] = $this->srv_enabled;
-            $extra['connection_options'] = $this->connection_options;
-        }
-
-        if ($this->isMysql() && $this->ssl_enabled) {
-            $extra['ssl_enabled'] = true;
-        }
+        $extra = $this->connectionRules()->extraConfig($this);
 
         return $extra === [] ? null : $extra;
     }
@@ -1439,11 +1296,12 @@ class DatabaseServerForm extends Form
     }
 
     /**
-     * Get SSH validation rules.
+     * Get SSH validation rules. Public so per-type connection rules
+     * (e.g. SQLite over SFTP) can include them in their test rules.
      *
      * @return array<string, string>
      */
-    private function getSshValidationRules(): array
+    public function getSshValidationRules(): array
     {
         $rules = [
             'ssh_host' => 'required|string|max:255',

--- a/docs/development/extending.md
+++ b/docs/development/extending.md
@@ -17,10 +17,12 @@ All database types implement `DatabaseInterface` and are resolved via `DatabaseP
 - `app/Services/Backup/Databases/{Type}Database.php` - Create handler implementing `DatabaseInterface` (`setConfig`, `dump`, `restore`, `prepareForRestore`, `listDatabases`, `testConnection`)
 - `app/Services/Backup/Databases/DatabaseProvider.php` - Add case to `make()` and config handling in `makeForServer()`
 - `app/Services/Backup/BackupJobFactory.php` - Add snapshot creation logic if different from default (e.g., instance-level types like Redis/SQLite)
-- `app/Livewire/Forms/DatabaseServerForm.php` - Validation rules, type helpers, UI behavior
+- `app/Livewire/Forms/Connection/ConnectionRules.php` - Wire the enum case in `for()`: reuse `ClientServerConnectionRules` for host/port/credential types, or add a `{Type}ConnectionRules` subclass for type-specific rules, extra_config, dump-preview config, or field defaults
+- `app/Livewire/Forms/DatabaseServerForm.php` - Shared form behavior only (type helpers, UI behavior); per-type validation lives in the connection rules classes
 
 **UI:**
-- `resources/views/livewire/database-server/_form.blade.php` - Conditional fields for the type
+- `resources/views/livewire/database-server/connection/{type}.blade.php` - Connection fields partial, resolved by convention from the `DatabaseType` value; `@include` the shared `_client-server-fields` partial and add type-specific fields
+- `resources/views/livewire/database-server/_form.blade.php` - Only for changes outside the connection section (dump config, section gating)
 - `resources/views/livewire/database-server/restore-modal.blade.php` - If restore behavior differs
 
 **Infrastructure:**

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -106,93 +106,13 @@ use App\Enums\DatabaseType;
                     </x-radio-card-group>
                 </div>
 
-                @if($form->database_type)
+                @php $selectedType = DatabaseType::tryFrom($form->database_type); @endphp
+                @if($selectedType)
                     @include('livewire.database-server._ssh-tunnel-config', ['form' => $form, 'isEdit' => $isEdit])
 
-                    @if($form->isSqlite())
-                        {{-- SQLite file paths now live on each backup configuration below.
-                             SQLite needs no host/port/credentials here; connection testing
-                             reads the paths from the first backup card. --}}
-                    @else
-                        <!-- Client-server database connection fields -->
-                        <div class="grid gap-4 md:grid-cols-2">
-                            <x-input
-                                wire:model="form.host"
-                                label="{{ __('Host') }}"
-                                placeholder="{{ __('e.g., localhost or 192.168.1.100') }}"
-                                type="text"
-                                required
-                            />
-
-                            @unless($form->isMongodb() && $form->srv_enabled)
-                                <x-input
-                                    wire:model="form.port"
-                                    label="{{ __('Port') }}"
-                                    placeholder="{{ __('e.g., 3306') }}"
-                                    type="number"
-                                    min="1"
-                                    max="65535"
-                                    required
-                                />
-                            @endunless
-                        </div>
-
-                        <div class="grid gap-4 md:grid-cols-2">
-                            <x-input
-                                wire:model="form.username"
-                                label="{{ __('Username') }}"
-                                placeholder="{{ $form->hasOptionalCredentials() ? __('Optional (for authenticated servers)') : __('Database username') }}"
-                                type="text"
-                                :required="!$form->hasOptionalCredentials()"
-                                autocomplete="off"
-                            />
-
-                            <x-password
-                                wire:model="form.password"
-                                label="{{ __('Password') }}"
-                                placeholder="{{ $isEdit ? __('Leave blank to keep current') : __('Database password') }}"
-                                :required="!$isEdit && !$form->hasOptionalCredentials()"
-                                autocomplete="off"
-                            />
-                        </div>
-
-                        @if($form->isMongodb())
-                            <x-input
-                                wire:model.live.debounce.300ms="form.auth_source"
-                                label="{{ __('Authentication Database') }}"
-                                placeholder="admin"
-                                hint="{{ __('The database used to authenticate credentials') }}"
-                                type="text"
-                            />
-
-                            <x-checkbox
-                                wire:model.live="form.srv_enabled"
-                                :label="__('Use DNS Seed List (SRV)')"
-                                :hint="__('For MongoDB Atlas and clusters using mongodb+srv connection strings. The port is resolved from DNS.')"
-                            />
-
-                            <div>
-                                <x-input
-                                    wire:model.live.debounce.300ms="form.connection_options"
-                                    :label="__('Connection Options')"
-                                    placeholder="tls=true&replicaSet=rs0&retryWrites=true"
-                                    :hint="__('Optional. key=value parameters for the connection string — set TLS, replica set and anything else here (e.g. tls=true, replicaSet=rs0).')"
-                                    type="text"
-                                />
-                                <a href="https://www.mongodb.com/docs/manual/reference/connection-string-options/"
-                                   target="_blank" rel="noopener"
-                                   class="link link-primary text-xs">{{ __('MongoDB connection string options reference') }}</a>
-                            </div>
-                        @endif
-
-                        @if($form->isMysql())
-                            <x-checkbox
-                                wire:model.live="form.ssl_enabled"
-                                :label="__('Use SSL')"
-                                :hint="__('Required for servers that enforce TLS, such as Amazon RDS with require_secure_transport. The server certificate is not verified.')"
-                            />
-                        @endif
-                    @endif
+                    {{-- Type-specific connection fields, resolved by convention
+                         from the DatabaseType value (like volume connectors). --}}
+                    @include('livewire.database-server.connection.' . $selectedType->value, ['form' => $form, 'isEdit' => $isEdit])
 
                     @if($form->supportsDumpFlags())
                         <x-collapse class="mt-2" :open="$form->dump_config_open">

--- a/resources/views/livewire/database-server/connection/_client-server-fields.blade.php
+++ b/resources/views/livewire/database-server/connection/_client-server-fields.blade.php
@@ -1,0 +1,43 @@
+@props(['form', 'isEdit' => false, 'showPort' => true])
+
+<!-- Client-server database connection fields -->
+<div class="grid gap-4 md:grid-cols-2">
+    <x-input
+        wire:model="form.host"
+        label="{{ __('Host') }}"
+        placeholder="{{ __('e.g., localhost or 192.168.1.100') }}"
+        type="text"
+        required
+    />
+
+    @if($showPort)
+        <x-input
+            wire:model="form.port"
+            label="{{ __('Port') }}"
+            placeholder="{{ __('e.g., 3306') }}"
+            type="number"
+            min="1"
+            max="65535"
+            required
+        />
+    @endif
+</div>
+
+<div class="grid gap-4 md:grid-cols-2">
+    <x-input
+        wire:model="form.username"
+        label="{{ __('Username') }}"
+        placeholder="{{ $form->hasOptionalCredentials() ? __('Optional (for authenticated servers)') : __('Database username') }}"
+        type="text"
+        :required="!$form->hasOptionalCredentials()"
+        autocomplete="off"
+    />
+
+    <x-password
+        wire:model="form.password"
+        label="{{ __('Password') }}"
+        placeholder="{{ $isEdit ? __('Leave blank to keep current') : __('Database password') }}"
+        :required="!$isEdit && !$form->hasOptionalCredentials()"
+        autocomplete="off"
+    />
+</div>

--- a/resources/views/livewire/database-server/connection/_client-server-fields.blade.php
+++ b/resources/views/livewire/database-server/connection/_client-server-fields.blade.php
@@ -4,8 +4,8 @@
 <div class="grid gap-4 md:grid-cols-2">
     <x-input
         wire:model="form.host"
-        label="{{ __('Host') }}"
-        placeholder="{{ __('e.g., localhost or 192.168.1.100') }}"
+        :label="__('Host')"
+        :placeholder="__('e.g., localhost or 192.168.1.100')"
         type="text"
         required
     />
@@ -13,8 +13,8 @@
     @if($showPort)
         <x-input
             wire:model="form.port"
-            label="{{ __('Port') }}"
-            placeholder="{{ __('e.g., 3306') }}"
+            :label="__('Port')"
+            :placeholder="__('e.g., 3306')"
             type="number"
             min="1"
             max="65535"
@@ -26,8 +26,8 @@
 <div class="grid gap-4 md:grid-cols-2">
     <x-input
         wire:model="form.username"
-        label="{{ __('Username') }}"
-        placeholder="{{ $form->hasOptionalCredentials() ? __('Optional (for authenticated servers)') : __('Database username') }}"
+        :label="__('Username')"
+        :placeholder="$form->hasOptionalCredentials() ? __('Optional (for authenticated servers)') : __('Database username')"
         type="text"
         :required="!$form->hasOptionalCredentials()"
         autocomplete="off"
@@ -35,8 +35,8 @@
 
     <x-password
         wire:model="form.password"
-        label="{{ __('Password') }}"
-        placeholder="{{ $isEdit ? __('Leave blank to keep current') : __('Database password') }}"
+        :label="__('Password')"
+        :placeholder="$isEdit ? __('Leave blank to keep current') : __('Database password')"
         :required="!$isEdit && !$form->hasOptionalCredentials()"
         autocomplete="off"
     />

--- a/resources/views/livewire/database-server/connection/firebird.blade.php
+++ b/resources/views/livewire/database-server/connection/firebird.blade.php
@@ -1,0 +1,3 @@
+@props(['form', 'isEdit' => false])
+
+@include('livewire.database-server.connection._client-server-fields', ['form' => $form, 'isEdit' => $isEdit])

--- a/resources/views/livewire/database-server/connection/mongodb.blade.php
+++ b/resources/views/livewire/database-server/connection/mongodb.blade.php
@@ -9,9 +9,9 @@
 
 <x-input
     wire:model.live.debounce.300ms="form.auth_source"
-    label="{{ __('Authentication Database') }}"
+    :label="__('Authentication Database')"
     placeholder="admin"
-    hint="{{ __('The database used to authenticate credentials') }}"
+    :hint="__('The database used to authenticate credentials')"
     type="text"
 />
 

--- a/resources/views/livewire/database-server/connection/mongodb.blade.php
+++ b/resources/views/livewire/database-server/connection/mongodb.blade.php
@@ -1,0 +1,35 @@
+@props(['form', 'isEdit' => false])
+
+{{-- SRV connections resolve host/port from DNS, so the port field is hidden. --}}
+@include('livewire.database-server.connection._client-server-fields', [
+    'form' => $form,
+    'isEdit' => $isEdit,
+    'showPort' => ! $form->srv_enabled,
+])
+
+<x-input
+    wire:model.live.debounce.300ms="form.auth_source"
+    label="{{ __('Authentication Database') }}"
+    placeholder="admin"
+    hint="{{ __('The database used to authenticate credentials') }}"
+    type="text"
+/>
+
+<x-checkbox
+    wire:model.live="form.srv_enabled"
+    :label="__('Use DNS Seed List (SRV)')"
+    :hint="__('For MongoDB Atlas and clusters using mongodb+srv connection strings. The port is resolved from DNS.')"
+/>
+
+<div>
+    <x-input
+        wire:model.live.debounce.300ms="form.connection_options"
+        :label="__('Connection Options')"
+        placeholder="tls=true&replicaSet=rs0&retryWrites=true"
+        :hint="__('Optional. key=value parameters for the connection string — set TLS, replica set and anything else here (e.g. tls=true, replicaSet=rs0).')"
+        type="text"
+    />
+    <a href="https://www.mongodb.com/docs/manual/reference/connection-string-options/"
+       target="_blank" rel="noopener"
+       class="link link-primary text-xs">{{ __('MongoDB connection string options reference') }}</a>
+</div>

--- a/resources/views/livewire/database-server/connection/mssql.blade.php
+++ b/resources/views/livewire/database-server/connection/mssql.blade.php
@@ -1,0 +1,3 @@
+@props(['form', 'isEdit' => false])
+
+@include('livewire.database-server.connection._client-server-fields', ['form' => $form, 'isEdit' => $isEdit])

--- a/resources/views/livewire/database-server/connection/mysql.blade.php
+++ b/resources/views/livewire/database-server/connection/mysql.blade.php
@@ -1,0 +1,9 @@
+@props(['form', 'isEdit' => false])
+
+@include('livewire.database-server.connection._client-server-fields', ['form' => $form, 'isEdit' => $isEdit])
+
+<x-checkbox
+    wire:model.live="form.ssl_enabled"
+    :label="__('Use SSL')"
+    :hint="__('Required for servers that enforce TLS, such as Amazon RDS with require_secure_transport. The server certificate is not verified.')"
+/>

--- a/resources/views/livewire/database-server/connection/postgres.blade.php
+++ b/resources/views/livewire/database-server/connection/postgres.blade.php
@@ -1,0 +1,3 @@
+@props(['form', 'isEdit' => false])
+
+@include('livewire.database-server.connection._client-server-fields', ['form' => $form, 'isEdit' => $isEdit])

--- a/resources/views/livewire/database-server/connection/redis.blade.php
+++ b/resources/views/livewire/database-server/connection/redis.blade.php
@@ -1,0 +1,3 @@
+@props(['form', 'isEdit' => false])
+
+@include('livewire.database-server.connection._client-server-fields', ['form' => $form, 'isEdit' => $isEdit])

--- a/resources/views/livewire/database-server/connection/sqlite.blade.php
+++ b/resources/views/livewire/database-server/connection/sqlite.blade.php
@@ -1,0 +1,5 @@
+@props(['form', 'isEdit' => false])
+
+{{-- SQLite file paths live on each backup configuration below.
+     SQLite needs no host/port/credentials here; connection testing
+     reads the paths from the backup cards. --}}

--- a/tests/Feature/DatabaseServer/ConnectionRulesTest.php
+++ b/tests/Feature/DatabaseServer/ConnectionRulesTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use App\Enums\DatabaseType;
+use App\Livewire\Forms\Connection\ConnectionRules;
+
+test('every database type resolves connection rules and a connection partial', function () {
+    foreach (DatabaseType::cases() as $type) {
+        expect(ConnectionRules::for($type))->toBeInstanceOf(ConnectionRules::class);
+        expect(view()->exists('livewire.database-server.connection.'.$type->value))
+            ->toBeTrue("Missing connection partial for database type [{$type->value}]");
+    }
+});

--- a/tests/Integration/DatabaseConnectionTesterTest.php
+++ b/tests/Integration/DatabaseConnectionTesterTest.php
@@ -3,10 +3,11 @@
 /**
  * Integration tests for DatabaseProvider::testConnectionForServer() with real databases.
  *
- * These tests require MySQL and PostgreSQL containers to be running.
+ * These tests require the database containers (MySQL, PostgreSQL, Redis, MongoDB, MSSQL, Firebird) to be running.
  * Run with: php artisan test --group=integration
  */
 
+use App\Enums\DatabaseType;
 use App\Facades\AppConfig;
 use App\Models\DatabaseServer;
 use App\Services\Backup\Databases\DatabaseProvider;
@@ -17,13 +18,12 @@ test('connection succeeds', function (string $databaseType) {
 
     if ($databaseType === 'sqlite') {
         IntegrationTestHelpers::createTestSqliteDatabase($config['host']);
-    } elseif ($databaseType === 'redis') {
-        // Redis doesn't need test data for connection testing
-    } else {
+    } elseif (in_array($databaseType, ['mysql', 'postgres', 'firebird'], true)) {
         // Create unique database for this parallel process
         $server = IntegrationTestHelpers::createDatabaseServer($databaseType);
         IntegrationTestHelpers::loadTestData($databaseType, $server);
     }
+    // Redis, MongoDB and MSSQL test the connection at server level - no test data needed
 
     $testServer = DatabaseServer::forConnectionTest([
         'database_type' => $databaseType,
@@ -36,6 +36,7 @@ test('connection succeeds', function (string $databaseType) {
             'firebird' => [$config['database']],
             default => null,
         },
+        'extra_config' => isset($config['auth_source']) ? ['auth_source' => $config['auth_source']] : null,
     ]);
 
     $result = app(DatabaseProvider::class)->testConnectionForServer($testServer);
@@ -44,10 +45,10 @@ test('connection succeeds', function (string $databaseType) {
         ->and($result['message'])->toBe('Connection successful');
 
     // Cleanup external database
-    if ($databaseType !== 'sqlite' && $databaseType !== 'redis') {
+    if (isset($server)) {
         IntegrationTestHelpers::dropDatabase($databaseType, $server, $config['database']);
     }
-})->with(['mysql', 'postgres', 'sqlite', 'redis', 'firebird']);
+})->with(array_column(DatabaseType::cases(), 'value'));
 
 test('connection fails with invalid credentials', function (string $databaseType) {
     $config = IntegrationTestHelpers::getDatabaseConfig($databaseType);


### PR DESCRIPTION
## Summary

Splits the connection section of `DatabaseServerForm` by database type, without changing behavior.

- New `app/Livewire/Forms/Connection/` strategy classes: `ConnectionRules::for(DatabaseType)` resolves per-type validation rules, test-connection rules, extra_config payloads, dump-preview config, and field defaults. `ClientServerConnectionRules` is the shared host/port/credentials default (used directly by MSSQL and Firebird); MySQL, PostgreSQL, Redis, MongoDB, and SQLite extend or replace it.
- New `resources/views/livewire/database-server/connection/{type}.blade.php` partials, resolved by convention from the enum value (same pattern as volume connectors). A shared `_client-server-fields` partial holds the common markup; per-type partials add their extras (MongoDB SRV options, MySQL SSL toggle, etc.).
- `DatabaseServerForm` drops ~200 lines: the four per-type rule methods and the `isSqlite()/isRedis()/isMongodb()/else` chains in `formValidate()`, `testConnection()`, `buildExtraConfigForTest()`, and `getDumpCommandPreview()` are replaced with strategy delegation. SSH rule merging is hoisted to one place. Unused `isMysql()`/`isMssql()` helpers removed.
- Adding a database type now means wiring the enum case in `ConnectionRules::for()` plus one partial. A guardrail test asserts both exist for every type, and the exhaustive match means PHPStan flags an unwired case. Docs checklists (CLAUDE.md, `docs/development/extending.md`) updated.

## Behavior notes

Two intentional micro-changes, both improvements:

- The "add at least one database path" check for Firebird now runs before field validation (it already did for SQLite), so an empty Firebird form reports the missing path first. Messages are unchanged; they are now one parameterized string.
- MongoDB test-connection no longer requires `port` when SRV mode is on. The field is hidden in SRV mode and the full-form rules already made it nullable; the two rule sets are now consistent.

## Testing

- Full suite: 1323 passed (3677 assertions), plus Pint and PHPStan clean via the pre-commit hook.
- New `ConnectionRulesTest` guards the type -> strategy -> partial wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database-type-specific connection fields and validation for MySQL, MongoDB, PostgreSQL, Redis, SQLite, Firebird, and MSSQL.
  * Improved “Test Connection” handling and type-specific config/dump-preview generation based on the selected database type.
  * Updated connection UI to render shared SSH settings plus the appropriate type-specific fields.

* **Documentation**
  * Updated the “Extending Databasement” guide with clearer steps for adding new database types and Blade attribute binding guidance.

* **Tests**
  * Added coverage to ensure every database type has matching connection rules and UI partials, and expanded integration connection testing across more engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->