### PR TITLE
fix(deps): resolve shell-quote DoS (CVE-2026-13311)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -973,14 +973,14 @@
       }
     },
     "node_modules/concurrently": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.3.tgz",
-      "integrity": "sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==",
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-10.0.4.tgz",
+      "integrity": "sha512-trZql+7l/0+WRAsAnEdctr4+iiOS6ZrViI6H8QWcCF9MFS/LT0dKpe8vluB1to6it+OxSI4VospFTIFMW8DJRw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
         "rxjs": "7.8.2",
-        "shell-quote": "1.8.4",
+        "shell-quote": "1.9.0",
         "supports-color": "10.2.2",
         "tree-kill": "1.2.2",
         "yargs": "18.0.0"
@@ -1833,9 +1833,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
Resolves Dependabot alert #89.

## Problem
`shell-quote` <=1.8.4 has a quadratic-complexity DoS in `parse()` (CVE-2026-13311 / GHSA-395f-4hp3-45gv). It was pulled in transitively via `concurrently@10.0.3`, which pinned `shell-quote@1.8.4`.

## Fix
Ran `npm update concurrently` (10.0.3 -> 10.0.4), which depends on the patched `shell-quote@1.9.0`. Only `package-lock.json` changed; the existing `^10.0.3` caret range already allowed the bump, so no `package.json` edit was needed.

## Verification
`npm audit` now reports 0 vulnerabilities.

Note: `concurrently` is only used for local dev scripts, so real-world exposure was low.