### PR TITLE
fix: expose port 2226 on Docker image

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -143,6 +143,9 @@ WORKDIR /app
 
 ENV WEB_DOCUMENT_ROOT=/app/public
 ENV SERVER_NAME=":2226"
+
+# FrankenPHP listens on 2226; declare it so reverse proxies pick the right port.
+EXPOSE 2226/tcp
 ENV ENABLE_QUEUE_WORKER="false"
 ENV ENABLE_DATABASE_MIGRATION="true"
 ENV TZ="UTC"

--- a/docs/docs/self-hosting/docker-compose.md
+++ b/docs/docs/self-hosting/docker-compose.md
@@ -258,6 +258,9 @@ Open http://localhost:2226 in your browser.
 To expose your Databasement instance with HTTPS, you can use Traefik as a reverse proxy. For detailed instructions on
 how to configure Traefik with Docker, please refer to
 the [official Traefik documentation](https://doc.traefik.io/traefik/expose/docker/).
+
+The image listens on port `2226`. Because it also inherits ports from its FrankenPHP base, point Traefik at `2226`
+explicitly with `traefik.http.services.<name>.loadbalancer.server.port=2226` so it routes to the right one.
 :::
 
 ## Custom User ID (PUID/PGID)


### PR DESCRIPTION
## Summary

Fixes #484. The image declared `80/tcp`, `443/tcp`, `2019/tcp`, `443/udp` (inherited from the FrankenPHP base image) instead of `2226/tcp`, so Traefik could not detect the correct service port.

- `docker/php/Dockerfile`: add `EXPOSE 2226/tcp` next to `SERVER_NAME=":2226"` (the base image is the source of truth for the port; the app image inherits it via `FROM`).
- `docs/docs/self-hosting/docker-compose.md`: note that Traefik should be pinned to `2226` via `loadbalancer.server.port`.

## Note

`EXPOSE` is additive and cannot remove the base image's inherited ports (verified: a child image ends up advertising `2226` plus the original four). Stripping the inherited ports would require rewriting the image config after build, which this PR intentionally does not do. The docs line covers the Traefik case in the meantime.

## Testing

- Docs build passes (broken-link check).
- No PHP changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified self-hosting instructions for configuring Traefik to route traffic through port 2226.
  * Documented the application’s container port to support correct reverse-proxy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->