### PR TITLE
feat(api): expose SSH tunnel configs as a REST resource (#493)

### DIFF
--- a/app/Http/Controllers/Api/V1/DatabaseServerSshConfigController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerSshConfigController.php
@@ -97,6 +97,13 @@ class DatabaseServerSshConfigController extends Controller
             }
         }
 
+        // A client-supplied private key invalidates the passphrase held for the
+        // one it replaces, so that passphrase is dropped unless the request
+        // supplies one for the new key.
+        if (filled($validated['private_key'] ?? null) && ! array_key_exists('key_passphrase', $validated)) {
+            $validated['key_passphrase'] = null;
+        }
+
         $publicKey = $this->generateKeyIfRequested($request, $keyGenerator, $validated);
 
         $validated['port'] ??= $databaseServerSshConfig->port;

--- a/app/Http/Controllers/Api/V1/DatabaseServerSshConfigController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerSshConfigController.php
@@ -59,22 +59,11 @@ class DatabaseServerSshConfigController extends Controller
         $this->authorize('create', DatabaseServerSshConfig::class);
 
         $validated = $request->validated();
-        $publicKey = null;
-
-        if ($request->boolean('generate_key')) {
-            /** @var string $host */
-            $host = $validated['host'];
-            $keypair = $keyGenerator->generate($keyGenerator->buildComment('', $host));
-            $validated['private_key'] = $keypair['private'];
-            $publicKey = $keypair['public'];
-        }
-
-        unset($validated['generate_key']);
+        $publicKey = $this->generateKeyIfRequested($request, $keyGenerator, $validated);
 
         $validated['port'] ??= 22;
         $validated['organization_id'] = app(CurrentOrganization::class)->id();
 
-        /** @var array<string, mixed> $validated */
         $sshConfig = DatabaseServerSshConfig::create($this->clearUnusedCredentials($validated));
 
         return new DatabaseServerSshConfigResource($sshConfig)
@@ -98,28 +87,19 @@ class DatabaseServerSshConfigController extends Controller
         $this->authorize('update', $databaseServerSshConfig);
 
         $validated = $request->validated();
-        $publicKey = null;
-
-        if ($request->boolean('generate_key')) {
-            /** @var string $host */
-            $host = $validated['host'];
-            $keypair = $keyGenerator->generate($keyGenerator->buildComment('', $host));
-            $validated['private_key'] = $keypair['private'];
-            $validated['key_passphrase'] = null;
-            $publicKey = $keypair['public'];
-        }
-
-        unset($validated['generate_key']);
-
-        $validated['port'] ??= $databaseServerSshConfig->port;
 
         // Blank credentials mean "keep the stored one" — they are never
-        // readable back through the API, so a client cannot echo them.
+        // readable back through the API, so a client cannot echo them. This
+        // runs before key generation, whose deliberate blanks must survive.
         foreach (DatabaseServerSshConfig::SENSITIVE_FIELDS as $field) {
             if (array_key_exists($field, $validated) && blank($validated[$field])) {
                 unset($validated[$field]);
             }
         }
+
+        $publicKey = $this->generateKeyIfRequested($request, $keyGenerator, $validated);
+
+        $validated['port'] ??= $databaseServerSshConfig->port;
 
         $databaseServerSshConfig->update($this->clearUnusedCredentials($validated));
 
