### PR TITLE
perf(logs): bound job log capture, storage and rendering

### DIFF
--- a/app/Livewire/Dashboard/LatestJobs.php
+++ b/app/Livewire/Dashboard/LatestJobs.php
@@ -80,6 +80,7 @@ class LatestJobs extends Component
     public function fetchJobs(): void
     {
         $query = BackupJob::forCurrentOrg()
+            ->withoutLogs()
             ->with([
                 'snapshot.databaseServer',
                 'restore.targetServer',

--- a/app/Models/BackupJob.php
+++ b/app/Models/BackupJob.php
@@ -19,6 +19,24 @@ class BackupJob extends Model implements BackupLogger
 {
     use HasUlids;
 
+    /**
+     * Columns a listing needs, excluding the potentially huge `logs` and
+     * `error_trace` payloads.
+     *
+     * @var array<int, string>
+     */
+    private const SUMMARY_COLUMNS = [
+        'id',
+        'job_id',
+        'status',
+        'started_at',
+        'completed_at',
+        'duration_ms',
+        'error_message',
+        'created_at',
+        'updated_at',
+    ];
+
     protected $fillable = [
         'job_id',
         'status',
@@ -61,6 +79,22 @@ class BackupJob extends Model implements BackupLogger
                         ->whereRaw('organization_id = ?', [$orgId]);
                 });
         });
+    }
+
+    /**
+     * Scope for listings: selects everything needed to render a job row except the
+     * `logs` JSON blob, which can reach megabytes on a chatty command and would
+     * otherwise be fetched and decoded for every row on the page.
+     *
+     * Jobs loaded through this scope must not be used to read logs — the logs
+     * modal re-fetches the job in full.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeWithoutLogs(Builder $query): Builder
+    {
+        return $query->select(self::SUMMARY_COLUMNS);
     }
 
     /**

--- a/app/Queries/RestoreQuery.php
+++ b/app/Queries/RestoreQuery.php
@@ -9,18 +9,27 @@ use Illuminate\Database\Eloquent\Builder;
 
 class RestoreQuery
 {
-    private const RELATIONSHIPS = [
-        'snapshot.databaseServer',
-        'targetServer',
-        'triggeredBy',
-        'scheduledRestore',
-        'job',
-    ];
-
     private const ALLOWED_SORT_COLUMNS = [
         'created_at',
         'status',
     ];
+
+    /**
+     * `job` is loaded without its `logs` blob: the listing only needs the status.
+     * The logs modal re-fetches the job in full.
+     *
+     * @return array<int|string, mixed>
+     */
+    private static function relationships(): array
+    {
+        return [
+            'snapshot.databaseServer',
+            'targetServer',
+            'triggeredBy',
+            'scheduledRestore',
+            'job' => fn ($query) => $query->withoutLogs(),
+        ];
+    }
 
     /**
      * Build query from manual parameters (for Livewire).
@@ -39,7 +48,7 @@ class RestoreQuery
         // The DatabaseServer model has an OrganizationScope global scope, so
         // whereHas('targetServer') automatically filters to the current org.
         $query = Restore::query()
-            ->with(self::RELATIONSHIPS)
+            ->with(self::relationships())
             ->whereHas('targetServer');
 
         $query

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -12,14 +12,6 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class SnapshotQuery
 {
-    private const RELATIONSHIPS = [
-        'databaseServer',
-        'backup',
-        'files.volume',
-        'triggeredBy',
-        'job',
-    ];
-
     private const ALLOWED_SORT_COLUMNS = [
         'started_at',
         'created_at',
@@ -29,12 +21,29 @@ class SnapshotQuery
     ];
 
     /**
+     * `job` is loaded without its `logs` blob: the listing only needs the status.
+     * The logs modal re-fetches the job in full.
+     *
+     * @return array<int|string, mixed>
+     */
+    private static function relationships(): array
+    {
+        return [
+            'databaseServer',
+            'backup',
+            'files.volume',
+            'triggeredBy',
+            'job' => fn ($query) => $query->withoutLogs(),
+        ];
+    }
+
+    /**
      * @return QueryBuilder<Snapshot>
      */
     public static function make(): QueryBuilder
     {
         return QueryBuilder::for(Snapshot::class)
-            ->with(self::RELATIONSHIPS)
+            ->with(self::relationships())
             ->allowedFilters(
                 AllowedFilter::exact('database_server_id'),
                 AllowedFilter::partial('database_name'),
@@ -71,7 +80,7 @@ class SnapshotQuery
         string $sortDirection = 'desc'
     ): Builder {
         $query = Snapshot::query()
-            ->with(self::RELATIONSHIPS);
+            ->with(self::relationships());
 
         $query->forCurrentOrg();
 

--- a/app/Services/Backup/OutputBuffer.php
+++ b/app/Services/Backup/OutputBuffer.php
@@ -108,9 +108,14 @@ class OutputBuffer
         $lastBreak = strrpos($chunk, "\n");
 
         if ($lastBreak === false) {
-            $this->head .= $chunk;
+            // A byte-sized cut can land inside a multi-byte character. Carry the
+            // partial trailing sequence over instead of dropping it, so the head
+            // stays valid UTF-8 on its own and the tail still starts on a lead
+            // byte. Nothing is discarded here, so the counters are untouched.
+            $complete = $this->dropTrailingPartialUtf8($chunk);
+            $this->head .= $complete;
 
-            return $rest;
+            return substr($chunk, strlen($complete)).$rest;
         }
 
         $this->head .= substr($chunk, 0, $lastBreak + 1);
@@ -135,8 +140,26 @@ class OutputBuffer
         $boundary = strpos($this->tail, "\n", $overflow);
         $cut = $boundary === false ? $overflow : $boundary + 1;
 
-        $this->droppedBytes += $cut;
+        $kept = substr($this->tail, $cut);
+
+        // A byte cut can land inside a multi-byte character. Drop the orphaned
+        // continuation bytes so the retained tail stays valid UTF-8.
+        $kept = preg_replace('/^[\x80-\xBF]+/', '', $kept) ?? $kept;
+
+        // Counted from what was actually discarded, orphans included. Continuation
+        // bytes are never 0x0A, so the line count is unaffected by that trim.
+        $this->droppedBytes += strlen($this->tail) - strlen($kept);
         $this->droppedLines += substr_count(substr($this->tail, 0, $cut), "\n");
-        $this->tail = substr($this->tail, $cut);
+        $this->tail = $kept;
+    }
+
+    /**
+     * Remove an incomplete multi-byte sequence at the end of a slice.
+     */
+    private function dropTrailingPartialUtf8(string $value): string
+    {
+        $pattern = '/(?:[\xC0-\xDF]|[\xE0-\xEF][\x80-\xBF]?|[\xF0-\xF7][\x80-\xBF]{0,2})\z/';
+
+        return preg_replace($pattern, '', $value) ?? $value;
     }
 }

