### PR TITLE
feat(postgres): add SSL toggle to require TLS on connections

### DIFF
--- a/app/Livewire/DatabaseServer/Connection/PostgresConnectionRules.php
+++ b/app/Livewire/DatabaseServer/Connection/PostgresConnectionRules.php
@@ -6,11 +6,17 @@ use App\Livewire\DatabaseServer\Form;
 
 class PostgresConnectionRules extends ClientServerConnectionRules
 {
+    public function extraConfig(Form $form): array
+    {
+        return $form->ssl_enabled ? ['ssl_enabled' => true] : [];
+    }
+
     public function dumpPreviewConfig(Form $form): array
     {
         return [
             'dump_format' => $form->dump_format,
             'dump_privileges' => $form->dump_privileges,
+            'ssl_enabled' => $form->ssl_enabled,
         ];
     }
 }

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -374,7 +374,7 @@ class DatabaseServer extends Model
             ['dump_flags',          fn ($v) => $type !== DatabaseType::SQLITE->value && $v !== '' && $v !== null,  fn ($v) => $v],
             ['dump_format',         fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v === 'custom',       fn () => 'custom'],
             ['dump_privileges',     fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v,                    fn () => true],
-            ['ssl_enabled',         fn ($v) => $type === DatabaseType::MYSQL->value && $v,                         fn () => true],
+            ['ssl_enabled',         fn ($v) => in_array($type, [DatabaseType::MYSQL->value, DatabaseType::POSTGRESQL->value], true) && $v, fn () => true],
         ];
 
         foreach ($rules as [$key, $keep, $store]) {

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -107,7 +107,7 @@ class DatabaseProvider
             $dbConfig['dump_flags'] = $extra['dump_flags'];
         }
 
-        if ($config->databaseType === DatabaseType::MYSQL && ! empty($extra['ssl_enabled'])) {
+        if (in_array($config->databaseType, [DatabaseType::MYSQL, DatabaseType::POSTGRESQL], true) && ! empty($extra['ssl_enabled'])) {
             $dbConfig['ssl_enabled'] = true;
         }
 

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -60,6 +60,19 @@ class PostgresqlDatabase implements DatabaseInterface
         $this->config = $config;
     }
 