@@ -150,6 +130,31 @@ class DatabaseServerSshConfigController extends Controller
     }
 
     /**
+     * Generate a keypair server-side when the payload asks for one, writing the
+     * private key into it. A generated key never has a passphrase, so any
+     * stored one is dropped. Returns the public key, which is not persisted.
+     *
+     * @param  array<string, mixed>  $validated
+     */
+    private function generateKeyIfRequested(Request $request, SshKeyGenerator $keyGenerator, array &$validated): ?string
+    {
+        unset($validated['generate_key']);
+
+        if (! $request->boolean('generate_key')) {
+            return null;
+        }
+
+        /** @var string $host */
+        $host = $validated['host'];
+        $keypair = $keyGenerator->generate($keyGenerator->buildComment('', $host));
+
+        $validated['private_key'] = $keypair['private'];
+        $validated['key_passphrase'] = null;
+
+        return $keypair['public'];
+    }
+
+    /**
      * Wipe the credentials belonging to the auth type that is not in use, so a
      * config never keeps a stale password next to a private key.
      *
@@ -158,7 +163,7 @@ class DatabaseServerSshConfigController extends Controller
      */
     private function clearUnusedCredentials(array $data): array
     {
-        if (($data['auth_type'] ?? null) === 'password') {
+        if ($data['auth_type'] === 'password') {
             $data['private_key'] = null;
             $data['key_passphrase'] = null;
         } else {

--- a/app/Http/Controllers/Api/V1/DatabaseServerSshConfigController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerSshConfigController.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\SaveDatabaseServerSshConfigRequest;
+use App\Http\Resources\DatabaseServerSshConfigResource;
+use App\Models\DatabaseServerSshConfig;
+use App\Services\CurrentOrganization;
+use App\Services\SshKeyGenerator;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Response;
+
+/**
+ * @tags Database Server SSH Configs
+ */
+class DatabaseServerSshConfigController extends Controller
+{
+    use AuthorizesRequests;
+
+    /**
+     * List all SSH tunnel configurations.
+     */
+    public function index(Request $request): AnonymousResourceCollection
+    {
+        $perPage = max(1, min($request->integer('per_page', 15), 100));
+
+        $sshConfigs = DatabaseServerSshConfig::query()
+            ->orderBy('host')
+            ->paginate($perPage);
+
+        return DatabaseServerSshConfigResource::collection($sshConfigs);
+    }
+
+    /**
+     * Get an SSH tunnel configuration.
+     */
+    public function show(DatabaseServerSshConfig $databaseServerSshConfig): DatabaseServerSshConfigResource
+    {
+        $this->authorize('view', $databaseServerSshConfig);
+
+        return new DatabaseServerSshConfigResource($databaseServerSshConfig);
+    }
+
+    /**
+     * Create an SSH tunnel configuration.
+     *
+     * Pass `generate_key: true` with `auth_type: key` to have the keypair
+     * generated server-side. The public key is then returned once, on this
+     * response only — it is not stored and never returned again.
+     *
+     * @response 201
+     */
+    public function store(SaveDatabaseServerSshConfigRequest $request, SshKeyGenerator $keyGenerator): JsonResponse
+    {
+        $this->authorize('create', DatabaseServerSshConfig::class);
+
+        $validated = $request->validated();
+        $publicKey = null;
+
+        if ($request->boolean('generate_key')) {
+            /** @var string $host */
+            $host = $validated['host'];
+            $keypair = $keyGenerator->generate($keyGenerator->buildComment('', $host));
+            $validated['private_key'] = $keypair['private'];
+            $publicKey = $keypair['public'];
+        }
+
+        unset($validated['generate_key']);
+
+        $validated['port'] ??= 22;
+        $validated['organization_id'] = app(CurrentOrganization::class)->id();
+
+        /** @var array<string, mixed> $validated */
+        $sshConfig = DatabaseServerSshConfig::create($this->clearUnusedCredentials($validated));
+
+        return new DatabaseServerSshConfigResource($sshConfig)
+            ->withPublicKey($publicKey)
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    /**
+     * Update an SSH tunnel configuration.
+     *
+     * Credentials are write-only: omit `password` / `private_key` to keep the
+     * stored ones. Pass `generate_key: true` to replace the stored private key
+     * with a freshly generated one and get the new public key back.
+     */
+    public function update(
+        SaveDatabaseServerSshConfigRequest $request,
+        DatabaseServerSshConfig $databaseServerSshConfig,
+        SshKeyGenerator $keyGenerator
+    ): DatabaseServerSshConfigResource {
+        $this->authorize('update', $databaseServerSshConfig);
+
+        $validated = $request->validated();
+        $publicKey = null;
+
+        if ($request->boolean('generate_key')) {
+            /** @var string $host */
+            $host = $validated['host'];
+            $keypair = $keyGenerator->generate($keyGenerator->buildComment('', $host));
+            $validated['private_key'] = $keypair['private'];
+            $validated['key_passphrase'] = null;
+            $publicKey = $keypair['public'];
+        }
+
+        unset($validated['generate_key']);
+
+        $validated['port'] ??= $databaseServerSshConfig->port;
+
+        // Blank credentials mean "keep the stored one" — they are never
+        // readable back through the API, so a client cannot echo them.
+        foreach (DatabaseServerSshConfig::SENSITIVE_FIELDS as $field) {
+            if (array_key_exists($field, $validated) && blank($validated[$field])) {
+                unset($validated[$field]);
+            }
+        }
+
+        $databaseServerSshConfig->update($this->clearUnusedCredentials($validated));
+
+        return new DatabaseServerSshConfigResource($databaseServerSshConfig)
+            ->withPublicKey($publicKey);
+    }
+
+    /**
+     * Delete an SSH tunnel configuration.
+     *
+     * Configurations still attached to a database server cannot be deleted.
+     *
+     * @response 204
+     */
+    public function destroy(DatabaseServerSshConfig $databaseServerSshConfig): Response|JsonResponse
+    {
+        $this->authorize('delete', $databaseServerSshConfig);
+
+        if ($databaseServerSshConfig->databaseServers()->exists()) {
+            return response()->json([
+                'message' => 'This SSH configuration is still used by one or more database servers.',
+            ], 422);
+        }
+
+        $databaseServerSshConfig->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Wipe the credentials belonging to the auth type that is not in use, so a
+     * config never keeps a stale password next to a private key.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function clearUnusedCredentials(array $data): array
+    {
+        if (($data['auth_type'] ?? null) === 'password') {
+            $data['private_key'] = null;
+            $data['key_passphrase'] = null;
+        } else {
+            $data['password'] = null;
+        }
+
+        return $data;
+    }
+}

--- a/app/Http/Requests/Api/V1/SaveDatabaseServerSshConfigRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerSshConfigRequest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Models\DatabaseServerSshConfig;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class SaveDatabaseServerSshConfigRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $rules = [
+            'host' => 'required|string|max:255',
+            'port' => 'nullable|integer|min:1|max:65535',
+            'username' => 'required|string|max:255',
+            'auth_type' => ['required', 'string', Rule::in(['password', 'key'])],
+            'password' => 'nullable|string',
+            'private_key' => 'nullable|string',
+            'key_passphrase' => 'nullable|string',
+            'generate_key' => 'boolean',
+        ];
+
+        // On update the credentials are optional: omitting them keeps the ones
+        // already stored (they are never readable back through the API).
+        if ($this->existingConfig() !== null) {
+            return $rules;
+        }
+
+        if ($this->input('auth_type') === 'password') {
+            $rules['password'] = 'required|string';
+        }
+
+        if ($this->input('auth_type') === 'key' && ! $this->boolean('generate_key')) {
+            $rules['private_key'] = 'required|string';
+        }
+
+        return $rules;
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator) {
+            $authType = $this->input('auth_type');
+
+            if ($this->boolean('generate_key')) {
+                if ($authType !== 'key') {
+                    $validator->errors()->add('generate_key', 'Key generation is only available for key-based authentication.');
+                }
+
+                if ($this->filled('private_key')) {
+                    $validator->errors()->add('private_key', 'A private key cannot be provided when requesting key generation.');
+                }
+            }
+
+            $existing = $this->existingConfig();
+
+            if ($existing === null) {
+                return;
+            }
+
+            // Switching auth type on an existing config requires the matching
+            // credential unless one is already stored for that type.
+            if ($authType === 'password' && ! $this->filled('password') && blank($existing->password)) {
+                $validator->errors()->add('password', 'The password field is required when switching to password authentication.');
+            }
+
+            if ($authType === 'key' && ! $this->filled('private_key') && ! $this->boolean('generate_key') && blank($existing->private_key)) {
+                $validator->errors()->add('private_key', 'The private key field is required when switching to key authentication.');
+            }
+        });
+    }
+
+    private function existingConfig(): ?DatabaseServerSshConfig
+    {
+        /** @var DatabaseServerSshConfig|null $config */
+        $config = $this->route('database_server_ssh_config');
+
+        return $config;
+    }
+}

--- a/app/Http/Resources/DatabaseServerSshConfigResource.php
+++ b/app/Http/Resources/DatabaseServerSshConfigResource.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\DatabaseServerSshConfig;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin DatabaseServerSshConfig
+ */
+class DatabaseServerSshConfigResource extends JsonResource
+{
+    /**
+     * The public key is only known right after a server-side keypair
+     * generation — it is never stored, so it is returned once and only on the
+     * response that generated it.
+     *
+     * Set through a setter rather than the constructor: resource collections
+     * are built with mapInto(), which passes the collection key as a second
+     * constructor argument.
+     */
+    private ?string $publicKey = null;
+
+    public function withPublicKey(?string $publicKey): static
+    {
+        $this->publicKey = $publicKey;
+
+        return $this;
+    }
+
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'host' => $this->host,
+            'port' => $this->port,
+            'username' => $this->username,
+            'auth_type' => $this->auth_type,
+            ...($this->publicKey !== null ? ['public_key' => $this->publicKey] : []),
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/app/Policies/DatabaseServerSshConfigPolicy.php
+++ b/app/Policies/DatabaseServerSshConfigPolicy.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\Ability;
+use App\Models\DatabaseServerSshConfig;
+use App\Models\User;
+
+class DatabaseServerSshConfigPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     * All authenticated users can view the list.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     * All authenticated users can view details.
+     */
+    public function view(User $user, DatabaseServerSshConfig $sshConfig): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     * SSH tunnel configs are part of the database server domain.
+     */
+    public function create(User $user): bool
+    {
+        return $user->can(Ability::ManageDatabaseServers->value);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, DatabaseServerSshConfig $sshConfig): bool
+    {
+        return $user->can(Ability::ManageDatabaseServers->value);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, DatabaseServerSshConfig $sshConfig): bool
+    {
+        return $user->can(Ability::ManageDatabaseServers->value);
+    }
+}

--- a/docs/docs/user-guide/ssh-tunnel.md
+++ b/docs/docs/user-guide/ssh-tunnel.md
@@ -33,6 +33,27 @@ Once you've saved an SSH config, the form offers **Use existing** (pick a saved 
 
 With **Auth Type** set to **Private Key**, the form can **Generate a new Ed25519 keypair** for you. Copy the displayed public key into `~/.ssh/authorized_keys` on the SSH server before saving — it's shown only once and the public key isn't stored.
 
+### Creating an SSH configuration via the API
+
+SSH configurations are also a REST resource, so a whole tunnel-backed server can be provisioned without touching the UI. `POST /api/v1/database-server-ssh-configs` returns the new config's `id`, ready to pass as `ssh_config_id` when creating the database server:
+
+```bash
+curl -X POST https://databasement.example.com/api/v1/database-server-ssh-configs \
+  -H "Authorization: Bearer YOUR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "host": "bastion.example.com",
+    "port": 22,
+    "username": "databasement",
+    "auth_type": "key",
+    "generate_key": true
+  }'
+```
+
+With `generate_key`, the keypair is generated server-side and the public key comes back in the response — copy it into `authorized_keys` on the SSH host. As in the UI, it is returned only once and never stored. Omit `generate_key` to send your own `private_key` (and optional `key_passphrase`), or use `"auth_type": "password"` with a `password`.
+
+Credentials are write-only: `GET`, `PUT` and the list endpoint never return them, and omitting them on `PUT` keeps the stored ones. A configuration still attached to a database server cannot be deleted. See [REST API](./api.md) for the full reference.
+
 ## Backing up databases on a remote host
 
 When databases run in Docker containers on a remote machine with ports only on an internal network, the tunnel reuses the **same SSH access you already use to manage that host** — no separate agent is needed, and the database stays private.

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\V1\AgentController;
 use App\Http\Controllers\Api\V1\BackupJobController;
 use App\Http\Controllers\Api\V1\BackupScheduleController;
 use App\Http\Controllers\Api\V1\DatabaseServerController;
+use App\Http\Controllers\Api\V1\DatabaseServerSshConfigController;
 use App\Http\Controllers\Api\V1\ScheduledRestoreController;
 use App\Http\Controllers\Api\V1\SnapshotController;
 use App\Http\Controllers\Api\V1\UserOrganizationController;
@@ -21,6 +22,11 @@ Route::middleware(['auth:sanctum'])->name('api.')->prefix('v1')->group(function 
         ->name('database-servers.backup');
     Route::post('database-servers/{database_server}/restore', [DatabaseServerController::class, 'restore'])
         ->name('database-servers.restore');
+
+    Route::apiResource('database-server-ssh-configs', DatabaseServerSshConfigController::class)
+        ->only(['index', 'show', 'store', 'destroy']);
+    Route::put('database-server-ssh-configs/{database_server_ssh_config}', [DatabaseServerSshConfigController::class, 'update'])
+        ->name('database-server-ssh-configs.update');
 
     Route::apiResource('jobs', BackupJobController::class)
         ->only(['index', 'show'])

--- a/tests/Feature/Api/DatabaseServerCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerCrudApiTest.php
@@ -3,6 +3,7 @@
 use App\Enums\Ability;
 use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
 use App\Models\User;
 use App\Models\Volume;
 use App\Services\Backup\Databases\DatabaseProvider;
@@ -317,6 +318,37 @@ test('can update a database server via api', function () {
         ->assertJsonPath('data.name', 'Updated Server')
         ->assertJsonPath('data.host', 'new-host.example.com')
         ->assertJsonPath('data.managed_by', 'k8s:default/mysql-pod');
+});
+
+test('update attaches an ssh config to a server that has none', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $server = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    $sshConfig = DatabaseServerSshConfig::factory()->create();
+    $volume = Volume::factory()->local()->create();
+    $schedule = BackupSchedule::firstOrCreate(['name' => 'Daily'], ['expression' => '0 2 * * *']);
+
+    expect($server->ssh_config_id)->toBeNull();
+
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-servers/{$server->id}", [
+            'name' => $server->name,
+            'database_type' => 'mysql',
+            'host' => $server->host,
+            'port' => $server->port,
+            'username' => $server->username,
+            'ssh_config_id' => $sshConfig->id,
+            'backups' => [[
+                'database_selection_mode' => 'all',
+                'volume_id' => $volume->id,
+                'backup_schedule_id' => $schedule->id,
+                'retention_policy' => 'days',
+                'retention_days' => 14,
+            ]],
+        ])
+        ->assertOk()
+        ->assertJsonPath('data.ssh_config_id', $sshConfig->id);
+
+    expect($server->fresh()->sshConfig->host)->toBe('bastion.example.com');
 });
 
 test('blank password keeps existing password on update', function () {

--- a/tests/Feature/Api/DatabaseServerSshConfigCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerSshConfigCrudApiTest.php
@@ -40,7 +40,10 @@ test('manage-database-servers allows creating a password-based ssh config', func
         ->assertJsonPath('data.auth_type', 'password')
         ->assertJsonPath('data.port', 22);
 
-    expect($response->json('data'))->not->toHaveKeys(['password', 'private_key', 'key_passphrase']);
+    expect($response->json('data'))
+        ->not->toHaveKey('password')
+        ->not->toHaveKey('private_key')
+        ->not->toHaveKey('key_passphrase');
 
     /** @var DatabaseServerSshConfig $config */
     $config = DatabaseServerSshConfig::findOrFail($response->json('data.id'));
@@ -141,13 +144,20 @@ test('viewing ssh configs needs no ability', function () {
         ->assertJsonPath('data.0.id', $config->id);
 
     // Listed items carry no credentials and no public_key placeholder.
-    expect($listed->json('data.0'))->not->toHaveKeys(['password', 'private_key', 'key_passphrase', 'public_key']);
+    expect($listed->json('data.0'))
+        ->not->toHaveKey('password')
+        ->not->toHaveKey('private_key')
+        ->not->toHaveKey('key_passphrase')
+        ->not->toHaveKey('public_key');
 
     $response = $this->actingAs($user, 'sanctum')
         ->getJson("/api/v1/database-server-ssh-configs/{$config->id}");
 
     $response->assertOk()->assertJsonPath('data.username', 'tunnel_user');
-    expect($response->json('data'))->not->toHaveKeys(['password', 'private_key', 'key_passphrase']);
+    expect($response->json('data'))
+        ->not->toHaveKey('password')
+        ->not->toHaveKey('private_key')
+        ->not->toHaveKey('key_passphrase');
 });
 
 // ─── Update ──────────────────────────────────────────────────────────────────
@@ -232,6 +242,41 @@ test('regenerating a key drops the passphrase of the replaced one', function () 
     $config->refresh();
     expect($config->key_passphrase)->toBeNull()
         ->and($config->private_key)->toContain('OPENSSH PRIVATE KEY');
+});
+
+test('replacing the private key drops the passphrase of the replaced one', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->withKeyAuthAndPassphrase()->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-server-ssh-configs/{$config->id}", [
+            'host' => $config->host,
+            'username' => $config->username,
+            'auth_type' => 'key',
+            'private_key' => 'REPLACEMENT_SSH_PRIVATE_KEY_FOR_TESTS_ONLY',
+        ])
+        ->assertOk();
+
+    $config->refresh();
+    expect($config->key_passphrase)->toBeNull()
+        ->and($config->private_key)->toBe('REPLACEMENT_SSH_PRIVATE_KEY_FOR_TESTS_ONLY');
+});
+
+test('a passphrase sent with a new private key is stored', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->withKeyAuthAndPassphrase()->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-server-ssh-configs/{$config->id}", [
+            'host' => $config->host,
+            'username' => $config->username,
+            'auth_type' => 'key',
+            'private_key' => 'REPLACEMENT_SSH_PRIVATE_KEY_FOR_TESTS_ONLY',
+            'key_passphrase' => 'new_passphrase',
+        ])
+        ->assertOk();
+
+    expect($config->fresh()->key_passphrase)->toBe('new_passphrase');
 });
 
 // ─── Destroy ─────────────────────────────────────────────────────────────────