--- a/app/Services/Backup/OutputBuffer.php
+++ b/app/Services/Backup/OutputBuffer.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Services\Backup;
+
+use App\Support\Formatters;
+
+/**
+ * Bounded accumulator for captured command output.
+ *
+ * Keeps the first and last slice of a stream and counts what fell in between, so
+ * a chatty command (e.g. a pg_dump emitting thousands of identical warnings)
+ * cannot grow a job log without bound. Cuts are aligned to line boundaries
+ * whenever possible so that a truncated line is never half-rendered, and so
+ * ShellProcessor::sanitize() keeps seeing whole lines when redacting secrets.
+ */
+class OutputBuffer
+{
+    private string $head = '';
+
+    private bool $headSealed = false;
+
+    private string $tail = '';
+
+    private int $droppedBytes = 0;
+
+    private int $droppedLines = 0;
+
+    public function __construct(
+        private readonly int $headBytes = 16384,
+        private readonly int $tailBytes = 16384,
+    ) {}
+
+    public function append(string $data): void
+    {
+        if (! $this->headSealed) {
+            $data = $this->fillHead($data);
+        }
+
+        if ($data === '') {
+            return;
+        }
+
+        $this->tail .= $data;
+        $this->trimTail();
+    }
+
+    public function isTruncated(): bool
+    {
+        return $this->droppedBytes > 0;
+    }
+
+    public function toString(): string
+    {
+        $marker = $this->marker();
+
+        if ($marker === null) {
+            return $this->head.$this->tail;
+        }
+
+        return rtrim($this->head, "\n")."\n".$marker."\n".ltrim($this->tail, "\n");
+    }
+
+    /**
+     * The line standing in for the omitted middle, or null if nothing was dropped.
+     *
+     * Public so a caller rendering the buffer line by line can tell the marker
+     * apart from real output and style it differently.
+     *
+     * Not translated on purpose: this is log content, written by a queue worker
+     * whose locale is unrelated to whoever later reads the log.
+     */
+    public function marker(): ?string
+    {
+        if (! $this->isTruncated()) {
+            return null;
+        }
+
+        $omitted = Formatters::humanFileSize($this->droppedBytes);
+
+        if ($this->droppedLines > 0) {
+            $omitted = number_format($this->droppedLines).' lines, '.$omitted;
+        }
+
+        return "[... {$omitted} of output omitted ...]";
+    }
+
+    /**
+     * Fill the head budget, returning whatever did not fit.
+     *
+     * Once full, the head is sealed on its last complete line so that no line is
+     * split in half; the partial line it would have ended on is handed back to be
+     * carried into the tail rather than dropped.
+     */
+    private function fillHead(string $data): string
+    {
+        $room = $this->headBytes - strlen($this->head);
+
+        if (strlen($data) <= $room) {
+            $this->head .= $data;
+
+            return '';
+        }
+
+        $chunk = substr($data, 0, $room);
+        $rest = substr($data, $room);
+        $this->headSealed = true;
+
+        $lastBreak = strrpos($chunk, "\n");
+
+        if ($lastBreak === false) {
+            $this->head .= $chunk;
+
+            return $rest;
+        }
+
+        $this->head .= substr($chunk, 0, $lastBreak + 1);
+
+        return substr($chunk, $lastBreak + 1).$rest;
+    }
+
+    /**
+     * Drop the oldest bytes once the tail outgrows its budget.
+     */
+    private function trimTail(): void
+    {
+        $overflow = strlen($this->tail) - $this->tailBytes;
+
+        if ($overflow <= 0) {
+            return;
+        }
+
+        // Cut at the next line boundary so the tail starts on a whole line. Output
+        // with no newline in the whole budget (not line-oriented) falls back to a
+        // plain byte cut, which keeps the most recent bytes rather than none.
+        $boundary = strpos($this->tail, "\n", $overflow);
+        $cut = $boundary === false ? $overflow : $boundary + 1;
+
+        $this->droppedBytes += $cut;
+        $this->droppedLines += substr_count(substr($this->tail, 0, $cut), "\n");
+        $this->tail = substr($this->tail, $cut);
+    }
+}

