### PR TITLE
fix(docker): install smbclient CLI so SMB volumes have a backend

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 RUN apk add --no-cache git \
         mariadb-client mariadb-connector-c \
         postgresql18-client \
+        samba-client \
         supervisor \
         gzip zstd 7zip \
         tzdata \


### PR DESCRIPTION
The php-smbclient extension alone did not give icewind/smb a usable backend at runtime ("No valid backend available"). Add the samba-client package, which provides the smbclient binary (the Wrapped backend icewind falls back to) and the libsmbclient runtime the native extension needs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Samba client support to the application environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->