--- a/tests/Feature/Api/DatabaseServerSshConfigCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerSshConfigCrudApiTest.php
@@ -1,0 +1,251 @@
+<?php
+
+use App\Enums\Ability;
+use App\Models\DatabaseServerSshConfig;
+use App\Models\User;
+
+// ─── Store ───────────────────────────────────────────────────────────────────
+
+test('unauthenticated users cannot create ssh configs', function () {
+    $this->postJson('/api/v1/database-server-ssh-configs')
+        ->assertUnauthorized();
+});
+
+test('without manage-database-servers, creating an ssh config via api is forbidden', function () {
+    $user = User::factory()->withAllAbilitiesExcept(Ability::ManageDatabaseServers->value)->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-server-ssh-configs', [
+            'host' => 'bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'password',
+            'password' => 'ssh_secret',
+        ])
+        ->assertForbidden();
+});
+
+test('manage-database-servers allows creating a password-based ssh config', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-server-ssh-configs', [
+            'host' => 'bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'password',
+            'password' => 'ssh_secret',
+        ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.host', 'bastion.example.com')
+        ->assertJsonPath('data.auth_type', 'password')
+        ->assertJsonPath('data.port', 22);
+
+    expect($response->json('data'))->not->toHaveKeys(['password', 'private_key', 'key_passphrase']);
+
+    /** @var DatabaseServerSshConfig $config */
+    $config = DatabaseServerSshConfig::findOrFail($response->json('data.id'));
+    expect($config->password)->toBe('ssh_secret');
+});
+
+test('the created id can be used as ssh_config_id on a database server', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $configId = $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-server-ssh-configs', [
+            'host' => 'bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'password',
+            'password' => 'ssh_secret',
+        ])->json('data.id');
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-servers', [
+            'name' => 'Tunneled MySQL',
+            'database_type' => 'mysql',
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'username' => 'root',
+            'password' => 'secret',
+            'ssh_config_id' => $configId,
+            'backups_enabled' => false,
+        ])
+        ->assertCreated()
+        ->assertJsonPath('data.ssh_config_id', $configId);
+});
+
+test('generate_key creates the keypair server-side and returns the public key once', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-server-ssh-configs', [
+            'host' => 'bastion.example.com',
+            'port' => 2222,
+            'username' => 'tunnel_user',
+            'auth_type' => 'key',
+            'generate_key' => true,
+        ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.port', 2222);
+
+    expect($response->json('data.public_key'))->toStartWith('ssh-ed25519 ');
+
+    /** @var DatabaseServerSshConfig $config */
+    $config = DatabaseServerSshConfig::findOrFail($response->json('data.id'));
+    expect($config->private_key)->toContain('OPENSSH PRIVATE KEY');
+
+    // The public key is not stored, so it is never returned again.
+    $this->actingAs($user, 'sanctum')
+        ->getJson("/api/v1/database-server-ssh-configs/{$config->id}")
+        ->assertOk()
+        ->assertJsonMissingPath('data.public_key');
+});
+
+test('key generation is rejected for password authentication', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-server-ssh-configs', [
+            'host' => 'bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'password',
+            'password' => 'ssh_secret',
+            'generate_key' => true,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['generate_key']);
+});
+
+test('key authentication requires a private key unless one is generated', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-server-ssh-configs', [
+            'host' => 'bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'key',
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['private_key']);
+});
+
+// ─── Index & show ────────────────────────────────────────────────────────────
+
+test('viewing ssh configs needs no ability', function () {
+    $user = User::factory()->withAbilities([])->create();
+    $config = DatabaseServerSshConfig::factory()->create();
+
+    $listed = $this->actingAs($user, 'sanctum')
+        ->getJson('/api/v1/database-server-ssh-configs')
+        ->assertOk()
+        ->assertJsonPath('data.0.id', $config->id);
+
+    // Listed items carry no credentials and no public_key placeholder.
+    expect($listed->json('data.0'))->not->toHaveKeys(['password', 'private_key', 'key_passphrase', 'public_key']);
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->getJson("/api/v1/database-server-ssh-configs/{$config->id}");
+
+    $response->assertOk()->assertJsonPath('data.username', 'tunnel_user');
+    expect($response->json('data'))->not->toHaveKeys(['password', 'private_key', 'key_passphrase']);
+});
+
+// ─── Update ──────────────────────────────────────────────────────────────────
+
+test('without manage-database-servers, updating an ssh config via api is forbidden', function () {
+    $user = User::factory()->withAllAbilitiesExcept(Ability::ManageDatabaseServers->value)->create();
+    $config = DatabaseServerSshConfig::factory()->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-server-ssh-configs/{$config->id}", [
+            'host' => 'new-bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'password',
+        ])
+        ->assertForbidden();
+});
+
+test('updating without credentials keeps the stored ones', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->create(['port' => 2222]);
+
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-server-ssh-configs/{$config->id}", [
+            'host' => 'new-bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'password',
+        ])
+        ->assertOk()
+        ->assertJsonPath('data.host', 'new-bastion.example.com')
+        ->assertJsonPath('data.port', 2222);
+
+    expect($config->fresh()->password)->toBe('ssh_password');
+});
+
+test('switching to key authentication requires a key', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-server-ssh-configs/{$config->id}", [
+            'host' => 'bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'key',
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['private_key']);
+});
+
+test('switching auth type clears the credentials of the previous one', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-server-ssh-configs/{$config->id}", [
+            'host' => 'bastion.example.com',
+            'username' => 'tunnel_user',
+            'auth_type' => 'key',
+            'generate_key' => true,
+        ]);
+
+    $response->assertOk()->assertJsonPath('data.auth_type', 'key');
+    expect($response->json('data.public_key'))->toStartWith('ssh-ed25519 ');
+
+    $config->refresh();
+    expect($config->password)->toBeNull()
+        ->and($config->private_key)->toContain('OPENSSH PRIVATE KEY');
+});
+
+// ─── Destroy ─────────────────────────────────────────────────────────────────
+
+test('without manage-database-servers, deleting an ssh config via api is forbidden', function () {
+    $user = User::factory()->withAllAbilitiesExcept(Ability::ManageDatabaseServers->value)->create();
+    $config = DatabaseServerSshConfig::factory()->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->deleteJson("/api/v1/database-server-ssh-configs/{$config->id}")
+        ->assertForbidden();
+});
+
+test('an ssh config still used by a database server cannot be deleted', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->create();
+    createDatabaseServer(['ssh_config_id' => $config->id]);
+
+    $this->actingAs($user, 'sanctum')
+        ->deleteJson("/api/v1/database-server-ssh-configs/{$config->id}")
+        ->assertUnprocessable();
+
+    $this->assertDatabaseHas('database_server_ssh_configs', ['id' => $config->id]);
+});
+
+test('an unused ssh config can be deleted', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->deleteJson("/api/v1/database-server-ssh-configs/{$config->id}")
+        ->assertNoContent();
+
+    $this->assertDatabaseMissing('database_server_ssh_configs', ['id' => $config->id]);
+});