--- a/app/Services/Backup/ShellProcessor.php
+++ b/app/Services/Backup/ShellProcessor.php
@@ -50,9 +50,11 @@ class ShellProcessor
         // Start the command log entry before execution
         $logIndex = $this->logger?->startCommandLog($sanitizedCommand);
 
-        // Run with output callback for incremental updates. The buffer is bounded,
-        // so neither the in-memory copy nor the stored log grows with a command
-        // that emits an unbounded number of warnings.
+        // Run with output callback for incremental updates. The buffer bounds what
+        // reaches the stored log, so a command emitting an unbounded number of
+        // warnings cannot grow the job's `logs` blob. It does not bound memory:
+        // Process keeps the full output internally for getOutput()/getErrorOutput()
+        // below, so a huge stream still accumulates for the command's lifetime.
         $incrementalOutput = $this->newOutputBuffer();
         $lastFlush = 0.0;
 

--- a/app/Services/Backup/ShellProcessor.php
+++ b/app/Services/Backup/ShellProcessor.php
@@ -11,6 +11,21 @@ class ShellProcessor
 {
     private ?BackupLogger $logger = null;
 
+    /**
+     * The flush interval matters as much as the output budget: every incremental
+     * write re-serializes the job's whole `logs` JSON blob, so flushing once per
+     * output chunk makes a chatty command quadratic in database writes.
+     *
+     * @param  int  $outputHeadBytes  Leading slice of a command's output to keep.
+     * @param  int  $outputTailBytes  Trailing slice of a command's output to keep.
+     * @param  float  $flushIntervalSeconds  Minimum delay between incremental log writes.
+     */
+    public function __construct(
+        private readonly int $outputHeadBytes = 16384,
+        private readonly int $outputTailBytes = 16384,
+        private readonly float $flushIntervalSeconds = 1.0,
+    ) {}
+
     public function setLogger(BackupLogger $logger): void
     {
         $this->logger = $logger;
@@ -35,18 +50,33 @@ class ShellProcessor
         // Start the command log entry before execution
         $logIndex = $this->logger?->startCommandLog($sanitizedCommand);
 
-        // Run with output callback for incremental updates
-        $incrementalOutput = '';
-        $process->run(function ($type, $data) use (&$incrementalOutput, $logIndex, $startTime) {
-            $incrementalOutput .= $data;
+        // Run with output callback for incremental updates. The buffer is bounded,
+        // so neither the in-memory copy nor the stored log grows with a command
+        // that emits an unbounded number of warnings.
+        $incrementalOutput = $this->newOutputBuffer();
+        $lastFlush = 0.0;
 
-            // Update the log entry with incremental output (sanitized)
-            if ($this->logger && $logIndex !== null) {
-                $this->logger->updateCommandLog($logIndex, [
-                    'output' => $this->sanitize(trim($incrementalOutput)),
-                    'duration_ms' => round((microtime(true) - $startTime) * 1000, 2),
-                ]);
+        $process->run(function ($type, $data) use ($incrementalOutput, &$lastFlush, $logIndex, $startTime) {
+            $incrementalOutput->append($data);
+
+            if (! $this->logger || $logIndex === null) {
+                return;
             }
+
+            // Throttle incremental updates; the final write below always runs, so
+            // nothing is lost by skipping a flush here.
+            $now = microtime(true);
+
+            if ($now - $lastFlush < $this->flushIntervalSeconds) {
+                return;
+            }
+
+            $lastFlush = $now;
+
+            $this->logger->updateCommandLog($logIndex, [
+                'output' => $this->sanitize(trim($incrementalOutput->toString())),
+                'duration_ms' => round(($now - $startTime) * 1000, 2),
+            ]);
         });
 
         $output = $process->getOutput();
@@ -55,9 +85,13 @@ class ShellProcessor
 
         // Finalize the log entry with exit code and status
         if ($this->logger && $logIndex !== null) {
-            $combinedOutput = $this->sanitize(trim($output."\n".$errorOutput));
+            $finalOutput = $this->newOutputBuffer();
+            $finalOutput->append($output);
+            $finalOutput->append("\n");
+            $finalOutput->append($errorOutput);
+
             $this->logger->updateCommandLog($logIndex, [
-                'output' => $combinedOutput,
+                'output' => $this->sanitize(trim($finalOutput->toString())),
                 'exit_code' => $exitCode,
                 'status' => $process->isSuccessful() ? 'completed' : 'failed',
                 'duration_ms' => round((microtime(true) - $startTime) * 1000, 2),
@@ -65,12 +99,22 @@ class ShellProcessor
         }
 
         if (! $process->isSuccessful()) {
-            $sanitizedError = $this->sanitize($errorOutput);
+            // Bounded as well: this message ends up in `backup_jobs.error_message`,
+            // a TEXT column that a multi-megabyte stderr would overflow.
+            $error = $this->newOutputBuffer();
+            $error->append($errorOutput);
+
+            $sanitizedError = $this->sanitize($error->toString());
             Log::error($sanitizedCommand."\n".$sanitizedError);
             throw new ShellProcessFailed($sanitizedError);
         }
 
         return $output;
+    }
+
+    private function newOutputBuffer(): OutputBuffer
+    {
+        return new OutputBuffer($this->outputHeadBytes, $this->outputTailBytes);
     }
 
     /**

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -141,7 +141,6 @@
                     $target = $restore->targetServer;
                     $canRerun = $snapshot && $target;
                     $job = $restore->job;
-                    $hasLogs = ! empty($job?->logs);
                 @endphp
                 <div class="flex items-center gap-1 justify-end">
                     @if($canRerun)
@@ -161,8 +160,8 @@
                         wire:click="viewLogs('{{ $job?->id }}')"
                         :tooltip="__('View Logs')"
                         class="btn-ghost btn-sm"
-                        :class="$hasLogs ? '' : 'opacity-30'"
-                        :disabled="! $hasLogs"
+                        :class="$job ? '' : 'opacity-30'"
+                        :disabled="! $job"
                     />
 
                     @can('delete', $restore)

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -124,7 +124,6 @@
                     $canDownload = $status === 'completed' && $completedFiles->where('file_exists', true)->isNotEmpty();
                     $canDelete = in_array($status, ['completed', 'failed'], true);
                     $canCancel = $status === 'pending' && $job;
-                    $hasLogs = ! empty($job?->logs);
                 @endphp
                 <div class="flex items-center gap-1 justify-end">
                     @if($canRestore)
@@ -165,8 +164,8 @@
                         wire:click="viewLogs('{{ $job?->id }}')"
                         :tooltip="__('View Logs')"
                         class="btn-ghost btn-sm"
-                        :class="$hasLogs ? '' : 'opacity-30'"
-                        :disabled="! $hasLogs"
+                        :class="$job ? '' : 'opacity-30'"
+                        :disabled="! $job"
                     />
 
                     @if($canDelete)

--- a/resources/views/partials/job-logs-modal.blade.php
+++ b/resources/views/partials/job-logs-modal.blade.php
@@ -240,13 +240,25 @@
                                             <div class="py-3 space-y-3">
                                                 @if($isCommand)
                                                     <!-- Command & Output -->
+                                                    @php
+                                                        // Same bounded head-and-tail logic ShellProcessor uses when
+                                                        // capturing, on a tighter budget: every line rendered here is a
+                                                        // DOM node that also rides along in the Livewire payload.
+                                                        $rendered = new \App\Services\Backup\OutputBuffer(4096, 4096);
+                                                        $rendered->append(trim($log['output'] ?? ''));
+                                                        $renderedOutput = $rendered->toString();
+                                                        $outputLines = $renderedOutput === '' ? [] : explode("\n", $renderedOutput);
+                                                        $truncationMarker = $rendered->marker();
+                                                    @endphp
                                                     <div class="mockup-code text-sm max-h-64 overflow-auto">
                                                         <pre data-prefix="$"><code>{{ $log['command'] }}</code></pre>
-                                                        @if(isset($log['output']) && !empty(trim($log['output'])))
-                                                            @foreach(explode("\n", trim($log['output'])) as $line)
+                                                        @foreach($outputLines as $line)
+                                                            @if($line === $truncationMarker)
+                                                                <pre data-prefix="…"><code class="text-warning">{{ $line }}</code></pre>
+                                                            @else
                                                                 <pre data-prefix=">"><code class="{{ $isError ? 'text-error' : '' }}">{{ $line }}</code></pre>
-                                                            @endforeach
-                                                        @endif
+                                                            @endif
+                                                        @endforeach
                                                     </div>
 
                                                     @if($isRunning || isset($log['exit_code']) || isset($log['duration_ms']))

--- a/tests/Feature/Dashboard/JobStatusGridTest.php
+++ b/tests/Feature/Dashboard/JobStatusGridTest.php
@@ -71,6 +71,41 @@ test('viewLogs sets selectedJobId and opens modal', function () {
         ->assertSet('selectedJobId', $job->id);
 });
 
+test('logs modal renders only the head and tail of a huge command output', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create([
+        'database_names' => ['test_db'],
+    ]);
+
+    $snapshots = $factory->createSnapshots($server->backups->first(), 'manual', $user->id);
+    $job = $snapshots[0]->job;
+
+    $lines = collect(range(1, 1000))->map(fn (int $i) => sprintf('logline-%04d-end', $i));
+
+    $job->update(['logs' => [[
+        'timestamp' => now()->toIso8601String(),
+        'type' => 'command',
+        'command' => 'pg_dump --verbose',
+        'output' => $lines->implode("\n"),
+        'exit_code' => 0,
+        'status' => 'completed',
+    ]]]);
+
+    // Each line becomes a DOM node in the Livewire payload, so only the head and
+    // the tail are rendered; the middle is replaced by the omission marker. The
+    // tail matters most: a failure reason sits at the end of the output.
+    Livewire::withoutLazyLoading()
+        ->actingAs($user)
+        ->test(JobStatusGrid::class)
+        ->call('viewLogs', $job->id)
+        ->assertSee('logline-0001-end')
+        ->assertDontSee('logline-0500-end')
+        ->assertSee('logline-1000-end')
+        ->assertSee('of output omitted');
+});
+
 test('closeLogs resets state', function () {
     $user = User::factory()->create();
     $factory = app(BackupJobFactory::class);

--- a/tests/Feature/Queries/SnapshotQueryTest.php
+++ b/tests/Feature/Queries/SnapshotQueryTest.php
@@ -73,3 +73,18 @@ test('can sort snapshots by column', function () {
     expect($results->first()->file_size)->toBe(5000)
         ->and($results->last()->file_size)->toBe(1000);
 });
+
+test('snapshot listing does not load the job log payload', function () {
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['db1']]);
+    $snapshots = $factory->createSnapshots($server->backups->first(), 'manual');
+    $snapshots[0]->job->update(['logs' => [['type' => 'log', 'message' => str_repeat('x', 10000)]]]);
+
+    $job = SnapshotQuery::buildFromParams()->get()->first()->job;
+
+    // Fetching `logs` for every row is what made the index page crawl once a
+    // chatty command filled the column. The logs modal re-fetches the job.
+    expect($job->getAttributes())->not->toHaveKey('logs')
+        ->and($job->status)->toBeInstanceOf(BackupJobStatus::class);
+});

--- a/tests/Feature/Services/Backup/ShellProcessorTest.php
+++ b/tests/Feature/Services/Backup/ShellProcessorTest.php
@@ -120,6 +120,77 @@ test('process works without logger', function () {
     expect(trim($output))->toBe('no logger');
 });
 
+test('process bounds the stored output of a chatty command', function () {
+    $backupJob = BackupJob::create([
+        'status' => 'running',
+    ]);
+
+    // 64-byte head/tail budget, so a few hundred bytes of warnings overflow it.
+    $processor = new ShellProcessor(outputHeadBytes: 64, outputTailBytes: 64);
+    $processor->setLogger($backupJob);
+
+    // A noisy pg_dump repeating a warning on stderr, in miniature.
+    $processor->process('seq 1 100 | sed "s/^/warning: line /" >&2');
+
+    $backupJob->refresh();
+    $output = $backupJob->getLogs()[0]['output'];
+
+    expect(strlen($output))->toBeLessThan(300)
+        ->and($output)->toContain('warning: line 1')
+        ->and($output)->toContain('warning: line 100')
+        ->and($output)->not->toContain('warning: line 50')
+        ->and($output)->toContain('of output omitted');
+});
+
+test('process bounds the error message thrown for a failing chatty command', function () {
+    Log::spy();
+
+    $processor = new ShellProcessor(outputHeadBytes: 64, outputTailBytes: 64);
+
+    $run = fn () => $processor->process('seq 1 100 | sed "s/^/warning: line /" >&2; exit 1');
+
+    expect($run)->toThrow(
+        fn (ShellProcessFailed $e) => expect(strlen($e->getMessage()))->toBeLessThan(300)
+    );
+});
+
+test('process throttles incremental log writes while a command runs', function () {
+    $logger = new class implements \App\Contracts\BackupLogger
+    {
+        public int $updates = 0;
+
+        public function logCommand(string $command, ?string $output = null, ?int $exitCode = null, ?float $startTime = null): void {}
+
+        public function startCommandLog(string $command): int
+        {
+            return 0;
+        }
+
+        public function updateCommandLog(int $index, array $data): void
+        {
+            $this->updates++;
+        }
+
+        public function log(string $message, string $level = 'info', ?array $context = null): void {}
+
+        public function getLogs(): array
+        {
+            return [];
+        }
+    };
+
+    // An interval no test run can reach, so every write after the first is skipped.
+    $processor = new ShellProcessor(flushIntervalSeconds: 3600);
+    $processor->setLogger($logger);
+
+    // ~2 MB delivered as many read chunks. Unthrottled this is one database
+    // write per chunk, each re-serializing the whole growing `logs` blob.
+    $processor->process('seq 1 300000');
+
+    // The first chunk, then the final write once the command exits.
+    expect($logger->updates)->toBe(2);
+});
+
 test('process creates log entry before command starts', function () {
     $backupJob = BackupJob::create([
         'status' => 'running',

--- a/tests/Unit/Services/Backup/OutputBufferTest.php
+++ b/tests/Unit/Services/Backup/OutputBufferTest.php
@@ -64,6 +64,31 @@ test('output arriving in chunks smaller than a line is reassembled', function ()
     expect($buffer->toString())->toBe("hello world\nsecond line\n");
 });
 
+test('byte cuts keep the buffer valid utf-8 when output has no line breaks', function () {
+    // Budgets deliberately not a multiple of the 3-byte character width, so the
+    // head seal and every tail trim land inside a character. Chunks are split on
+    // bytes too, as process output genuinely arrives.
+    $buffer = new OutputBuffer(11, 11);
+
+    foreach (str_split(str_repeat('€', 200), 7) as $chunk) {
+        $buffer->append($chunk);
+    }
+
+    expect($buffer->isTruncated())->toBeTrue()
+        ->and(mb_check_encoding($buffer->toString(), 'UTF-8'))->toBeTrue()
+        ->and($buffer->toString())->toContain('€');
+});
+
+test('sealing the head mid-character loses nothing when the output still fits', function () {
+    // An 11-byte head splits the 4th character, but the whole input fits within
+    // the combined budget, so the buffer must reproduce it byte for byte.
+    $buffer = new OutputBuffer(11, 100);
+    $buffer->append(str_repeat('€', 10));
+
+    expect($buffer->isTruncated())->toBeFalse()
+        ->and($buffer->toString())->toBe(str_repeat('€', 10));
+});
+
 test('output with no line breaks is still bounded', function () {
     $buffer = new OutputBuffer(64, 64);
     $buffer->append(str_repeat('a', 10_000));

--- a/tests/Unit/Services/Backup/OutputBufferTest.php
+++ b/tests/Unit/Services/Backup/OutputBufferTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Services\Backup\OutputBuffer;
+
+test('short output is kept verbatim', function () {
+    $buffer = new OutputBuffer(64, 64);
+    $buffer->append("first\n");
+    $buffer->append("second\n");
+
+    expect($buffer->isTruncated())->toBeFalse()
+        ->and($buffer->toString())->toBe("first\nsecond\n");
+});
+
+test('long output keeps the head and the tail and drops the middle', function () {
+    $buffer = new OutputBuffer(64, 64);
+
+    for ($i = 1; $i <= 500; $i++) {
+        $buffer->append("warning line {$i}\n");
+    }
+
+    $result = $buffer->toString();
+
+    expect($buffer->isTruncated())->toBeTrue()
+        ->and($result)->toContain('warning line 1')
+        ->and($result)->toContain('warning line 500')
+        ->and($result)->not->toContain('warning line 250')
+        ->and($result)->toContain('of output omitted');
+});
+
+test('truncated output stays within the configured budget', function () {
+    $buffer = new OutputBuffer(1024, 1024);
+
+    for ($i = 0; $i < 10_000; $i++) {
+        $buffer->append(str_repeat('x', 200)."\n");
+    }
+
+    // Head + tail + the marker line, well under the 2 MB that was appended.
+    expect(strlen($buffer->toString()))->toBeLessThan(1024 + 1024 + 200);
+});
+
+test('lines are never split in half by truncation', function () {
+    $buffer = new OutputBuffer(64, 64);
+
+    for ($i = 1; $i <= 200; $i++) {
+        $buffer->append(sprintf("line-%03d-end\n", $i));
+    }
+
+    foreach (explode("\n", trim($buffer->toString())) as $line) {
+        if (str_starts_with($line, '[...')) {
+            continue;
+        }
+
+        expect($line)->toMatch('/^line-\d{3}-end$/');
+    }
+});
+
+test('output arriving in chunks smaller than a line is reassembled', function () {
+    $buffer = new OutputBuffer(64, 64);
+
+    foreach (str_split("hello world\nsecond line\n", 3) as $chunk) {
+        $buffer->append($chunk);
+    }
+
+    expect($buffer->toString())->toBe("hello world\nsecond line\n");
+});
+
+test('output with no line breaks is still bounded', function () {
+    $buffer = new OutputBuffer(64, 64);
+    $buffer->append(str_repeat('a', 10_000));
+
+    expect($buffer->isTruncated())->toBeTrue()
+        ->and(strlen($buffer->toString()))->toBeLessThan(400);
+});


### PR DESCRIPTION
Fixes #489

A `pg_dump` emitting a large number of warnings made the whole interface crawl. The log payload was unbounded at four independent layers, each enough to cause the slowdown on its own:

1. **Write amplification.** `ShellProcessor` flushed to the logger on every output chunk, and `BackupJob::updateCommandLog()` re-serializes the entire `logs` JSON blob for a full `UPDATE`. Thousands of writes against a blob that keeps growing, so a chatty command was quadratic in database writes. This hammers the database and slows the whole app, not just the modal.
2. **No cap on stored output.** The `logs` JSON column grew without limit. A failing command's stderr also ends up in `backup_jobs.error_message`, a TEXT column a multi-megabyte stderr would overflow.
3. **Listings loaded the blob.** `SnapshotQuery`, `RestoreQuery` and the dashboard eager-loaded the `job` relation including its full `logs` column for every row, used only to test whether it was empty. This is why the index page was slow before opening anything.
4. **Uncapped rendering.** The logs modal emitted one DOM node per output line, all serialized through the Livewire payload.

## Changes

**`OutputBuffer`** (new): a bounded head-and-tail accumulator. Keeps the first and last slice of a stream and reports what it dropped. Cuts align to line boundaries so no line is split in half, which also keeps `ShellProcessor::sanitize()` seeing whole lines when redacting secrets.

**`ShellProcessor`**: uses the buffer for the incremental writes, the final write and the thrown `ShellProcessFailed` message, and throttles incremental flushes to at most one per second (the final write always runs, so nothing is lost). Bounds and flush interval are constructor parameters, so tests exercise the behaviour with 64-byte budgets instead of generating megabytes. Because this is the single choke point for both the server and agent paths, it also fixes a related bug: an agent's oversized log was previously rejected outright by the `max:50000` validation rather than truncated, so a noisy backup reported nothing at all.

**Logs modal**: reuses the same buffer on a tighter budget (4 KB head and tail) instead of reimplementing truncation in the view, so the omission marker and the line-boundary rules come for free.

**Listings**: load the job through a new `BackupJob::scopeWithoutLogs()`. The logs button is now gated on the job existing rather than on it having logs, since the modal already has a "No logs available for this job." empty state.

## Notes

Symfony's `Process` still buffers a command's full output internally regardless of our cap, so a genuinely enormous stderr can still pressure queue worker memory. That is out of scope here and worth a separate issue if it needs to be airtight.

Verified with `make lint-check`, `make phpstan` and `make test` (1378 passing). Not checked in a browser: the view change is covered by a render test asserting the head, tail and marker, but I did not look at it in a real page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Job logs now display the beginning and end of lengthy command output, with a clear marker showing omitted content.
  - Log handling preserves readable line boundaries, UTF-8 text, and outputs without line breaks.
  - Live log updates are refreshed at a controlled interval for smoother viewing.

- **Performance**
  - Dashboard, snapshot, and restore listings load without fetching large log and error details.

- **Bug Fixes**
  - The View Logs action is now available whenever a related job exists, even when no logs are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->