### PR TITLE
fix(backup): keep MySQL 26.x dumps working (#494)

### DIFF
--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -111,6 +111,12 @@ class DatabaseProvider
             $dbConfig['ssl_enabled'] = true;
         }
 
+        // Marks a live server: the handler may query it for the MySQL/MariaDB
+        // flavour. Display-only configs, like the dump preview, leave it unset.
+        if ($config->databaseType === DatabaseType::MYSQL) {
+            $dbConfig['probe_server_version'] = true;
+        }
+
         if ($config->databaseType === DatabaseType::POSTGRESQL
             && ($snapshotDumpFormat ?? $extra['dump_format'] ?? null) === 'custom') {
             $dbConfig['dump_format'] = 'custom';

--- a/app/Services/Backup/Databases/MysqlDatabase.php
+++ b/app/Services/Backup/Databases/MysqlDatabase.php
@@ -4,6 +4,7 @@ namespace App\Services\Backup\Databases;
 
 use App\Contracts\BackupLogger;
 use App\Exceptions\Backup\ConnectionException;
+use App\Services\Backup\DTO\DatabaseOperationLog;
 use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
@@ -13,6 +14,9 @@ class MysqlDatabase implements DatabaseInterface
 {
     /** @var array<string, mixed> */
     private array $config;
+
+    /** Cached VERSION() result; '' means "asked and could not tell". */
+    private ?string $serverVersion = null;
 
     private const string DUMP_BINARY = 'mariadb-dump';
 
@@ -25,6 +29,9 @@ class MysqlDatabase implements DatabaseInterface
         '--hex-blob',           // Encode binary data as hex for safer transport
         '--quote-names',        // Quote identifiers with backticks
     ];
+
+    /** Server version from which the MariaDB client dumps stored packages. */
+    private const string MARIADB_PACKAGES_VERSION = '10.3.0';
 
     private const array EXCLUDED_DATABASES = [
         'information_schema',
@@ -62,6 +69,15 @@ class MysqlDatabase implements DatabaseInterface
         $options = self::DUMP_OPTIONS;
         $options[] = $this->getSslFlag();
 
+        $log = null;
+        if (! $this->canDumpRoutines()) {
+            $options = array_values(array_diff($options, ['--routines']));
+            $log = new DatabaseOperationLog(
+                'Stored routines were excluded from this dump: the MariaDB client cannot dump routines from a MySQL server reporting version '.$this->serverVersion().'.',
+                'warning',
+            );
+        }
+
         $extraFlags = '';
         if (! empty($this->config['dump_flags'])) {
             $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
@@ -82,7 +98,50 @@ class MysqlDatabase implements DatabaseInterface
 
         $command .= ' > '.escapeshellarg($outputPath);
 
-        return new DatabaseOperationResult(command: $command);
+        return new DatabaseOperationResult(command: $command, log: $log);
+    }
+
+    /**
+     * The client gates stored packages on the numeric server version alone, so a
+     * MySQL server on the YY.M scheme (9.7 → 26.7) gets a MariaDB-only
+     * `SHOW PACKAGE STATUS` and the dump dies. No flag skips just the packages.
+     * Unknown versions keep `--routines`, preserving the previous behaviour.
+     */
+    private function canDumpRoutines(): bool
+    {
+        $version = $this->serverVersion();
+
+        if ($version === null || str_contains(strtolower($version), 'mariadb')) {
+            return true;
+        }
+
+        return version_compare($version, self::MARIADB_PACKAGES_VERSION, '<');
+    }
+
+    /**
+     * Server version as reported by the server, or null when it cannot be read.
+     */
+    protected function serverVersion(): ?string
+    {
+        // Unset for configs that never reach a server, such as the UI preview.
+        if (empty($this->config['probe_server_version'])) {
+            return null;
+        }
+
+        if ($this->serverVersion !== null) {
+            return $this->serverVersion === '' ? null : $this->serverVersion;
+        }
+
+        try {
+            $statement = $this->createPdo()->query('SELECT VERSION()');
+            $version = $statement === false ? false : $statement->fetchColumn();
+        } catch (\PDOException) {
+            $version = false;
+        }
+
+        $this->serverVersion = is_string($version) ? $version : '';
+
+        return $this->serverVersion === '' ? null : $this->serverVersion;
     }
 
     public function restore(string $inputPath): DatabaseOperationResult

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -12,7 +12,7 @@ Databasement uses standard CLI tools to perform backup and restore operations. T
 
 | Engine     | Supported Versions           | CLI Tool                     | Restore |
 |------------|------------------------------|------------------------------|---------|
-| MySQL      | 5.6, 5.7, 8.x, 9.x           | `mariadb-dump`               | Yes     |
+| MySQL      | 5.6, 5.7, 8.x, 9.x, 26.x     | `mariadb-dump`               | Yes     |
 | MariaDB    | 10.x, 11.x, 12.x             | `mariadb-dump`               | Yes     |
 | PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v18                | Yes     |
 | SQL Server | 2017, 2019, 2022, Azure SQL  | `sqlpackage` (`.dacpac`)     | Yes     |
@@ -23,7 +23,7 @@ Databasement uses standard CLI tools to perform backup and restore operations. T
 | Valkey     | 7.2+                         | `redis-cli --rdb`            | No      |
 
 :::info How this works
-- **MySQL / MariaDB**: Databasement ships the MariaDB 11.4 client (`mariadb-dump`), which is wire-protocol compatible with MySQL servers.
+- **MySQL / MariaDB**: Databasement ships the MariaDB 11.4 client (`mariadb-dump`), which is wire-protocol compatible with MySQL servers. On MySQL 26.0 and later, stored procedures and functions are left out of the dump: the client reads MySQL's new YY.M version number (9.7 → 26.7) as a MariaDB one and asks for stored packages, which MySQL rejects. Tables, data, views and triggers are unaffected, and the job logs a warning.
 - **PostgreSQL**: The `pg_dump` v18 client can dump from any server version back to 9.2. Versions below 12 have reached end-of-life and are not recommended.
 - **SQL Server**: Backups are extracted as `.dacpac` files (schema + table data) using Microsoft's `sqlpackage` CLI (`/Action:Extract`) and re-applied with `/Action:Publish`. Server-bound objects (logins, users, permissions, role memberships) are excluded so backups stay portable across instances and don't fail on Windows-auth principals like `[NT AUTHORITY\SYSTEM]`. Works against on-prem SQL Server 2017+ and Azure SQL Database. Connections use the `pdo_sqlsrv` PHP extension.
 - **MongoDB**: The MongoDB Database Tools (`mongodump` / `mongorestore`) officially support server versions 4.2 through 8.0.

--- a/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
@@ -58,6 +58,64 @@ test('dump includes extra dump flags', function () {
         ->and($result->command)->toEndWith("> '/tmp/dump.sql'");
 });
 
+/** A handler on a live server reporting $version, or an unreadable one for null. */
+function mysqlDatabaseReportingVersion(?string $version): MysqlDatabase
+{
+    $pdo = Mockery::mock(PDO::class);
+
+    if ($version === null) {
+        $pdo->shouldReceive('query')->andThrow(new PDOException('server has gone away'));
+    } else {
+        $statement = Mockery::mock(\PDOStatement::class);
+        $statement->shouldReceive('fetchColumn')->andReturn($version);
+        $pdo->shouldReceive('query')->with('SELECT VERSION()')->andReturn($statement);
+    }
+
+    $db = Mockery::mock(MysqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldReceive('createPdo')->andReturn($pdo);
+    $db->setConfig([
+        'host' => 'db.local',
+        'port' => 3306,
+        'user' => 'root',
+        'pass' => 'secret',
+        'database' => 'myapp',
+        'probe_server_version' => true,
+    ]);
+
+    return $db;
+}
+
+test('dump keeps --routines for servers the MariaDB client can dump routines from', function (?string $version) {
+    $result = mysqlDatabaseReportingVersion($version)->dump('/tmp/dump.sql');
+
+    expect($result->command)->toContain('--routines')
+        ->and($result->log)->toBeNull();
+})->with([
+    'MariaDB inside its own package range' => ['11.4.12-MariaDB-ubu2404'],
+    'MySQL on the pre-2026 scheme' => ['9.7.2'],
+    'MySQL 8' => ['8.4.11'],
+    'unreadable version' => [null],
+]);
+
+// MySQL 26.7 clears the client's >= 10.3 package gate, so --routines triggers
+// SHOW PACKAGE STATUS and MySQL rejects it with a syntax error (#494).
+test('dump drops --routines for MySQL versions that trip the MariaDB package check', function () {
+    $result = mysqlDatabaseReportingVersion('26.7.0')->dump('/tmp/dump.sql');
+
+    expect($result->command)->not->toContain('--routines')
+        ->and($result->command)->toContain('mariadb-dump --single-transaction --add-drop-table')
+        ->and($result->log?->level)->toBe('warning')
+        ->and($result->log?->message)->toContain('26.7.0');
+});
+
+test('dump does not probe the server when the config is not for a live server', function () {
+    $db = Mockery::mock(MysqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldNotReceive('createPdo');
+    $db->setConfig(['host' => 'hostname', 'port' => 3306, 'user' => 'user', 'pass' => '***', 'database' => 'dbname']);
+
+    expect($db->dump('/path/to/output')->command)->toContain('--routines');
+});
+
 test('restore builds correct command with skip_ssl by default', function () {
     $result = $this->db->restore('/tmp/restore.sql');
 


### PR DESCRIPTION
Fixes #494.

## What breaks

`mariadb-dump` decides which features a server has from its numeric version (`major * 10000 + minor * 100 + patch`). Stored packages are gated on 10.3. MySQL switched to a YY.M scheme in July 2026, so 26.7 clears that gate, `--routines` issues `SHOW PACKAGE STATUS`, and MySQL kills the dump:

```
mariadb-dump: Couldn't execute 'SHOW PACKAGE STATUS WHERE Db = 'grafana_db'':
You have an error in your SQL syntax ... (1064)
```

Reproduced with `mysql:26.7.0`; the same command against `mysql:9.7` (90000, below the gate) succeeds.

## Why not just bump the client

Tested clients 11.4.12, 11.8.8, 12.3.2 and 13.0.1-RC against MySQL 26.7: all fail identically. No MDEV is open for this yet; [MDEV-17429](https://jira.mariadb.org/browse/MDEV-17429) is the same error against pre-10.3 MariaDB servers, and the version gate added to fix it is what MySQL now defeats. There is also no flag to skip only the packages.

## Fix

Read `VERSION()` on the connection we already open, and drop `--routines` when the server is MySQL numbered 10.3 or above. A warning is logged on the job. Unknown or unreachable versions keep the flag, so nothing changes for MariaDB or MySQL 8.x/9.x. Everything else in the dump works on 26.7, so this is the only change needed.

The probe only runs for configs pointing at a live server (`probe_server_version`), so the dump-command preview in the UI stays offline.

Stored routines are the known cost: dumping them ourselves over PDO is the follow-up.

## Verified

Against real containers (26.7.0 / 9.7 / MariaDB 11.4): flag dropped only on 26.7, dump exit code 0 on all three. Unit tests cover the version matrix and the preview path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database backups for newer MySQL versions by omitting incompatible stored procedure and function options.
  * Added warning logs when routines cannot be included.
  * Preserved routines for compatible, MariaDB, unknown, and non-live database configurations.

* **Documentation**
  * Updated supported MySQL versions and documented routine limitations for MySQL 26.0 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->