+    /**
+     * Environment prefix that forces TLS when the server is configured to use SSL.
+     *
+     * Emits `PGSSLMODE=require ` (encrypted, server certificate not verified),
+     * consumed by every libpq-based tool below (pg_dump, pg_restore, psql). An
+     * empty string leaves libpq at its default (`prefer`), which negotiates TLS
+     * opportunistically but silently falls back to plaintext.
+     */
+    private function sslEnvPrefix(): string
+    {
+        return ! empty($this->config['ssl_enabled']) ? 'PGSSLMODE=require ' : '';
+    }
+
     public function dump(string $outputPath): DatabaseOperationResult
     {
         $options = $this->withPrivilegeOptions(self::DUMP_OPTIONS);
@@ -74,7 +87,8 @@ class PostgresqlDatabase implements DatabaseInterface
 
         // Flags must come before the database name (last positional argument)
         $command = sprintf(
-            'PGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s%s %s',
+            '%sPGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s%s %s',
+            $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
             implode(' ', $options),
             escapeshellarg($this->config['host']),
@@ -93,7 +107,8 @@ class PostgresqlDatabase implements DatabaseInterface
     {
         if (($this->config['dump_format'] ?? 'plain') === 'custom') {
             return new DatabaseOperationResult(command: sprintf(
-                'PGPASSWORD=%s pg_restore %s --host=%s --port=%s --username=%s --dbname=%s %s',
+                '%sPGPASSWORD=%s pg_restore %s --host=%s --port=%s --username=%s --dbname=%s %s',
+                $this->sslEnvPrefix(),
                 escapeshellarg($this->config['pass']),
                 implode(' ', $this->withPrivilegeOptions(self::RESTORE_CUSTOM_FORMAT_OPTIONS)),
                 escapeshellarg($this->config['host']),
@@ -105,7 +120,8 @@ class PostgresqlDatabase implements DatabaseInterface
         }
 
         return new DatabaseOperationResult(command: sprintf(
-            'PGPASSWORD=%s psql --host=%s --port=%s --username=%s %s -f %s',
+            '%sPGPASSWORD=%s psql --host=%s --port=%s --username=%s %s -f %s',
+            $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
@@ -274,6 +290,11 @@ class PostgresqlDatabase implements DatabaseInterface
     {
         $dsn = sprintf('pgsql:host=%s;port=%d;dbname=%s', $this->config['host'], $this->config['port'], $database);
 
+        if (! empty($this->config['ssl_enabled'])) {
+            // Force TLS without verifying the server certificate, matching the CLI's PGSSLMODE.
+            $dsn .= ';sslmode=require';
+        }
+
         $timeout = (int) ($this->config['connect_timeout'] ?? 30);
         $dsn .= ';connect_timeout='.$timeout;
 
@@ -286,7 +307,8 @@ class PostgresqlDatabase implements DatabaseInterface
     private function getQueryCommand(string $query): string
     {
         return sprintf(
-            'PGPASSWORD=%s psql --host=%s --port=%s --user=%s %s -t -c %s',
+            '%sPGPASSWORD=%s psql --host=%s --port=%s --user=%s %s -t -c %s',
+            $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),

--- a/resources/views/livewire/database-server/connection/postgres.blade.php
+++ b/resources/views/livewire/database-server/connection/postgres.blade.php
@@ -1,3 +1,9 @@
 @props(['form', 'isEdit' => false])
 
 @include('livewire.database-server.connection._client-server-fields', ['form' => $form, 'isEdit' => $isEdit])
+
+<x-checkbox
+    wire:model.live="form.ssl_enabled"
+    :label="__('Use SSL')"
+    :hint="__('Forces TLS (sslmode=require) for servers that enforce encrypted connections, such as Neon or Amazon RDS. The server certificate is not verified.')"
+/>

--- a/tests/Feature/Models/DatabaseServerTest.php
+++ b/tests/Feature/Models/DatabaseServerTest.php
@@ -137,6 +137,9 @@ test('buildExtraConfig folds type-specific fields into extra_config', function (
     'keeps boolean flag when enabled' => [
         ['database_type' => 'mysql', 'ssl_enabled' => true], null, null, ['ssl_enabled' => true],
     ],
+    'keeps ssl_enabled for postgres' => [
+        ['database_type' => 'postgres', 'ssl_enabled' => true], null, null, ['ssl_enabled' => true],
+    ],
     'drops field not relevant to the type' => [
         ['database_type' => 'sqlite', 'dump_flags' => '--anything'], null, null, null,
     ],

--- a/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
@@ -141,6 +141,22 @@ test('makeFromConfig passes ssl_enabled from extra_config for mysql', function (
         ->not->toContain('--skip_ssl');
 });
 
+test('makeFromConfig passes ssl_enabled from extra_config for postgres', function () {
+    $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
+        databaseType: DatabaseType::POSTGRESQL,
+        serverName: 'PG Server',
+        host: 'pg.example.com',
+        port: 5432,
+        username: 'postgres',
+        password: 'secret',
+        extraConfig: ['ssl_enabled' => true],
+    );
+
+    $database = (new DatabaseProvider)->makeFromConfig($config, 'myapp', 'pg.example.com', 5432);
+
+    expect($database->dump('/tmp/test.sql')->command)->toStartWith('PGSSLMODE=require ');
+});
+
 test('makeFromConfig passes dump_privileges from extra_config for postgres', function () {
     $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
         databaseType: DatabaseType::POSTGRESQL,

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -124,6 +124,83 @@ test('restore falls back to psql when dump_format is absent', function () {
         ->and($result->command)->toContain('-f ');
 });
 
+test('dump prefixes PGSSLMODE=require when ssl_enabled is true', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'ssl_enabled' => true,
+    ]);
+
+    $result = $db->dump('/tmp/dump.sql');
+
+    expect($result->command)->toStartWith("PGSSLMODE=require PGPASSWORD='pg_secret' pg_dump ");
+});
+
+test('plain restore prefixes PGSSLMODE=require when ssl_enabled is true', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'ssl_enabled' => true,
+    ]);
+
+    $result = $db->restore('/tmp/restore.sql');
+
+    expect($result->command)->toStartWith("PGSSLMODE=require PGPASSWORD='pg_secret' psql ");
+});
+
+test('custom-format restore prefixes PGSSLMODE=require when ssl_enabled is true', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'dump_format' => 'custom',
+        'ssl_enabled' => true,
+    ]);
+
+    $result = $db->restore('/tmp/snapshot.sql');
+
+    expect($result->command)->toStartWith("PGSSLMODE=require PGPASSWORD='pg_secret' pg_restore ");
+});
+
+test('dump and restore omit PGSSLMODE when ssl_enabled is absent', function () {
+    expect($this->db->dump('/tmp/dump.sql')->command)->not->toContain('PGSSLMODE')
+        ->and($this->db->restore('/tmp/restore.sql')->command)->not->toContain('PGSSLMODE');
+});
+
+test('testConnection query command carries PGSSLMODE=require when ssl_enabled is true', function () {
+    Process::preventStrayProcesses();
+    Process::fake([
+        'PGSSLMODE=require*version*' => Process::result(output: 'PostgreSQL 16.2'),
+        'PGSSLMODE=require*ssl*' => Process::result(output: 'yes'),
+    ]);
+
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'ssl_enabled' => true,
+    ]);
+
+    $result = $db->testConnection();
+
+    expect($result['success'])->toBeTrue();
+    Process::assertRan(fn ($process) => str_starts_with($process->command, 'PGSSLMODE=require PGPASSWORD='));
+});
+
 test('listDatabases returns databases excluding managed-service internals but keeps postgres', function () {
     $pdoStatement = Mockery::mock(\PDOStatement::class);
     $pdoStatement->shouldReceive('fetchAll')


### PR DESCRIPTION
Closes #490.

## Problem

PostgreSQL servers had no SSL configuration. `createPdoForDatabase()` built a bare DSN and `getQueryCommand()` / `dump()` / `restore()` shelled out to `psql`/`pg_dump`/`pg_restore` with no `sslmode`, so every connection fell back to libpq's default (`prefer`). There was no way to *require* an encrypted connection short of the documented hack of appending `;sslmode=require` into the host field. MySQL already had an `ssl_enabled` toggle; PostgreSQL had no equivalent.

## Change

Adds a "Use SSL" checkbox to the PostgreSQL connection form, mirroring the existing MySQL `ssl_enabled` flag. When enabled:

- the PDO DSN gets `;sslmode=require` appended
- every libpq CLI command (`pg_dump`, `pg_restore`, `psql`) is prefixed with `PGSSLMODE=require`

Both force TLS without verifying the server certificate (consistent with the MySQL toggle's behaviour).

The flag is threaded through the existing plumbing: `Form` (property already existed), `DatabaseServer::buildExtraConfig()`, `PostgresConnectionRules`, and `DatabaseProvider::makeFromConfig()`.

## No regression when SSL is off

`sslEnvPrefix()` returns `''` when the flag is unset, and the DSN addition is behind an `if (! empty(...))` guard, so commands and the DSN are byte-identical to before. The config branches only broaden the existing MySQL-only paths additively; MySQL behaviour is untouched and the old host-field workaround still works.

## Note on the `"ssl": "no"` status against Neon

The reporter's own follow-up confirmed the connection is genuinely encrypted; the misleading status is a proxy artifact (`pg_stat_ssl` reflects the backend's view, and Neon terminates TLS at its proxy), which this can't flip. This change delivers the actionable part: real, explicit control to require TLS instead of relying on a hack.

## Tests

- `PostgresqlDatabaseTest`: `PGSSLMODE=require` on dump / plain restore / custom-format restore / test-connection query, plus an SSL-off guard
- `DatabaseServerTest`: `buildExtraConfig` persists `ssl_enabled` for postgres
- `DatabaseProviderTest`: pass-through for postgres

Full suite passes (1346 tests), PHPStan clean, Pint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an SSL-enabled option to PostgreSQL connection settings.
  * PostgreSQL backups, restores, connection tests, and database connections can now enforce TLS with `sslmode=require`.
  * SSL settings are preserved when configuring PostgreSQL databases.

* **Tests**
  * Added coverage for PostgreSQL SSL configuration across dumps, restores, connection testing, and connection setup.
  * Verified existing behavior remains unchanged when SSL is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->