### PR TITLE
fix(queue): stop a running backup being re-delivered to a second worker (#488)

### DIFF
--- a/app/Console/Commands/RecoverStuckJobsCommand.php
+++ b/app/Console/Commands/RecoverStuckJobsCommand.php
@@ -6,13 +6,14 @@ use App\Enums\BackupJobStatus;
 use App\Facades\AppConfig;
 use App\Models\AgentJob;
 use App\Models\BackupJob;
+use App\Support\QueueTimeouts;
 use Illuminate\Console\Command;
 use RuntimeException;
 
 class RecoverStuckJobsCommand extends Command
 {
     /** Grace period added to the configured timeout before a job is considered stuck. */
-    private const GRACE_PERIOD_SECONDS = 300;
+    private const int GRACE_PERIOD_SECONDS = QueueTimeouts::RETRY_GRACE_SECONDS;
 
     protected $signature = 'jobs:recover-stuck';
 

--- a/app/Console/Commands/RecoverStuckJobsCommand.php
+++ b/app/Console/Commands/RecoverStuckJobsCommand.php
@@ -12,9 +12,6 @@ use RuntimeException;
 
 class RecoverStuckJobsCommand extends Command
 {
-    /** Grace period added to the configured timeout before a job is considered stuck. */
-    private const int GRACE_PERIOD_SECONDS = QueueTimeouts::RETRY_GRACE_SECONDS;
-
     protected $signature = 'jobs:recover-stuck';
 
     protected $description = 'Recover stuck jobs (expired agent leases and timed-out backup jobs)';
@@ -84,7 +81,7 @@ class RecoverStuckJobsCommand extends Command
      */
     private function recoverBackupJobs(): bool
     {
-        $timeout = AppConfig::get('backup.job_timeout') + self::GRACE_PERIOD_SECONDS;
+        $timeout = AppConfig::get('backup.job_timeout') + QueueTimeouts::RETRY_GRACE_SECONDS;
         $cutoff = now()->subSeconds($timeout);
 
         $stuckJobs = BackupJob::query()

--- a/app/Jobs/ProcessBackupJob.php
+++ b/app/Jobs/ProcessBackupJob.php
@@ -14,10 +14,12 @@ use App\Services\Backup\DTO\DatabaseConnectionConfig;
 use App\Services\Backup\DTO\VolumeConfig;
 use App\Services\NotificationService;
 use App\Support\FilesystemSupport;
+use App\Support\QueueTimeouts;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
@@ -41,6 +43,25 @@ class ProcessBackupJob implements ShouldQueue
         $this->backoff = AppConfig::get('backup.job_backoff');
         $this->tries = AppConfig::get('backup.job_tries');
         $this->onQueue('backups');
+    }
+
+    /**
+     * Refuse to dump the same snapshot twice at once.
+     *
+     * QueueTimeouts keeps retry_after above the job timeout, so a re-delivery
+     * mid-run should no longer happen. This is the second line of defence: a
+     * duplicate copy is dropped rather than released, because releasing it would
+     * only run the same dump again once the original finishes.
+     *
+     * @return array<int, WithoutOverlapping>
+     */
+    public function middleware(): array
+    {
+        return [
+            (new WithoutOverlapping($this->snapshotId))
+                ->expireAfter(QueueTimeouts::lockExpiry($this->timeout))
+                ->dontRelease(),
+        ];
     }
 
     /**

--- a/app/Jobs/ProcessBackupJob.php
+++ b/app/Jobs/ProcessBackupJob.php
@@ -49,19 +49,13 @@ class ProcessBackupJob implements ShouldQueue
      * Refuse to dump the same snapshot twice at once.
      *
      * QueueTimeouts keeps retry_after above the job timeout, so a re-delivery
-     * mid-run should no longer happen. This is the second line of defence: a
-     * duplicate copy is dropped rather than released, because releasing it would
-     * only run the same dump again once the original finishes.
+     * mid-run should no longer happen. This is the second line of defence.
      *
      * @return array<int, WithoutOverlapping>
      */
     public function middleware(): array
     {
-        return [
-            (new WithoutOverlapping($this->snapshotId))
-                ->expireAfter(QueueTimeouts::lockExpiry($this->timeout))
-                ->dontRelease(),
-        ];
+        return [QueueTimeouts::overlapGuard($this->snapshotId, $this->timeout)];
     }
 
     /**

--- a/app/Jobs/ProcessRestoreJob.php
+++ b/app/Jobs/ProcessRestoreJob.php
@@ -46,18 +46,13 @@ class ProcessRestoreJob implements ShouldQueue
      * Refuse to run the same restore twice at once.
      *
      * Two workers dropping and recreating the same target database concurrently
-     * is worse than a missed retry, so a duplicate copy is dropped rather than
-     * released back to the queue.
+     * is worse than a missed retry.
      *
      * @return array<int, WithoutOverlapping>
      */
     public function middleware(): array
     {
-        return [
-            (new WithoutOverlapping($this->restoreId))
-                ->expireAfter(QueueTimeouts::lockExpiry($this->timeout))
-                ->dontRelease(),
-        ];
+        return [QueueTimeouts::overlapGuard($this->restoreId, $this->timeout)];
     }
 
     /**

--- a/app/Jobs/ProcessRestoreJob.php
+++ b/app/Jobs/ProcessRestoreJob.php
@@ -11,10 +11,12 @@ use App\Services\Backup\DTO\VolumeConfig;
 use App\Services\Backup\RestoreTask;
 use App\Services\NotificationService;
 use App\Support\FilesystemSupport;
+use App\Support\QueueTimeouts;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
 
@@ -38,6 +40,24 @@ class ProcessRestoreJob implements ShouldQueue
         $this->backoff = AppConfig::get('backup.job_backoff');
         $this->tries = AppConfig::get('backup.job_tries');
         $this->onQueue('backups');
+    }
+
+    /**
+     * Refuse to run the same restore twice at once.
+     *
+     * Two workers dropping and recreating the same target database concurrently
+     * is worse than a missed retry, so a duplicate copy is dropped rather than
+     * released back to the queue.
+     *
+     * @return array<int, WithoutOverlapping>
+     */
+    public function middleware(): array
+    {
+        return [
+            (new WithoutOverlapping($this->restoreId))
+                ->expireAfter(QueueTimeouts::lockExpiry($this->timeout))
+                ->dontRelease(),
+        ];
     }
 
     /**

--- a/app/Livewire/Configuration/Form.php
+++ b/app/Livewire/Configuration/Form.php
@@ -160,12 +160,9 @@ class Form extends \Livewire\Form
             AppConfig::set($configKey, $this->{$property});
         }
 
-        // A worker bakes retry_after into its queue connection at boot from the
-        // job timeout in force at the time (see App\Support\QueueTimeouts), so a
-        // raised timeout would not reach running workers and their retry_after
-        // would sit below the timeout of the jobs they pick up next. Ask them to
-        // restart; the flag is only read between jobs, so nothing in flight is
-        // interrupted.
+        // Workers resolve retry_after from the job timeout when they boot (see
+        // App\Support\QueueTimeouts), so a changed timeout only reaches them on
+        // restart. The flag is read between jobs, so nothing in flight is cut off.
         if ($previousJobTimeout !== (int) $this->job_timeout) {
             Artisan::call('queue:restart');
         }

--- a/app/Livewire/Configuration/Form.php
+++ b/app/Livewire/Configuration/Form.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Configuration;
 use App\Enums\CompressionType;
 use App\Facades\AppConfig;
 use Cron\CronExpression;
+use Illuminate\Support\Facades\Artisan;
 
 class Form extends \Livewire\Form
 {
@@ -138,6 +139,8 @@ class Form extends \Livewire\Form
     {
         $this->validate($this->backupRules());
 
+        $previousJobTimeout = (int) AppConfig::get('backup.job_timeout');
+
         $backupKeyMap = [
             'working_directory' => 'backup.working_directory',
             'compression' => 'backup.compression',
@@ -155,6 +158,16 @@ class Form extends \Livewire\Form
 
         foreach ($backupKeyMap as $property => $configKey) {
             AppConfig::set($configKey, $this->{$property});
+        }
+
+        // A worker bakes retry_after into its queue connection at boot from the
+        // job timeout in force at the time (see App\Support\QueueTimeouts), so a
+        // raised timeout would not reach running workers and their retry_after
+        // would sit below the timeout of the jobs they pick up next. Ask them to
+        // restart; the flag is only read between jobs, so nothing in flight is
+        // interrupted.
+        if ($previousJobTimeout !== (int) $this->job_timeout) {
+            Artisan::call('queue:restart');
         }
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -19,6 +19,7 @@ use App\Services\Backup\Filesystems\SftpFilesystem;
 use App\Services\Backup\Filesystems\SmbFilesystem;
 use App\Services\Backup\ShellProcessor;
 use App\Services\CurrentOrganization;
+use App\Support\QueueTimeouts;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\Parameter;
@@ -103,6 +104,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->warnDeprecatedEnvVars();
+        $this->configureQueueTimeouts();
         $this->registerOidcSocialiteProvider();
         $this->validateOAuthConfiguration();
         $this->registerBouncer();
@@ -186,6 +188,22 @@ class AppServiceProvider extends ServiceProvider
             Log::warning('Deprecated BACKUP_* environment variables detected. Backup settings are now configured in the UI. You can safely remove BACKUP_* variables from your environment.');
         }
 
+    }
+
+    /**
+     * Keep the queue's retry_after above the longest a backup/restore may run.
+     *
+     * Only workers act on retry_after, so this is skipped for web requests to
+     * avoid a database read on every one. Agent mode runs on the sync driver and
+     * has no database at all.
+     */
+    private function configureQueueTimeouts(): void
+    {
+        if (config('agent.enabled') || ! $this->app->runningInConsole()) {
+            return;
+        }
+
+        QueueTimeouts::apply();
     }
 
     /**

--- a/app/Support/QueueTimeouts.php
+++ b/app/Support/QueueTimeouts.php
@@ -17,6 +17,12 @@ use App\Facades\AppConfig;
  * The lock outlives the job so a running dump can never be duplicated, and
  * expires before `retry_after` so that a genuine retry (worker killed, lock
  * never released) is still allowed to run.
+ *
+ * A worker resolves `retry_after` once, when it boots: the value is baked into
+ * the queue connection and later config changes do not reach it. Editing
+ * `backup.job_timeout` therefore signals a worker restart (see
+ * App\Livewire\Configuration\Form::saveBackup), otherwise a raised timeout would
+ * leave running workers with a retry_after below it.
  */
 final class QueueTimeouts
 {

--- a/app/Support/QueueTimeouts.php
+++ b/app/Support/QueueTimeouts.php
@@ -3,6 +3,7 @@
 namespace App\Support;
 
 use App\Facades\AppConfig;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 
 /**
  * Timing window that keeps a queued backup/restore from running twice.
@@ -54,13 +55,27 @@ final class QueueTimeouts
 
         foreach (self::CONNECTIONS as $connection) {
             $key = "queue.connections.{$connection}.retry_after";
+            $configured = config($key);
 
-            if (config($key) === null) {
+            if ($configured === null) {
                 continue;
             }
 
-            config([$key => max((int) config($key), $minimum)]);
+            config([$key => max((int) $configured, $minimum)]);
         }
+    }
+
+    /**
+     * Guard that stops a second copy of a job running alongside the first.
+     *
+     * The duplicate is dropped rather than released: releasing it would only run
+     * the same dump or restore again once the original finished.
+     */
+    public static function overlapGuard(string $key, int $jobTimeout): WithoutOverlapping
+    {
+        return (new WithoutOverlapping($key))
+            ->expireAfter($jobTimeout + self::LOCK_GRACE_SECONDS)
+            ->dontRelease();
     }
 
     /**
@@ -69,14 +84,6 @@ final class QueueTimeouts
     public static function retryAfter(): int
     {
         return self::jobTimeout() + self::RETRY_GRACE_SECONDS;
-    }
-
-    /**
-     * Lifetime of a job's overlap lock, in seconds.
-     */
-    public static function lockExpiry(int $jobTimeout): int
-    {
-        return $jobTimeout + self::LOCK_GRACE_SECONDS;
     }
 
     private static function jobTimeout(): int

--- a/app/Support/QueueTimeouts.php
+++ b/app/Support/QueueTimeouts.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Support;
+
+use App\Facades\AppConfig;
+
+/**
+ * Timing window that keeps a queued backup/restore from running twice.
+ *
+ * Laravel hands a reserved job to another worker once `retry_after` elapses,
+ * whether or not it is still running. The framework default is 90 seconds while
+ * `backup.job_timeout` defaults to 7200, so any dump longer than 90 seconds was
+ * picked up a second time mid-run. The three values below must keep this order:
+ *
+ *     job timeout  <  overlap lock expiry  <  retry_after
+ *
+ * The lock outlives the job so a running dump can never be duplicated, and
+ * expires before `retry_after` so that a genuine retry (worker killed, lock
+ * never released) is still allowed to run.
+ */
+final class QueueTimeouts
+{
+    /** Seconds added to the job timeout before a reserved job may be handed to another worker. */
+    public const int RETRY_GRACE_SECONDS = 300;
+
+    /** Seconds added to the job timeout before the overlap lock expires on its own. */
+    public const int LOCK_GRACE_SECONDS = 60;
+
+    /**
+     * Queue connections whose `retry_after` governs re-delivery of reserved jobs.
+     *
+     * SQS is absent on purpose: its equivalent (the visibility timeout) lives on
+     * the AWS queue itself and cannot be set from here.
+     *
+     * @var list<string>
+     */
+    private const array CONNECTIONS = ['database', 'redis', 'beanstalkd'];
+
+    /**
+     * Raise the configured `retry_after` above the longest a job may run.
+     *
+     * An explicitly configured value is never lowered, only raised to the safe
+     * minimum.
+     */
+    public static function apply(): void
+    {
+        $minimum = self::retryAfter();
+
+        foreach (self::CONNECTIONS as $connection) {
+            $key = "queue.connections.{$connection}.retry_after";
+
+            if (config($key) === null) {
+                continue;
+            }
+
+            config([$key => max((int) config($key), $minimum)]);
+        }
+    }
+
+    /**
+     * Earliest a reserved job may be re-delivered, in seconds.
+     */
+    public static function retryAfter(): int
+    {
+        return self::jobTimeout() + self::RETRY_GRACE_SECONDS;
+    }
+
+    /**
+     * Lifetime of a job's overlap lock, in seconds.
+     */
+    public static function lockExpiry(int $jobTimeout): int
+    {
+        return $jobTimeout + self::LOCK_GRACE_SECONDS;
+    }
+
+    private static function jobTimeout(): int
+    {
+        return (int) AppConfig::get('backup.job_timeout');
+    }
+}

--- a/config/queue.php
+++ b/config/queue.php
@@ -27,6 +27,11 @@ return [
     | Drivers: "sync", "database", "beanstalkd", "sqs", "redis",
     |          "deferred", "failover", "null"
     |
+    | The `retry_after` values below are only a floor. App\Support\QueueTimeouts
+    | raises them at runtime to sit above `backup.job_timeout`, so that a dump
+    | still in progress is never handed to a second worker. SQS is the one
+    | exception: set its visibility timeout on the AWS queue itself.
+    |
     */
 
     'connections' => [

--- a/tests/Feature/Configuration/BackupTest.php
+++ b/tests/Feature/Configuration/BackupTest.php
@@ -9,6 +9,7 @@ use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
 use App\Models\ScheduledRestore;
 use App\Models\User;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use Livewire\Livewire;
 
@@ -236,4 +237,30 @@ test('without manage-backup-settings, running verify files is forbidden', functi
         ->test(Backup::class)
         ->call('runVerifyFiles')
         ->assertForbidden();
+});
+
+test('changing the job timeout tells running workers to restart', function () {
+    // Workers resolve retry_after from the job timeout when they boot, so the
+    // new value only reaches them once they restart.
+    Cache::forget('illuminate:queue:restart');
+
+    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
+        ->test(Backup::class)
+        ->set('form.job_timeout', 3600)
+        ->call('saveBackupConfig')
+        ->assertHasNoErrors();
+
+    expect(Cache::get('illuminate:queue:restart'))->not->toBeNull();
+});
+
+test('saving unrelated backup settings leaves workers running', function () {
+    Cache::forget('illuminate:queue:restart');
+
+    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
+        ->test(Backup::class)
+        ->set('form.compression_level', 9)
+        ->call('saveBackupConfig')
+        ->assertHasNoErrors();
+
+    expect(Cache::get('illuminate:queue:restart'))->toBeNull();
 });

--- a/tests/Feature/Support/QueueTimeoutsTest.php
+++ b/tests/Feature/Support/QueueTimeoutsTest.php
@@ -4,26 +4,20 @@ use App\Facades\AppConfig;
 use App\Jobs\ProcessBackupJob;
 use App\Jobs\ProcessRestoreJob;
 use App\Support\QueueTimeouts;
-use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Facades\Cache;
 
 /**
- * Hold the overlap lock the way the worker running the original copy would.
+ * Hold the overlap lock as the worker running the original copy would, then
+ * report whether a second delivery of the same job still executes.
  */
-$holdOverlapLock = function (ProcessBackupJob|ProcessRestoreJob $job): void {
-    /** @var WithoutOverlapping $middleware */
-    $middleware = $job->middleware()[0];
+$duplicateRuns = function (
+    ProcessBackupJob|ProcessRestoreJob $original,
+    ProcessBackupJob|ProcessRestoreJob $duplicate,
+): bool {
+    Cache::lock($original->middleware()[0]->getLockKey($original), 60)->get();
 
-    Cache::lock($middleware->getLockKey($job), 60)->get();
-};
-
-/**
- * Run a job through its overlap middleware and report whether it executed.
- */
-$runThroughOverlapGuard = function (ProcessBackupJob|ProcessRestoreJob $job): bool {
     $executed = false;
-
-    $job->middleware()[0]->handle($job, function () use (&$executed) {
+    $duplicate->middleware()[0]->handle($duplicate, function () use (&$executed) {
         $executed = true;
     });
 
@@ -55,26 +49,23 @@ test('an explicitly higher retry_after is left alone', function () {
 test('the overlap lock outlives the job but expires before a retry is allowed', function () {
     AppConfig::set('backup.job_timeout', 3600);
 
+    $guard = QueueTimeouts::overlapGuard('snapshot-id', 3600);
+
     // A lock shorter than the job would let a duplicate through mid-run; one
     // longer than retry_after would swallow the retry after a killed worker.
-    expect(QueueTimeouts::lockExpiry(3600))->toBeGreaterThan(3600)
-        ->and(QueueTimeouts::lockExpiry(3600))->toBeLessThan(QueueTimeouts::retryAfter());
+    expect($guard->expiresAfter)->toBeGreaterThan(3600)
+        ->and($guard->expiresAfter)->toBeLessThan(QueueTimeouts::retryAfter())
+        ->and($guard->releaseAfter)->toBeNull();
 });
 
-test('a backup re-delivered while the original is still running is dropped', function () use ($holdOverlapLock, $runThroughOverlapGuard) {
-    $holdOverlapLock(new ProcessBackupJob('snapshot-id'));
-
-    expect($runThroughOverlapGuard(new ProcessBackupJob('snapshot-id')))->toBeFalse();
+test('a backup re-delivered while the original is still running is dropped', function () use ($duplicateRuns) {
+    expect($duplicateRuns(new ProcessBackupJob('snapshot-id'), new ProcessBackupJob('snapshot-id')))->toBeFalse();
 });
 
-test('a restore re-delivered while the original is still running is dropped', function () use ($holdOverlapLock, $runThroughOverlapGuard) {
-    $holdOverlapLock(new ProcessRestoreJob('restore-id'));
-
-    expect($runThroughOverlapGuard(new ProcessRestoreJob('restore-id')))->toBeFalse();
+test('a restore re-delivered while the original is still running is dropped', function () use ($duplicateRuns) {
+    expect($duplicateRuns(new ProcessRestoreJob('restore-id'), new ProcessRestoreJob('restore-id')))->toBeFalse();
 });
 
-test('backups of different snapshots still run concurrently', function () use ($holdOverlapLock, $runThroughOverlapGuard) {
-    $holdOverlapLock(new ProcessBackupJob('snapshot-one'));
-
-    expect($runThroughOverlapGuard(new ProcessBackupJob('snapshot-two')))->toBeTrue();
+test('backups of different snapshots still run concurrently', function () use ($duplicateRuns) {
+    expect($duplicateRuns(new ProcessBackupJob('snapshot-one'), new ProcessBackupJob('snapshot-two')))->toBeTrue();
 });

--- a/tests/Feature/Support/QueueTimeoutsTest.php
+++ b/tests/Feature/Support/QueueTimeoutsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Facades\AppConfig;
+use App\Jobs\ProcessBackupJob;
+use App\Jobs\ProcessRestoreJob;
+use App\Support\QueueTimeouts;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Hold the overlap lock the way the worker running the original copy would.
+ */
+$holdOverlapLock = function (ProcessBackupJob|ProcessRestoreJob $job): void {
+    /** @var WithoutOverlapping $middleware */
+    $middleware = $job->middleware()[0];
+
+    Cache::lock($middleware->getLockKey($job), 60)->get();
+};
+
+/**
+ * Run a job through its overlap middleware and report whether it executed.
+ */
+$runThroughOverlapGuard = function (ProcessBackupJob|ProcessRestoreJob $job): bool {
+    $executed = false;
+
+    $job->middleware()[0]->handle($job, function () use (&$executed) {
+        $executed = true;
+    });
+
+    return $executed;
+};
+
+test('retry_after is raised above the configured job timeout', function () {
+    AppConfig::set('backup.job_timeout', 3600);
+    config([
+        'queue.connections.database.retry_after' => 90,
+        'queue.connections.redis.retry_after' => 90,
+    ]);
+
+    QueueTimeouts::apply();
+
+    expect(config('queue.connections.database.retry_after'))->toBe(3900)
+        ->and(config('queue.connections.redis.retry_after'))->toBe(3900);
+});
+
+test('an explicitly higher retry_after is left alone', function () {
+    AppConfig::set('backup.job_timeout', 3600);
+    config(['queue.connections.database.retry_after' => 20000]);
+
+    QueueTimeouts::apply();
+
+    expect(config('queue.connections.database.retry_after'))->toBe(20000);
+});
+
+test('the overlap lock outlives the job but expires before a retry is allowed', function () {
+    AppConfig::set('backup.job_timeout', 3600);
+
+    // A lock shorter than the job would let a duplicate through mid-run; one
+    // longer than retry_after would swallow the retry after a killed worker.
+    expect(QueueTimeouts::lockExpiry(3600))->toBeGreaterThan(3600)
+        ->and(QueueTimeouts::lockExpiry(3600))->toBeLessThan(QueueTimeouts::retryAfter());
+});
+
+test('a backup re-delivered while the original is still running is dropped', function () use ($holdOverlapLock, $runThroughOverlapGuard) {
+    $holdOverlapLock(new ProcessBackupJob('snapshot-id'));
+
+    expect($runThroughOverlapGuard(new ProcessBackupJob('snapshot-id')))->toBeFalse();
+});
+
+test('a restore re-delivered while the original is still running is dropped', function () use ($holdOverlapLock, $runThroughOverlapGuard) {
+    $holdOverlapLock(new ProcessRestoreJob('restore-id'));
+
+    expect($runThroughOverlapGuard(new ProcessRestoreJob('restore-id')))->toBeFalse();
+});
+
+test('backups of different snapshots still run concurrently', function () use ($holdOverlapLock, $runThroughOverlapGuard) {
+    $holdOverlapLock(new ProcessBackupJob('snapshot-one'));
+
+    expect($runThroughOverlapGuard(new ProcessBackupJob('snapshot-two')))->toBeTrue();
+});


### PR DESCRIPTION
Fixes #488.

## Cause

`retry_after` on the `database` and `redis` queue connections defaulted to 90 seconds, while `backup.job_timeout` defaults to 7200. Laravel hands a reserved job to another worker once `retry_after` elapses, whether or not it is still running, so any dump longer than 90 seconds was picked up a second time mid-run. With two workers that means two concurrent `pg_dump`s of the same snapshot. The timestamps in the issue are 91 seconds apart.

A single worker is affected too, it just re-runs the job after the first pass finishes instead of running it in parallel.

Reproduced locally with `retry_after=5` and a 20s job:

```
07:58:45 START attempt=1 pid=1198
07:58:50 START attempt=2 pid=1207
07:58:55 START attempt=3 pid=1162
07:59:05 END   attempt=1 pid=1198
```

## Fix

**1. `retry_after` now tracks the job timeout.** New `App\Support\QueueTimeouts` computes `backup.job_timeout + 300` and raises the `database`, `redis` and `beanstalkd` connections to it. It only raises, never lowers, so an explicitly configured higher value is kept. Applied from `AppServiceProvider::boot()`, console only (workers are the only thing that acts on `retry_after`, so web requests don't pay for the config read) and skipped in agent mode.

This has to happen at runtime rather than as a config default, because `job_timeout` is editable in the Configuration screen. Existing installs pick it up with no `.env` change, which matters because neither the compose file, the Helm chart, nor the native docs set these vars.

**2. Overlap guard on both jobs.** `ProcessBackupJob` and `ProcessRestoreJob` carry `WithoutOverlapping(<id>)->expireAfter(timeout + 60)->dontRelease()`. `dontRelease()` is the important part: a released duplicate would just run the same dump again once the original finished, so it is dropped instead.

The three values keep the order `job timeout < lock expiry < retry_after`. The lock outliving the job is what blocks a mid-run duplicate; the lock expiring before `retry_after` is what still allows a genuine retry when a worker is SIGKILLed and the `finally` never runs.

`RecoverStuckJobsCommand` now takes its 300s grace from `QueueTimeouts::RETRY_GRACE_SECONDS`, same quantity with one definition.

SQS is untouched: its equivalent is the visibility timeout on the AWS queue, which cannot be set from config. Noted in `config/queue.php`.

## Verification

Worker context after the change:

```
retry_after=7500 job_timeout=7200
```

6 new tests in `tests/Feature/Support/QueueTimeoutsTest.php`: `retry_after` is raised above the timeout, an explicitly higher value is untouched, the lock-expiry ordering invariant, a re-delivered backup and a re-delivered restore are each dropped rather than executed (through the real middleware and cache lock), and different snapshots still run concurrently.

Full suite green (1411 passed), PHPStan and Pint clean.

One caveat worth flagging: raising `retry_after` is per-connection, so it also delays retries for `default` queue jobs after a hard worker kill. The overlap guard plus the existing `jobs:recover-stuck` schedule is what makes that acceptable.

## Follow-up: workers must restart when the timeout changes

A worker resolves `retry_after` once, at boot (the value is baked into the queue connection by `DatabaseConnector`), so raising `backup.job_timeout` in the Configuration screen left running workers with a `retry_after` below the timeout of the jobs they picked up next. Saving a changed job timeout now calls `queue:restart`. The flag is only read between jobs, so nothing in flight is interrupted.

The reverse case (timeout lowered while a job queued under the old, larger timeout is still pending) needs no extra handling: the overlap lock expiry derives from the job's own serialized timeout, not from current config, so that job still holds its lock longer than the new `retry_after` and a duplicate delivery is dropped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate backup and restore jobs from running concurrently.
  * Duplicate jobs are now discarded while an identical job is in progress.
  * Improved queue retry timing for long-running jobs.

* **Improvements**
  * Standardized queue timeout and lock-expiry handling across supported queue drivers.
  * Preserved explicitly configured retry delays when they exceed required minimums.
  * Queue workers now restart automatically when backup job timeouts change.
  * Applied queue safeguards without affecting web requests or agent operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->