### PR TITLE
fix: show validation errors on auth forms (#481)

### DIFF
--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -14,6 +14,7 @@
 
             <x-password
                 name="password"
+                error-field="password"
                 label="{{ __('Password') }}"
                 required
                 autocomplete="current-password"

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -15,6 +15,8 @@
             <!-- Email Address -->
             <x-input
                 name="email"
+                error-field="email"
+                :value="old('email')"
                 label="{{ __('Email Address') }}"
                 type="email"
                 required

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -49,7 +49,6 @@
             <!-- Confirm Password -->
             <x-password
                 name="password_confirmation"
-                error-field="password_confirmation"
                 label="{{ __('Confirm password') }}"
                 required
                 autocomplete="new-password"

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -14,6 +14,8 @@
             <!-- Name -->
             <x-input
                 name="name"
+                error-field="name"
+                :value="old('name')"
                 label="{{ __('Name') }}"
                 type="text"
                 required
@@ -25,6 +27,8 @@
             <!-- Email Address -->
             <x-input
                 name="email"
+                error-field="email"
+                :value="old('email')"
                 label="{{ __('Email address') }}"
                 type="email"
                 required
@@ -35,6 +39,7 @@
             <!-- Password -->
             <x-password
                 name="password"
+                error-field="password"
                 label="{{ __('Password') }}"
                 required
                 autocomplete="new-password"
@@ -44,6 +49,7 @@
             <!-- Confirm Password -->
             <x-password
                 name="password_confirmation"
+                error-field="password_confirmation"
                 label="{{ __('Confirm password') }}"
                 required
                 autocomplete="new-password"

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -38,7 +38,6 @@
             <!-- Confirm Password -->
             <x-password
                 name="password_confirmation"
-                error-field="password_confirmation"
                 label="{{ __('Confirm password') }}"
                 required
                 autocomplete="new-password"

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -17,7 +17,8 @@
             <!-- Email Address -->
             <x-input
                 name="email"
-                value="{{ request('email') }}"
+                error-field="email"
+                :value="old('email', request('email'))"
                 label="{{ __('Email') }}"
                 type="email"
                 required
@@ -27,6 +28,7 @@
             <!-- Password -->
             <x-password
                 name="password"
+                error-field="password"
                 label="{{ __('Password') }}"
                 required
                 autocomplete="new-password"
@@ -36,6 +38,7 @@
             <!-- Confirm Password -->
             <x-password
                 name="password_confirmation"
+                error-field="password_confirmation"
                 label="{{ __('Confirm password') }}"
                 required
                 autocomplete="new-password"

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -53,6 +53,31 @@ test('first user can create demo backup during registration', function () {
     $this->assertAuthenticated();
 });
 
+test('registration screen renders validation errors inline for each field', function () {
+    // Guards the Mary `error-field` wiring: without it the plain-POST form
+    // silently swallows validation errors (issue #481).
+    $response = $this->from(route('register'))
+        ->followingRedirects()
+        ->post(route('register.store'), [
+            'name' => 'Jane Doe',
+            'email' => 'not-an-email',
+            'password' => 'short',
+            'password_confirmation' => 'mismatch',
+        ]);
+
+    $response->assertOk()
+        // Each field's message is rendered inline (Mary emits `text-error` divs).
+        ->assertSee('The email field must be a valid email address.')
+        ->assertSee('The password field must be at least 8 characters.')
+        ->assertSee('The password field confirmation does not match.')
+        // Non-secret fields keep their old input; passwords are never repopulated.
+        ->assertSee('value="Jane Doe"', escape: false)
+        ->assertSee('value="not-an-email"', escape: false)
+        ->assertDontSee('value="short"', escape: false);
+
+    $this->assertGuest();
+});
+
 // Registration closed after first user (blocked)
 test('registration screen returns 401 when users exist', function () {
     User::factory()->create();


### PR DESCRIPTION
## Problem

Fixes #481. Registration appeared to "do nothing": the user fills the form, clicks **Create account**, and lands back on a blank-looking register page with no message. The POST returns `302 -> /register`, which is a validation bounce (e.g. a password shorter than 8 characters), not a Docker or SQLite issue. Migrations run fine and a strong password registers successfully.

## Root cause

The plain-POST Fortify auth forms (`register`, `forgot-password`, `reset-password`, `confirm-password`) bind their inputs with `name="..."` and no `wire:model`. Mary UI keys its automatic error display off `wire:model`, so `errorFieldName()` resolves to `null`, `$errors->has(null)` is always false, and the validation errors are never rendered. `login.blade.php` avoids this because it has an explicit `@error` alert; the other forms never got one.

## Fix

- Add `error-field="..."` to each Mary input so the matching validation error renders inline under the field.
- Repopulate non-secret fields with `old()` so a bounce no longer wipes what the user typed (passwords are never repopulated).

`accept-invitation.blade.php` was already correct (it uses `wire:model`, which Mary maps automatically), so it is untouched.

## Validation

- Reproduced the original bounce, then confirmed in a real browser (fresh throwaway DB) that a weak password now shows **"The password field must be at least 8 characters."** inline under the field.
- Added a feature test that drives the real flow (bad submit -> follow redirect) and asserts each error renders inline **and** that name/email are repopulated while the password is not.
- Full suite green (1339 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved inline validation error binding for password confirmation, forgot-password email, and registration name/email/password fields.
  - Updated reset-password form to better repopulate email after validation errors.
  - Preserved previously entered non-sensitive values after failed submissions and avoided repopulating password fields.

- **Tests**
  - Added a registration feature test to verify per-field inline validation messages, retained input values, and non-repopulation of password fields after invalid submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->