### PR TITLE
feat(snapshots): badge each volume copy on the snapshot list

### DIFF
--- a/resources/views/components/snapshot-volume-badge.blade.php
+++ b/resources/views/components/snapshot-volume-badge.blade.php
@@ -1,0 +1,27 @@
+@props(['file'])
+
+@php
+    [$badgeClass, $tooltip] = match (true) {
+        $file->status === \App\Enums\SnapshotFileStatus::Failed => [
+            'badge-error',
+            $file->error ?: __('Upload to this volume failed'),
+        ],
+        $file->status === \App\Enums\SnapshotFileStatus::Pending => [
+            'badge-ghost opacity-60',
+            __('Upload pending'),
+        ],
+        ! $file->file_exists => [
+            'badge-warning',
+            __('Backup file not found on volume'),
+        ],
+        default => [
+            'badge-ghost',
+            $file->volume->getVolumeType()->label(),
+        ],
+    };
+@endphp
+
+<span class="badge badge-xs gap-1 cursor-help {{ $badgeClass }}" title="{{ $tooltip }}">
+    <x-volume-type-icon :type="$file->volume->type" class="w-3 h-3" />
+    {{ $file->volume->name }}
+</span>

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -54,13 +54,11 @@
                         </div>
                         <div class="flex items-center gap-2 mt-1 flex-wrap">
                             <x-id-popover :id="$snapshot->id" />
-                            @php $volumeNames = $snapshot->files->where('status', \App\Enums\SnapshotFileStatus::Completed)->pluck('volume.name')->filter(); @endphp
-                            @if($volumeNames->isNotEmpty())
-                                <span class="inline-flex items-center gap-1 text-xs text-base-content/50">
-                                    <x-icon name="o-server-stack" class="w-3 h-3" />
-                                    {{ $volumeNames->implode(', ') }}
-                                </span>
-                            @endif
+                            @foreach($snapshot->files as $file)
+                                @if($file->volume)
+                                    <x-snapshot-volume-badge :file="$file" />
+                                @endif
+                            @endforeach
                             @if($fileMissing)
                                 <x-popover>
                                     <x-slot:trigger>
@@ -204,6 +202,14 @@
             <p class="text-sm text-base-content/70">
                 {{ __('This snapshot is stored on several volumes. Choose which copy to download.') }}
             </p>
+
+            {{-- The same archive is uploaded to every volume, so the size is shown once. --}}
+            @if($this->downloadSnapshot->file_size)
+                <div class="mt-2 flex items-center gap-1 text-xs text-base-content/60">
+                    <x-icon name="o-archive-box" class="w-3.5 h-3.5" />
+                    <span class="font-mono">{{ $this->downloadSnapshot->getHumanFileSize() }}</span>
+                </div>
+            @endif
 
             <div class="mt-4 space-y-2">
                 @foreach($this->downloadSnapshot->files->where('status', \App\Enums\SnapshotFileStatus::Completed) as $file)


### PR DESCRIPTION
Follow-up polish on #478.

## Snapshot list

The row listed only the volume names of *completed* copies, as plain comma-separated text, so a volume whose upload failed was invisible. Each copy now renders its own badge with the volume-type icon (reusing `VolumeType::icon()` via the existing `x-volume-type-icon`) and a colour per state:

| state | badge | tooltip |
| --- | --- | --- |
| upload failed | red (`badge-error`) | the copy's `error`, or "Upload to this volume failed" |
| uploaded, file gone from volume | amber (`badge-warning`) | "Backup file not found on volume" |
| still uploading | muted `badge-ghost` | "Upload pending" |
| stored | `badge-ghost` | volume type label |

This is per-copy state, complementing the existing "File missing" popover badge, which fires only when *every* copy is gone and carries the last-verified timestamp.

No query change: `SnapshotQuery::RELATIONSHIPS` already eager-loads `files.volume`, so the old blade block was reading in-memory data rather than causing N+1. A SQL join was considered and rejected: it multiplies snapshot rows by their copy count, which breaks the `paginate(15)` count and page slicing.

## Download modal

The volume picker now shows the archive size. Rendered once above the list rather than per row, since the same archive is uploaded unchanged to every volume (`file_size` lives on the snapshot, not on `snapshot_files`). Hidden when there is no size, as `Formatters::humanFileSize()` renders null/0 as `0 B`.

## Checks

Pre-commit suite passed: Pint clean, PHPStan 0 errors, 1360 tests / 3822 assertions passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual badges to snapshot entries showing volume type, name, status, and backup availability.
  * Added the snapshot archive size to the download dialog when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->