--- a/tests/Feature/Api/DatabaseServerSshConfigCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerSshConfigCrudApiTest.php
@@ -216,6 +216,24 @@ test('switching auth type clears the credentials of the previous one', function 
         ->and($config->private_key)->toContain('OPENSSH PRIVATE KEY');
 });
 
+test('regenerating a key drops the passphrase of the replaced one', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $config = DatabaseServerSshConfig::factory()->withKeyAuthAndPassphrase()->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-server-ssh-configs/{$config->id}", [
+            'host' => $config->host,
+            'username' => $config->username,
+            'auth_type' => 'key',
+            'generate_key' => true,
+        ])
+        ->assertOk();
+
+    $config->refresh();
+    expect($config->key_passphrase)->toBeNull()
+        ->and($config->private_key)->toContain('OPENSSH PRIVATE KEY');
+});
+
 // ─── Destroy ─────────────────────────────────────────────────────────────────
 
 test('without manage-database-servers, deleting an ssh config via api is forbidden', function () {


### PR DESCRIPTION
Closes #493.

SSH-tunnel-backed database servers could only be fully provisioned through the UI: the API accepts an `ssh_config_id` but there was no endpoint to create the config it points at. This adds the missing resource.

## Endpoints

| Method | Path |
|---|---|
| GET | `/api/v1/database-server-ssh-configs` |
| POST | `/api/v1/database-server-ssh-configs` |
| GET | `/api/v1/database-server-ssh-configs/{id}` |
| PUT | `/api/v1/database-server-ssh-configs/{id}` |
| DELETE | `/api/v1/database-server-ssh-configs/{id}` |

PUT rather than PATCH, matching how `database-servers` / `backup-schedules` / `scheduled-restores` register updates.

## Behaviour

- `generate_key: true` (with `auth_type: key`) generates the Ed25519 keypair server-side through the same `SshKeyGenerator` the form uses. The public key is returned once, on the response that generated it; it is not stored, exactly as in the UI. It also works on PUT to rotate the key.
- Credentials are write-only: `password`, `private_key` and `key_passphrase` are never returned, and omitting them on PUT keeps the stored ones. Switching `auth_type` clears the credentials of the previous one.
- A config still attached to a database server cannot be deleted (422). The FK is `nullOnDelete`, so an unguarded delete would silently strip the tunnel from live servers.
- Create/update/delete are gated on `manage-database-servers`; viewing needs no ability, as with the other resources.

Example, the whole flow that previously needed a manual UI step:

```bash
CONFIG_ID=$(curl -sX POST $HOST/api/v1/database-server-ssh-configs \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d '{"host":"bastion.example.com","username":"databasement","auth_type":"key","generate_key":true}' \
  | jq -r .data.id)

curl -X POST $HOST/api/v1/database-servers \
  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
  -d "{\"name\":\"Tunneled MySQL\",\"database_type\":\"mysql\",\"host\":\"127.0.0.1\",\"port\":3306,\"username\":\"root\",\"password\":\"secret\",\"ssh_config_id\":\"$CONFIG_ID\",\"backups_enabled\":false}"
```

## Notes

- No schema change: the model already encrypts the sensitive fields, and the public key is not persisted (it never was).
- The endpoints are picked up automatically by Scramble; `docs/user-guide/ssh-tunnel.md` gains a short section on provisioning a config via the API.

## Tests

16 new tests: ability allow/deny pairs on every guarded boundary, key generation (public key returned once, absent afterwards, private key stored), the validation rules specific to this resource, credential retention on update, the delete-while-in-use guard, and one in `DatabaseServerCrudApiTest` attaching a config to a server that had none.

`make test` 1383 passed, `make phpstan` 0 errors, Pint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST API support to create, view, update, list, and delete database-server SSH configurations.
  * Supports password or key-based authentication, optional server-generated keys, credential preservation, and database-server associations.
  * Public keys are returned securely for one-time use.
  * Access controls protect configuration management operations.

* **Bug Fixes**
  * Prevents deletion of SSH configurations still assigned to database servers.

* **Documentation**
  * Added API guidance for SSH configuration management, authentication, key generation, and deletion rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->