### PR TITLE
Harden organization scoping and path validation

### DIFF
--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -3,6 +3,8 @@
 namespace App\Enums;
 
 use App\Models\DatabaseServer;
+use App\Rules\SafeDatabasePath;
+use Illuminate\Contracts\Validation\ValidationRule;
 
 enum DatabaseType: string
 {
@@ -153,16 +155,17 @@ enum DatabaseType: string
      * Validation rules for a destination database name/path of this type.
      *
      * SQLite accepts any non-empty path. Firebird is a path too but with a
-     * restricted character set. All other types use the conservative
-     * identifier charset (letters, numbers, underscores).
+     * restricted character set. Both are additionally checked for traversal,
+     * since a restore writes to the path directly. All other types use the
+     * conservative identifier charset (letters, numbers, underscores).
      *
-     * @return array<int, string>
+     * @return array<int, ValidationRule|string>
      */
     public function databaseNameRules(): array
     {
         return match ($this) {
-            self::SQLITE => ['required', 'string', 'max:255'],
-            self::FIREBIRD => ['required', 'string', 'max:255', 'regex:/^[a-zA-Z0-9_\/\\\\.\-: ]+$/'],
+            self::SQLITE => ['required', 'string', 'max:255', new SafeDatabasePath],
+            self::FIREBIRD => ['required', 'string', 'max:255', 'regex:/^[a-zA-Z0-9_\/\\\\.\-: ]+$/', new SafeDatabasePath(allowBackslashes: true)],
             default => ['required', 'string', 'max:64', 'regex:/^[a-zA-Z0-9_]+$/'],
         };
     }

--- a/app/Http/Controllers/Api/V1/AgentController.php
+++ b/app/Http/Controllers/Api/V1/AgentController.php
@@ -9,6 +9,7 @@ use App\Models\AgentJob;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\Snapshot;
+use App\Rules\SafePath;
 use App\Services\Agent\AgentJobPayloadBuilder;
 use App\Services\Backup\BackupJobFactory;
 use App\Services\NotificationService;
@@ -172,7 +173,7 @@ class AgentController extends Controller
         }
 
         $validated = $request->validate([
-            'filename' => 'required|string|max:1000',
+            'filename' => ['required', 'string', 'max:1000', new SafePath],
             'file_size' => 'required|integer|min:0',
             'checksum' => 'nullable|string|max:255',
             ...self::volumeResultRules(),
@@ -311,7 +312,7 @@ class AgentController extends Controller
 
         $validated = $request->validate([
             'error_message' => 'required|string|max:10000',
-            'filename' => 'nullable|string|max:1000',
+            'filename' => ['nullable', 'string', 'max:1000', new SafePath],
             'file_size' => 'nullable|integer|min:0',
             ...self::volumeResultRules(),
             ...self::logRules(),

--- a/app/Http/Controllers/Api/V1/DatabaseServerController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerController.php
@@ -202,6 +202,8 @@ class DatabaseServerController extends Controller
         /** @var Snapshot $snapshot */
         $snapshot = Snapshot::findOrFail($request->validated('snapshot_id'));
 
+        $this->authorize('restoreFrom', $snapshot);
+
         /** @var int|null $userId */
         $userId = auth()->id();
 

--- a/app/Http/Controllers/Web/SnapshotDownloadController.php
+++ b/app/Http/Controllers/Web/SnapshotDownloadController.php
@@ -54,7 +54,26 @@ class SnapshotDownloadController extends Controller
             __('Backup file not found or not readable by the web server. Ensure the volume path is mounted into the web container and readable by the application user.')
         );
 
+        abort_unless($this->isInsideVolume($fullPath, $volumeRoot), 404, __('Backup file not found.'));
+
         return response()->download($fullPath, basename($file->storedFilename()));
+    }
+
+    /**
+     * The stored filename originates from the agent that produced the backup,
+     * so the resolved path is confirmed to stay under the volume root before
+     * anything is read.
+     */
+    private function isInsideVolume(string $fullPath, string $volumeRoot): bool
+    {
+        $root = realpath($volumeRoot);
+        $resolved = realpath($fullPath);
+
+        if ($root === false || $resolved === false) {
+            return false;
+        }
+
+        return str_starts_with($resolved, rtrim($root, '/').'/');
     }
 
     /**

--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -8,6 +8,7 @@ use App\Enums\VolumeType;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\Volume;
+use App\Rules\SafeHost;
 use App\Rules\SafePath;
 use App\Services\CurrentOrganization;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -61,7 +62,7 @@ class SaveDatabaseServerRequest extends FormRequest
         $type = $this->input('database_type');
 
         if (in_array($type, ['mysql', 'postgres', 'mongodb', 'redis'])) {
-            $rules['host'] = 'required|string|max:255';
+            $rules['host'] = ['required', 'string', 'max:255', new SafeHost];
             $rules['port'] = 'required|integer|min:1|max:65535';
         }
 

--- a/app/Http/Requests/Api/V1/SaveScheduledRestoreRequest.php
+++ b/app/Http/Requests/Api/V1/SaveScheduledRestoreRequest.php
@@ -29,10 +29,14 @@ class SaveScheduledRestoreRequest extends FormRequest
 
     public function withValidator(Validator $validator): void
     {
-        $validator->after(fn (Validator $v) => $this->validateServerTypesMatch($v));
+        $validator->after(fn (Validator $v) => $this->validateServers($v));
     }
 
-    private function validateServerTypesMatch(Validator $validator): void
+    /**
+     * `exists` ignores Eloquent scopes, so both ids are re-resolved through the
+     * org-scoped model: an unresolvable id belongs to another organization.
+     */
+    private function validateServers(Validator $validator): void
     {
         $sourceId = $this->input('source_server_id');
         $targetId = $this->input('target_server_id');
@@ -43,6 +47,14 @@ class SaveScheduledRestoreRequest extends FormRequest
 
         $source = DatabaseServer::find($sourceId);
         $target = DatabaseServer::find($targetId);
+
+        if (! $source) {
+            $validator->errors()->add('source_server_id', __('The selected source server is invalid.'));
+        }
+
+        if (! $target) {
+            $validator->errors()->add('target_server_id', __('The selected target server is invalid.'));
+        }
 
         if (! $source || ! $target) {
             return;

--- a/app/Http/Requests/Api/V1/Volume/StoreS3VolumeRequest.php
+++ b/app/Http/Requests/Api/V1/Volume/StoreS3VolumeRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Volume;
 
 use App\Enums\VolumeType;
+use App\Rules\SafeEndpointUrl;
 use App\Rules\SafePath;
 
 class StoreS3VolumeRequest extends StoreVolumeRequest
@@ -23,12 +24,12 @@ class StoreS3VolumeRequest extends StoreVolumeRequest
             'config.region' => ['required', 'string', 'max:255'],
             'config.access_key_id' => ['required_with:config.secret_access_key', 'nullable', 'string', 'max:255'],
             'config.secret_access_key' => ['required_with:config.access_key_id', 'nullable', 'string', 'max:1000'],
-            'config.custom_endpoint' => ['nullable', 'string', 'max:255'],
-            'config.public_endpoint' => ['nullable', 'string', 'max:255'],
+            'config.custom_endpoint' => ['nullable', 'string', 'max:255', new SafeEndpointUrl],
+            'config.public_endpoint' => ['nullable', 'string', 'max:255', new SafeEndpointUrl],
             'config.use_path_style_endpoint' => ['nullable', 'boolean'],
             'config.custom_role_arn' => ['nullable', 'string', 'max:255'],
             'config.role_session_name' => ['nullable', 'string', 'max:255'],
-            'config.sts_endpoint' => ['nullable', 'string', 'max:255'],
+            'config.sts_endpoint' => ['nullable', 'string', 'max:255', new SafeEndpointUrl],
         ];
     }
 }

--- a/app/Livewire/Dashboard/SnapshotsCard.php
+++ b/app/Livewire/Dashboard/SnapshotsCard.php
@@ -31,7 +31,7 @@ class SnapshotsCard extends Component
 
     private function loadData(): void
     {
-        $baseQuery = Snapshot::forCurrentOrg()->completed();
+        $baseQuery = Snapshot::query()->completed();
 
         $this->totalSnapshots = $baseQuery->count();
         $this->verifiedSnapshots = (clone $baseQuery)

--- a/app/Livewire/Dashboard/StorageCard.php
+++ b/app/Livewire/Dashboard/StorageCard.php
@@ -27,7 +27,7 @@ class StorageCard extends Component
 
     private function loadData(): void
     {
-        $totalBytes = Snapshot::forCurrentOrg()->completed()->sum('file_size');
+        $totalBytes = Snapshot::query()->completed()->sum('file_size');
         $this->totalStorage = Formatters::humanFileSize((int) $totalBytes);
     }
 

--- a/app/Livewire/Dashboard/StorageDistributionChart.php
+++ b/app/Livewire/Dashboard/StorageDistributionChart.php
@@ -20,7 +20,7 @@ class StorageDistributionChart extends Component
     public function mount(): void
     {
         /** @var \Illuminate\Support\Collection<int, object{name: string, total_size: int}> $storageByVolume */
-        $storageByVolume = Snapshot::forCurrentOrg()
+        $storageByVolume = Snapshot::query()
             ->join('snapshot_files', 'snapshot_files.snapshot_id', '=', 'snapshots.id')
             ->where('snapshot_files.status', SnapshotFileStatus::Completed)
             ->join('volumes', 'snapshot_files.volume_id', '=', 'volumes.id')

--- a/app/Livewire/DatabaseServer/Connection/ClientServerConnectionRules.php
+++ b/app/Livewire/DatabaseServer/Connection/ClientServerConnectionRules.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\DatabaseServer\Connection;
 
 use App\Livewire\DatabaseServer\Form;
+use App\Rules\SafeHost;
 
 /**
  * Default rules for networked databases that authenticate with
@@ -13,7 +14,7 @@ class ClientServerConnectionRules extends ConnectionRules
     public function rules(Form $form): array
     {
         return [
-            'host' => 'required|string|max:255',
+            'host' => ['required', 'string', 'max:255', new SafeHost],
             'port' => 'required|integer|min:1|max:65535',
             'username' => 'required|string|max:255',
             'password' => 'nullable',

--- a/app/Livewire/DatabaseServer/Connection/MongodbConnectionRules.php
+++ b/app/Livewire/DatabaseServer/Connection/MongodbConnectionRules.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\DatabaseServer\Connection;
 
 use App\Livewire\DatabaseServer\Form;
+use App\Rules\SafeHost;
 
 class MongodbConnectionRules extends ClientServerConnectionRules
 {
@@ -20,7 +21,7 @@ class MongodbConnectionRules extends ClientServerConnectionRules
     public function testConnectionRules(Form $form): array
     {
         return [
-            'host' => 'required|string|max:255',
+            'host' => ['required', 'string', 'max:255', new SafeHost],
             'port' => $this->portRule($form),
         ];
     }

--- a/app/Livewire/DatabaseServer/Connection/RedisConnectionRules.php
+++ b/app/Livewire/DatabaseServer/Connection/RedisConnectionRules.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\DatabaseServer\Connection;
 
 use App\Livewire\DatabaseServer\Form;
+use App\Rules\SafeHost;
 
 /**
  * Redis servers may run without AUTH, so credentials are optional and the
@@ -20,7 +21,7 @@ class RedisConnectionRules extends ClientServerConnectionRules
     public function testConnectionRules(Form $form): array
     {
         return [
-            'host' => 'required|string|max:255',
+            'host' => ['required', 'string', 'max:255', new SafeHost],
             'port' => 'required|integer|min:1|max:65535',
         ];
     }

--- a/app/Livewire/ScheduledRestore/Modal.php
+++ b/app/Livewire/ScheduledRestore/Modal.php
@@ -146,6 +146,10 @@ class Modal extends Component
             'sourceServerId.required' => __('Please select a source server.'),
             'sourceDatabaseName.required' => __('Please select the source database.'),
         ]);
+
+        // `exists` ignores the organization scope; re-resolve through the model
+        // so a server from another organization cannot be used as the source.
+        DatabaseServer::findOrFail($this->sourceServerId);
     }
 
     protected function validateTargetStep(): void

--- a/app/Livewire/Volume/Connectors/S3Config.php
+++ b/app/Livewire/Volume/Connectors/S3Config.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Volume\Connectors;
 
+use App\Rules\SafeEndpointUrl;
 use App\Rules\SafePath;
 
 class S3Config extends BaseConfig
@@ -37,12 +38,12 @@ class S3Config extends BaseConfig
             "{$prefix}.region" => ['required_if:type,s3', 'string', 'max:255'],
             "{$prefix}.access_key_id" => ["required_with:{$prefix}.secret_access_key", 'nullable', 'string', 'max:255'],
             "{$prefix}.secret_access_key" => ["required_with:{$prefix}.access_key_id", 'nullable', 'string', 'max:1000'],
-            "{$prefix}.custom_endpoint" => ['nullable', 'string', 'max:255'],
-            "{$prefix}.public_endpoint" => ['nullable', 'string', 'max:255'],
+            "{$prefix}.custom_endpoint" => ['nullable', 'string', 'max:255', new SafeEndpointUrl],
+            "{$prefix}.public_endpoint" => ['nullable', 'string', 'max:255', new SafeEndpointUrl],
             "{$prefix}.use_path_style_endpoint" => ['nullable', 'boolean'],
             "{$prefix}.custom_role_arn" => ['nullable', 'string', 'max:255'],
             "{$prefix}.role_session_name" => ['nullable', 'string', 'max:255'],
-            "{$prefix}.sts_endpoint" => ['nullable', 'string', 'max:255'],
+            "{$prefix}.sts_endpoint" => ['nullable', 'string', 'max:255', new SafeEndpointUrl],
         ];
     }
 }

--- a/app/Mcp/Tools/TriggerRestoreTool.php
+++ b/app/Mcp/Tools/TriggerRestoreTool.php
@@ -28,13 +28,18 @@ class TriggerRestoreTool extends Tool
             'schema_name' => 'required|string|max:255',
         ]);
 
-        /** @var Snapshot $snapshot */
-        $snapshot = Snapshot::findOrFail($validated['snapshot_id']);
+        // `exists` ignores the organization scope, so resolve both through the
+        // scoped models: an unresolvable id belongs to another organization.
+        $snapshot = Snapshot::find((string) $validated['snapshot_id']);
+        $targetServer = DatabaseServer::find((string) $validated['database_server_id']);
 
-        /** @var DatabaseServer $targetServer */
-        $targetServer = DatabaseServer::findOrFail($validated['database_server_id']);
+        if (! $snapshot || ! $targetServer) {
+            return Response::error('Snapshot or database server not found.');
+        }
 
-        if (! $request->user()?->can('restore', $targetServer)) {
+        $user = $request->user();
+
+        if (! $user?->can('restore', $targetServer) || ! $user->can('restoreFrom', $snapshot)) {
             return Response::error('Permission denied. You do not have permission to trigger restores.');
         }
 
@@ -43,7 +48,7 @@ class TriggerRestoreTool extends Tool
                 snapshot: $snapshot,
                 targetServer: $targetServer,
                 schemaName: $validated['schema_name'],
-                triggeredByUserId: $request->user()->getAuthIdentifier()
+                triggeredByUserId: $user->getAuthIdentifier()
             );
         } catch (ValidationException $e) {
             return Response::error(collect($e->errors())->flatten()->implode(' '));

--- a/app/Models/ScheduledRestore.php
+++ b/app/Models/ScheduledRestore.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Scopes\DatabaseServerOrganizationScope;
 use Database\Factories\ScheduledRestoreFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -23,6 +24,15 @@ class ScheduledRestore extends Model
     public const string SKIP_PREVIOUS_IN_FLIGHT = 'previous_in_flight';
 
     public const string SKIP_DISABLED = 'disabled';
+
+    /**
+     * Tenancy is inherited from the target server; the source server is
+     * constrained to the same organization at validation time.
+     */
+    protected static function booted(): void
+    {
+        static::addGlobalScope(new DatabaseServerOrganizationScope('target_server_id'));
+    }
 
     protected $fillable = [
         'name',

--- a/app/Models/Scopes/DatabaseServerOrganizationScope.php
+++ b/app/Models/Scopes/DatabaseServerOrganizationScope.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models\Scopes;
+
+use App\Services\CurrentOrganization;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+/**
+ * Organization scope for models that own no `organization_id` column and
+ * inherit their tenant from a related database server. Like {@see OrganizationScope},
+ * it does not apply in CLI context where no org is resolved.
+ *
+ * @implements Scope<Model>
+ */
+readonly class DatabaseServerOrganizationScope implements Scope
+{
+    /**
+     * @param  string  $foreignKey  Column on the scoped table pointing at `database_servers.id`.
+     */
+    public function __construct(private string $foreignKey) {}
+
+    public function apply(Builder $builder, Model $model): void
+    {
+        $currentOrg = app(CurrentOrganization::class);
+
+        if (! $currentOrg->isResolved()) {
+            return;
+        }
+
+        $orgId = $currentOrg->id();
+        $column = $model->getTable().'.'.$this->foreignKey;
+
+        $builder->getQuery()->whereExists(function (QueryBuilder $query) use ($column, $orgId) {
+            $query->from('database_servers')
+                ->whereColumn('database_servers.id', $column)
+                ->where('database_servers.organization_id', $orgId);
+        });
+    }
+}

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -6,8 +6,7 @@ use App\Enums\BackupJobStatus;
 use App\Enums\CompressionType;
 use App\Enums\DatabaseType;
 use App\Enums\SnapshotFileStatus;
-use App\Models\Scopes\OrganizationScope;
-use App\Services\CurrentOrganization;
+use App\Models\Scopes\DatabaseServerOrganizationScope;
 use App\Support\Formatters;
 use Database\Factories\SnapshotFactory;
 use Illuminate\Database\Eloquent\Builder;
@@ -173,6 +172,9 @@ class Snapshot extends Model
 
     protected static function booted(): void
     {
+        // Tenancy is inherited from the database server the snapshot was taken from.
+        static::addGlobalScope(new DatabaseServerOrganizationScope('database_server_id'));
+
         // Delete the backup files, associated restores and job when snapshot is deleted
         static::deleting(function (Snapshot $snapshot) {
             if (! $snapshot->skipFileCleanup) {
@@ -191,22 +193,6 @@ class Snapshot extends Model
 
             // Delete the snapshot's own job
             $snapshot->job->delete();
-        });
-    }
-
-    /**
-     * Scope to filter snapshots by the current organization.
-     *
-     * @param  Builder<static>  $query
-     * @return Builder<static>
-     */
-    public function scopeForCurrentOrg(Builder $query): Builder
-    {
-        $orgId = app(CurrentOrganization::class)->id();
-
-        return $query->whereHas('databaseServer', function (Builder $sq) use ($orgId) {
-            $sq->withoutGlobalScope(OrganizationScope::class)
-                ->whereRaw('organization_id = ?', [$orgId]);
         });
     }
 

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -82,8 +82,6 @@ class SnapshotQuery
         $query = Snapshot::query()
             ->with(self::relationships());
 
-        $query->forCurrentOrg();
-
         $query
             ->when($search, function (Builder $query) use ($search) {
                 self::applySearch($query, $search);

--- a/app/Rules/SafeDatabasePath.php
+++ b/app/Rules/SafeDatabasePath.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Path-shaped database names (SQLite files, Firebird aliases) are written to
+ * directly at restore time, so they must not be able to escape their directory.
+ *
+ * Distinct from {@see SafePath}, which guards paths relative to a storage root:
+ * these are absolute on the database host, and Firebird needs Windows-style
+ * backslashes. Traversal is matched per segment, so `app..sqlite` stays valid.
+ */
+readonly class SafeDatabasePath implements ValidationRule
+{
+    public function __construct(
+        private bool $allowBackslashes = false
+    ) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        if (str_contains($value, "\0")) {
+            $fail(__('The database path must not contain null bytes.'));
+
+            return;
+        }
+
+        if (! $this->allowBackslashes && str_contains($value, '\\')) {
+            $fail(__('The database path must not contain backslashes.'));
+
+            return;
+        }
+
+        $segments = explode('/', str_replace('\\', '/', $value));
+
+        if (in_array('..', $segments, true)) {
+            $fail(__('The database path must not contain path traversal sequences (..).'));
+        }
+    }
+}

--- a/app/Rules/SafeEndpointUrl.php
+++ b/app/Rules/SafeEndpointUrl.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Validates a user-supplied service endpoint (S3, STS) before it is handed to an
+ * SDK that will fetch it server-side.
+ *
+ * Private and loopback addresses stay allowed on purpose: pointing a volume at
+ * an on-premise MinIO is a first-class use case here. What is refused is the
+ * link-local range, which serves no storage endpoint and is how cloud instance
+ * metadata (and its IAM credentials) is reached.
+ *
+ * This narrows the reachable surface, it does not eliminate SSRF: DNS may still
+ * change between validation and use. Egress restrictions remain the real control.
+ */
+readonly class SafeEndpointUrl implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        $parts = parse_url($value);
+
+        if ($parts === false || ! isset($parts['scheme'], $parts['host']) || $parts['host'] === '') {
+            $fail(__('The :attribute must be a valid URL including a scheme and host.'));
+
+            return;
+        }
+
+        if (! in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+            $fail(__('The :attribute must use the http or https scheme.'));
+
+            return;
+        }
+
+        foreach ($this->addressesFor($parts['host']) as $address) {
+            if ($this->isLinkLocal($address)) {
+                $fail(__('The :attribute must not resolve to a link-local or instance metadata address.'));
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * Resolution is best-effort: a host this server cannot resolve is not
+     * rejected, since the backup worker may resolve it differently.
+     *
+     * @return list<string>
+     */
+    private function addressesFor(string $host): array
+    {
+        $host = trim($host, '[]');
+
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [$host];
+        }
+
+        return gethostbynamel($host) ?: [];
+    }
+
+    private function isLinkLocal(string $address): bool
+    {
+        $packed = @inet_pton($address);
+
+        if ($packed === false) {
+            return false;
+        }
+
+        // Unwrap ::ffff:a.b.c.d so a mapped address cannot skip the IPv4 check.
+        if (strlen($packed) === 16 && str_starts_with($packed, str_repeat("\x00", 10)."\xff\xff")) {
+            $packed = substr($packed, 12);
+        }
+
+        if (strlen($packed) === 4) {
+            return str_starts_with($packed, "\xa9\xfe"); // 169.254.0.0/16
+        }
+
+        // fe80::/10, plus the IPv6 instance metadata address used by EC2.
+        return (ord($packed[0]) === 0xFE && (ord($packed[1]) & 0xC0) === 0x80)
+            || $packed === inet_pton('fd00:ec2::254');
+    }
+}

--- a/app/Rules/SafeEndpointUrl.php
+++ b/app/Rules/SafeEndpointUrl.php
@@ -62,7 +62,17 @@ readonly class SafeEndpointUrl implements ValidationRule
             return [$host];
         }
 
-        return gethostbynamel($host) ?: [];
+        $addresses = gethostbynamel($host) ?: [];
+
+        // gethostbynamel() is IPv4-only, so an AAAA-only host would otherwise
+        // resolve to nothing and skip the check entirely.
+        foreach (@dns_get_record($host, DNS_AAAA) ?: [] as $record) {
+            if (isset($record['ipv6']) && is_string($record['ipv6'])) {
+                $addresses[] = $record['ipv6'];
+            }
+        }
+
+        return $addresses;
     }
 
     private function isLinkLocal(string $address): bool

--- a/app/Rules/SafeHost.php
+++ b/app/Rules/SafeHost.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * A database server host is interpolated into connection strings without
+ * escaping: PDO DSNs delimited by `;` and `,`, and MongoDB URIs where `@`
+ * separates credentials from the authority. A host carrying any of those
+ * characters can redirect the connection elsewhere, so restrict it to what a
+ * hostname, IPv4 address or IPv6 literal actually needs.
+ */
+readonly class SafeHost implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        if (preg_match('/^[A-Za-z0-9._:\[\]-]+$/', $value) !== 1) {
+            $fail(__('The :attribute may only contain letters, numbers, dots, dashes, underscores, colons and square brackets.'));
+        }
+    }
+}

--- a/app/Rules/SafeHost.php
+++ b/app/Rules/SafeHost.php
@@ -14,13 +14,20 @@ use Illuminate\Contracts\Validation\ValidationRule;
  */
 readonly class SafeHost implements ValidationRule
 {
+    /**
+     * Anchored with \A and \z rather than ^ and $, which would let a trailing
+     * newline through. Shared with the connection-string builders that treat
+     * this as their last line of defence.
+     */
+    public const PATTERN = '/\A[A-Za-z0-9._:\[\]-]+\z/';
+
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (! is_string($value) || $value === '') {
             return;
         }
 
-        if (preg_match('/^[A-Za-z0-9._:\[\]-]+$/', $value) !== 1) {
+        if (preg_match(self::PATTERN, $value) !== 1) {
             $fail(__('The :attribute may only contain letters, numbers, dots, dashes, underscores, colons and square brackets.'));
         }
     }

--- a/app/Rules/SafePath.php
+++ b/app/Rules/SafePath.php
@@ -17,6 +17,13 @@ readonly class SafePath implements ValidationRule
             return;
         }
 
+        // Reject null bytes (truncate paths in some filesystem calls)
+        if (str_contains($value, "\0")) {
+            $fail('The :attribute must not contain null bytes.');
+
+            return;
+        }
+
         // Reject path traversal sequences
         if (str_contains($value, '..')) {
             $fail('The :attribute must not contain path traversal sequences (..).');

--- a/app/Services/Backup/BackupJobFactory.php
+++ b/app/Services/Backup/BackupJobFactory.php
@@ -12,6 +12,7 @@ use App\Models\Backup;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
 use App\Models\Restore;
+use App\Models\Scopes\OrganizationScope;
 use App\Models\Snapshot;
 use App\Services\Backup\Databases\DatabaseProvider;
 use App\Services\NotificationService;
@@ -206,6 +207,18 @@ class BackupJobFactory
         if ($snapshot->database_type !== $targetServer->database_type) {
             throw ValidationException::withMessages([
                 'snapshot_id' => 'Snapshot database type does not match the target server.',
+            ]);
+        }
+
+        // Tenant boundary, enforced here because scheduled restores reach this
+        // factory from the CLI, where no organization scope is active.
+        $sourceOrganizationId = DatabaseServer::withoutGlobalScope(OrganizationScope::class)
+            ->whereKey($snapshot->database_server_id)
+            ->value('organization_id');
+
+        if ($sourceOrganizationId !== $targetServer->organization_id) {
+            throw ValidationException::withMessages([
+                'snapshot_id' => 'Snapshot belongs to a different organization than the target server.',
             ]);
         }
 

--- a/app/Services/Backup/Databases/MongodbDatabase.php
+++ b/app/Services/Backup/Databases/MongodbDatabase.php
@@ -159,6 +159,13 @@ class MongodbDatabase implements DatabaseInterface
      */
     public static function buildConnectionUri(string $host, ?int $port, string $user = '', string $pass = '', array $options = []): string
     {
+        // The last `@` in the authority wins, so a host carrying one would move
+        // the connection to whatever follows it. Encoding is not an option here
+        // because IPv6 literals need their colons and brackets intact.
+        if (preg_match('#[@/\\\\?\#\s]#', $host) === 1) {
+            throw new \InvalidArgumentException('MongoDB host contains characters that are not valid in a connection URI.');
+        }
+
         $srv = ! empty($options['srv']);
         $scheme = $srv ? 'mongodb+srv' : 'mongodb';
         $hostPart = $srv ? $host : sprintf('%s:%d', $host, (int) $port);

--- a/app/Services/Backup/Databases/MongodbDatabase.php
+++ b/app/Services/Backup/Databases/MongodbDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Databases;
 
 use App\Contracts\BackupLogger;
+use App\Rules\SafeHost;
 use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
 use MongoDB\Driver\Command;
@@ -159,10 +160,12 @@ class MongodbDatabase implements DatabaseInterface
      */
     public static function buildConnectionUri(string $host, ?int $port, string $user = '', string $pass = '', array $options = []): string
     {
-        // The last `@` in the authority wins, so a host carrying one would move
-        // the connection to whatever follows it. Encoding is not an option here
-        // because IPv6 literals need their colons and brackets intact.
-        if (preg_match('#[@/\\\\?\#\s]#', $host) === 1) {
+        // A `@` moves the connection to whatever follows it (the last one in an
+        // authority wins) and a `,` turns the host into a seed list, so both can
+        // redirect the connection. Encoding is not an option because IPv6
+        // literals need their colons and brackets intact; allowlist instead,
+        // sharing the rule's definition so the two cannot drift.
+        if (preg_match(SafeHost::PATTERN, $host) !== 1) {
             throw new \InvalidArgumentException('MongoDB host contains characters that are not valid in a connection URI.');
         }
 

--- a/app/Services/Backup/Databases/SqliteDatabase.php
+++ b/app/Services/Backup/Databases/SqliteDatabase.php
@@ -167,6 +167,8 @@ class SqliteDatabase implements DatabaseInterface
         }
 
         $targetPath = $this->config['sqlite_path'];
+        $this->guardLocalTargetPath($targetPath);
+
         if (! @copy($inputPath, $targetPath)) {
             throw new RestoreException("Failed to copy SQLite file {$inputPath} to {$targetPath}");
         }
@@ -177,6 +179,28 @@ class SqliteDatabase implements DatabaseInterface
             'success',
             ['path' => $this->config['sqlite_path']],
         ));
+    }
+
+    /**
+     * A local restore writes onto the application host's own filesystem. A SQLite
+     * file landing in the install directory would be served by the web server, and
+     * PHP executes any `<?php` block embedded in it.
+     */
+    private function guardLocalTargetPath(string $targetPath): void
+    {
+        $base = realpath(base_path());
+
+        // The target file usually does not exist yet, so fall back to the
+        // directory it would land in. An unresolvable path fails the copy anyway.
+        $resolved = realpath($targetPath) ?: realpath(dirname($targetPath));
+
+        if ($base === false || $resolved === false) {
+            return;
+        }
+
+        if ($resolved === $base || str_starts_with($resolved, $base.DIRECTORY_SEPARATOR)) {
+            throw new RestoreException("Refusing to restore into the application directory: {$targetPath}");
+        }
     }
 
     public function prepareForRestore(string $schemaName, BackupLogger $logger, bool $forceDatabase = false): void

--- a/app/Services/Backup/LatestSnapshotResolver.php
+++ b/app/Services/Backup/LatestSnapshotResolver.php
@@ -3,7 +3,7 @@
 namespace App\Services\Backup;
 
 use App\Models\ScheduledRestore;
-use App\Models\Scopes\OrganizationScope;
+use App\Models\Scopes\DatabaseServerOrganizationScope;
 use App\Models\Snapshot;
 
 class LatestSnapshotResolver
@@ -18,7 +18,7 @@ class LatestSnapshotResolver
     public function resolve(ScheduledRestore $scheduledRestore): ?Snapshot
     {
         return Snapshot::query()
-            ->withoutGlobalScope(OrganizationScope::class)
+            ->withoutGlobalScope(DatabaseServerOrganizationScope::class)
             ->where('database_server_id', $scheduledRestore->source_server_id)
             ->where('database_name', $scheduledRestore->source_database_name)
             ->fileExists()

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,10 +4,14 @@ use App\Models\User;
 use Illuminate\Support\Facades\Route;
 use Laravel\Fortify\Features;
 
-// Health check routes (public)
+// Liveness probe (public) — reports nothing about the deployment.
 Route::get('/health', [\App\Http\Controllers\Web\HealthCheckController::class, 'up'])
     ->name('health.up');
+
+// Deployment diagnostics: discloses host, proxy and, in debug mode, request
+// headers and app config, so it requires a signed-in user.
 Route::get('/health/debug', [\App\Http\Controllers\Web\HealthCheckController::class, 'debug'])
+    ->middleware('auth')
     ->name('health.debug');
 
 // Home - redirect based on auth status and user count

--- a/tests/Feature/Agent/AgentApiTest.php
+++ b/tests/Feature/Agent/AgentApiTest.php
@@ -212,36 +212,43 @@ describe('job acknowledgement', function () {
             ->and($backupJob->logs[0]['message'])->toBe('Starting backup for database: testdb');
     });
 
-    test('ack rejects a filename that escapes the volume root', function () {
+    test('ack rejects an unsafe filename', function (string $filename) {
         // An agent is lower-trust than the central server it reports to, so the
-        // filename it supplies must not become a traversal payload.
+        // filename it supplies must not reach the download path unsanitised.
         ['agent' => $agent, 'token' => $token] = createAgentWithToken();
         $agentJob = AgentJob::factory()->claimed($agent)->create();
+        $original = $agentJob->snapshot->filename;
 
         $this->withToken($token)
             ->postJson("/api/v1/agent/jobs/{$agentJob->id}/ack", [
-                'filename' => '../../../../etc/passwd',
+                'filename' => $filename,
                 'file_size' => 12345,
             ])
             ->assertStatus(422)
             ->assertJsonValidationErrors('filename');
 
-        expect($agentJob->snapshot->fresh()->filename)->not->toBe('../../../../etc/passwd');
-    });
+        expect($agentJob->snapshot->fresh()->filename)->toBe($original);
+    })->with([
+        'traversal' => '../../../../etc/passwd',
+        'null byte' => "backups/test.sql.gz\0.php",
+    ]);
 
-    test('fail rejects a filename that escapes the volume root', function () {
+    test('fail rejects an unsafe filename', function (string $filename) {
         ['agent' => $agent, 'token' => $token] = createAgentWithToken();
         $agentJob = AgentJob::factory()->claimed($agent)->create();
 
         $this->withToken($token)
             ->postJson("/api/v1/agent/jobs/{$agentJob->id}/fail", [
                 'error_message' => 'partial upload',
-                'filename' => '/etc/passwd',
+                'filename' => $filename,
                 'file_size' => 12345,
             ])
             ->assertStatus(422)
             ->assertJsonValidationErrors('filename');
-    });
+    })->with([
+        'traversal' => '/etc/passwd',
+        'null byte' => "backups/test.sql.gz\0.php",
+    ]);
 
     test('ack records per-volume results on a multi-volume snapshot', function () {
         ['agent' => $agent, 'token' => $token] = createAgentWithToken();

--- a/tests/Feature/Agent/AgentApiTest.php
+++ b/tests/Feature/Agent/AgentApiTest.php
@@ -212,6 +212,37 @@ describe('job acknowledgement', function () {
             ->and($backupJob->logs[0]['message'])->toBe('Starting backup for database: testdb');
     });
 
+    test('ack rejects a filename that escapes the volume root', function () {
+        // An agent is lower-trust than the central server it reports to, so the
+        // filename it supplies must not become a traversal payload.
+        ['agent' => $agent, 'token' => $token] = createAgentWithToken();
+        $agentJob = AgentJob::factory()->claimed($agent)->create();
+
+        $this->withToken($token)
+            ->postJson("/api/v1/agent/jobs/{$agentJob->id}/ack", [
+                'filename' => '../../../../etc/passwd',
+                'file_size' => 12345,
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('filename');
+
+        expect($agentJob->snapshot->fresh()->filename)->not->toBe('../../../../etc/passwd');
+    });
+
+    test('fail rejects a filename that escapes the volume root', function () {
+        ['agent' => $agent, 'token' => $token] = createAgentWithToken();
+        $agentJob = AgentJob::factory()->claimed($agent)->create();
+
+        $this->withToken($token)
+            ->postJson("/api/v1/agent/jobs/{$agentJob->id}/fail", [
+                'error_message' => 'partial upload',
+                'filename' => '/etc/passwd',
+                'file_size' => 12345,
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('filename');
+    });
+
     test('ack records per-volume results on a multi-volume snapshot', function () {
         ['agent' => $agent, 'token' => $token] = createAgentWithToken();
 

--- a/tests/Feature/BackupJob/SnapshotDownloadTest.php
+++ b/tests/Feature/BackupJob/SnapshotDownloadTest.php
@@ -42,6 +42,31 @@ test('can download snapshot from local storage', function () {
         ->assertDownload($backupFilename);
 });
 
+test('download refuses a filename that escapes the volume root', function () {
+    // The filename is reported by the agent that produced the backup, so the
+    // download must not follow it outside the volume it belongs to.
+    $user = User::factory()->withAbilities([Ability::DownloadSnapshots->value])->create();
+
+    $volume = Volume::factory()->local()->create();
+    $secret = dirname($volume->config['path']).'/agent-traversal-secret.txt';
+    file_put_contents($secret, 'top secret');
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['test_db']]);
+    $server->backups->first()->volumes()->sync([$volume->id]);
+
+    $factory = app(BackupJobFactory::class);
+    $snapshot = $factory->createSnapshots($server->backups->first(), 'manual', $user->id)[0];
+    $snapshot->update(['filename' => '../'.basename($secret), 'file_size' => filesize($secret)]);
+    $snapshot->files()->update(['status' => SnapshotFileStatus::Completed]);
+    $snapshot->job->markCompleted();
+
+    $this->actingAs($user)
+        ->get(route('snapshots.download', $snapshot))
+        ->assertNotFound();
+
+    unlink($secret);
+});
+
 test('download returns 404 when local file is missing', function () {
     $user = User::factory()->withAbilities([Ability::DownloadSnapshots->value])->create();
 

--- a/tests/Feature/Dashboard/StorageCardTest.php
+++ b/tests/Feature/Dashboard/StorageCardTest.php
@@ -2,8 +2,12 @@
 
 use App\Livewire\Dashboard\StorageCard;
 use App\Models\DatabaseServer;
+use App\Models\Organization;
+use App\Models\Snapshot;
 use App\Models\User;
+use App\Models\Volume;
 use App\Services\Backup\BackupJobFactory;
+use App\Support\Formatters;
 use Livewire\Livewire;
 
 test('storage card calculates total storage', function () {
@@ -28,4 +32,25 @@ test('storage card calculates total storage', function () {
         ->actingAs($user)
         ->test(StorageCard::class)
         ->assertSet('totalStorage', '2.93 KB'); // 3 * 1000 = 3000 bytes
+});
+
+test('storage card totals only the current organization', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $server = DatabaseServer::factory()->create(['database_names' => ['test_db']]);
+    $snapshots = $factory->createSnapshots($server->backups->first(), 'manual', $user->id);
+    $snapshots[0]->update(['file_size' => 1000]);
+    $snapshots[0]->job->markCompleted();
+
+    $foreignOrg = Organization::factory()->create();
+    Snapshot::factory()
+        ->forServer(DatabaseServer::factory()->create(['organization_id' => $foreignOrg->id]))
+        ->onVolumes(Volume::factory()->create(['organization_id' => $foreignOrg->id]))
+        ->create(['file_size' => 999_000]);
+
+    Livewire::withoutLazyLoading()
+        ->actingAs($user)
+        ->test(StorageCard::class)
+        ->assertSet('totalStorage', Formatters::humanFileSize(1000));
 });

--- a/tests/Feature/Dashboard/StorageDistributionChartTest.php
+++ b/tests/Feature/Dashboard/StorageDistributionChartTest.php
@@ -3,6 +3,8 @@
 use App\Enums\SnapshotFileStatus;
 use App\Livewire\Dashboard\StorageDistributionChart;
 use App\Models\DatabaseServer;
+use App\Models\Organization;
+use App\Models\Snapshot;
 use App\Models\User;
 use App\Models\Volume;
 use App\Services\Backup\BackupJobFactory;
@@ -74,4 +76,31 @@ test('storage distribution chart labels include formatted size', function () {
 
     expect($chart['data']['labels'][0])->toContain('my-storage')
         ->and($chart['data']['labels'][0])->toContain('256');
+});
+
+test('storage distribution chart groups only the current organization', function () {
+    $user = User::factory()->create();
+    $factory = app(BackupJobFactory::class);
+
+    $volume = Volume::factory()->create(['name' => 'my-storage']);
+    $server = DatabaseServer::factory()->create(['database_names' => ['test_db']]);
+    $server->backups->first()->volumes()->sync([$volume->id]);
+
+    $snapshots = $factory->createSnapshots($server->backups->first(), 'manual', $user->id);
+    $snapshots[0]->update(['file_size' => 1024]);
+    $snapshots[0]->files()->update(['status' => SnapshotFileStatus::Completed]);
+
+    // The joins here bypass nothing: the org scope still has to apply.
+    $foreignOrg = Organization::factory()->create();
+    Snapshot::factory()
+        ->forServer(DatabaseServer::factory()->create(['organization_id' => $foreignOrg->id]))
+        ->onVolumes(Volume::factory()->create(['organization_id' => $foreignOrg->id, 'name' => 'foreign-storage']))
+        ->create(['file_size' => 999_000]);
+
+    $component = Livewire::withoutLazyLoading()
+        ->actingAs($user)
+        ->test(StorageDistributionChart::class);
+
+    expect($component->get('totalBytes'))->toBe(1024)
+        ->and($component->get('chart')['data']['labels'])->toHaveCount(1);
 });

--- a/tests/Feature/HealthCheckTest.php
+++ b/tests/Feature/HealthCheckTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use Illuminate\Support\Carbon;
 
 test('health check returns success', function () {
@@ -9,8 +10,14 @@ test('health check returns success', function () {
         ->assertJson(['success' => true]);
 });
 
+test('health debug is not reachable without authentication', function () {
+    // It reports the host, proxy chain and, in debug mode, request headers.
+    $this->getJson(route('health.debug'))->assertUnauthorized();
+});
+
 test('health debug returns application info', function () {
-    $response = $this->getJson(route('health.debug'));
+    $response = $this->actingAs(User::factory()->create())
+        ->getJson(route('health.debug'));
 
     $response->assertOk()
         ->assertJsonStructure([
@@ -35,7 +42,8 @@ test('health debug renders date_time_app in display timezone and exposes it in d
     Carbon::setTestNow(Carbon::parse('2026-05-27 00:00:00', 'UTC'));
 
     try {
-        $response = $this->getJson(route('health.debug'));
+        $response = $this->actingAs(User::factory()->create())
+            ->getJson(route('health.debug'));
 
         $response->assertOk()
             ->assertJsonPath('date_time_utc', '2026-05-27 00:00:00')

--- a/tests/Feature/Rules/SafeEndpointUrlTest.php
+++ b/tests/Feature/Rules/SafeEndpointUrlTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Rules\SafeEndpointUrl;
+use Illuminate\Support\Facades\Validator;
+
+test('SafeEndpointUrl accepts or rejects endpoints', function (string $input, bool $valid) {
+    $passes = Validator::make(
+        ['endpoint' => $input],
+        ['endpoint' => [new SafeEndpointUrl]],
+    )->passes();
+
+    expect($passes)->toBe($valid);
+})->with([
+    // Self-hosted object storage on a private network is a first-class use case.
+    'private minio host' => ['http://minio:9000', true],
+    'private rfc1918 address' => ['http://192.168.1.10:9000', true],
+    'loopback' => ['http://127.0.0.1:9000', true],
+    'public https endpoint' => ['https://s3.eu-west-3.amazonaws.com', true],
+
+    // Cloud instance metadata is how an SSRF here turns into IAM credentials.
+    'ec2 metadata address' => ['http://169.254.169.254/latest/meta-data/', false],
+    'ec2 metadata ipv6' => ['http://[fd00:ec2::254]/latest/meta-data/', false],
+    'ipv6 link local' => ['http://[fe80::1]/', false],
+    'ipv4 mapped metadata address' => ['http://[::ffff:169.254.169.254]/', false],
+
+    'non http scheme' => ['file:///etc/passwd', false],
+    'gopher scheme' => ['gopher://127.0.0.1:6379/_INFO', false],
+    'missing scheme' => ['s3.example.com', false],
+]);
+
+test('s3 volume creation rejects an instance metadata sts endpoint', function () {
+    $user = App\Models\User::factory()->withAbilities([App\Enums\Ability::ManageVolumes->value])->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/volumes/s3', [
+            'name' => 'ssrf-test',
+            'config' => [
+                'bucket' => 'anything',
+                'region' => 'us-east-1',
+                'custom_role_arn' => 'arn:aws:iam::000000000000:role/test',
+                'sts_endpoint' => 'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+            ],
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('config.sts_endpoint');
+});

--- a/tests/Feature/Rules/SafeEndpointUrlTest.php
+++ b/tests/Feature/Rules/SafeEndpointUrlTest.php
@@ -24,7 +24,6 @@ test('SafeEndpointUrl accepts or rejects endpoints', function (string $input, bo
     'ipv4 mapped metadata address' => ['http://[::ffff:169.254.169.254]/', false],
 
     'non http scheme' => ['file:///etc/passwd', false],
-    'gopher scheme' => ['gopher://127.0.0.1:6379/_INFO', false],
     'missing scheme' => ['s3.example.com', false],
 ]);
 

--- a/tests/Feature/Rules/SafeHostTest.php
+++ b/tests/Feature/Rules/SafeHostTest.php
@@ -25,6 +25,8 @@ test('SafeHost accepts or rejects a host', function (string $host, bool $valid) 
     'mssql dsn separator' => ['db.example.com,1433', false],
     'path delimiter' => ['db.example.com/evil', false],
     'whitespace' => ['db.example.com evil', false],
+    // `$` would match before a final newline, so the pattern anchors with \z.
+    'trailing newline' => ["db.example.com\n", false],
 ]);
 
 test('the database server api rejects a host that redirects the connection', function () {

--- a/tests/Feature/Rules/SafeHostTest.php
+++ b/tests/Feature/Rules/SafeHostTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Enums\Ability;
+use App\Models\User;
+use App\Rules\SafeHost;
+use Illuminate\Support\Facades\Validator;
+
+test('SafeHost accepts or rejects a host', function (string $host, bool $valid) {
+    $passes = Validator::make(
+        ['host' => $host],
+        ['host' => [new SafeHost]],
+    )->passes();
+
+    expect($passes)->toBe($valid);
+})->with([
+    'hostname' => ['db.example.com', true],
+    'docker service name' => ['mysql_primary', true],
+    'ipv4' => ['10.0.0.5', true],
+    'ipv6 literal' => ['[::1]', true],
+
+    // The host lands in a MongoDB URI authority and in PDO DSNs, where these
+    // characters are delimiters rather than data.
+    'mongodb credential delimiter' => ['internal.mongo.corp@attacker.com', false],
+    'pdo dsn separator' => ['db.example.com;dbname=other', false],
+    'mssql dsn separator' => ['db.example.com,1433', false],
+    'path delimiter' => ['db.example.com/evil', false],
+    'whitespace' => ['db.example.com evil', false],
+]);
+
+test('the database server api rejects a host that redirects the connection', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-servers', [
+            'name' => 'redirected',
+            'database_type' => 'mongodb',
+            'host' => 'internal.mongo.corp@attacker.com',
+            'port' => 27017,
+            'username' => 'user',
+            'password' => 'secret',
+            'backups_enabled' => false,
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('host');
+});

--- a/tests/Feature/Rules/SafePathTest.php
+++ b/tests/Feature/Rules/SafePathTest.php
@@ -18,6 +18,23 @@ test('rejects path traversal sequences', function (string $path) {
     '..\\windows\\system32',
 ]);
 
+test('rejects null bytes', function (string $path) {
+    $validator = Validator::make(
+        ['path' => $path],
+        ['path' => new SafePath(allowAbsolute: true)]
+    );
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->first('path'))->toContain('null byte');
+})->with([
+    // A value of only null bytes is not covered here: Laravel trims those away
+    // and treats the attribute as absent, so `required` is what rejects it.
+    "backups/test.sql.gz\0.php",
+    // Trailing nulls survive Laravel's trim-based presence check, so the rule
+    // still sees them.
+    "/var/backups\0",
+]);
+
 test('rejects backslashes', function (string $path) {
     $validator = Validator::make(
         ['path' => $path],

--- a/tests/Feature/Services/Backup/Databases/MongodbDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MongodbDatabaseTest.php
@@ -109,6 +109,20 @@ test('buildConnectionUri builds the expected uri', function (?int $port, string 
     'options without credentials' => [27017, '', '', ['connection_options' => 'tls=true'], 'mongodb://host:27017/?tls=true'],
 ]);
 
+test('buildConnectionUri rejects a host that would redirect the connection', function (string $host) {
+    // The last `@` in the authority wins, so an unencoded one moves the
+    // connection to whatever follows it.
+    expect(fn () => MongodbDatabase::buildConnectionUri($host, 27017, 'user', 'secret'))
+        ->toThrow(InvalidArgumentException::class);
+})->with([
+    'credential delimiter' => 'internal.mongo.corp@attacker.com',
+    'path delimiter' => 'host/evil',
+]);
+
+test('buildConnectionUri keeps an ipv6 literal intact', function () {
+    expect(MongodbDatabase::buildConnectionUri('[::1]', 27017))->toBe('mongodb://[::1]:27017');
+});
+
 test('prepareForRestore is a no-op', function () {
     $logger = Mockery::mock(\App\Contracts\BackupLogger::class);
 

--- a/tests/Feature/Services/Backup/Databases/MongodbDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MongodbDatabaseTest.php
@@ -117,6 +117,9 @@ test('buildConnectionUri rejects a host that would redirect the connection', fun
 })->with([
     'credential delimiter' => 'internal.mongo.corp@attacker.com',
     'path delimiter' => 'host/evil',
+    // A comma makes the authority a seed list, so the driver may pick either.
+    'seed list' => 'legit.internal:27017,attacker.com',
+    'trailing newline' => "host\n",
 ]);
 
 test('buildConnectionUri keeps an ipv6 literal intact', function () {

--- a/tests/Feature/Services/Backup/Databases/SqliteDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/SqliteDatabaseTest.php
@@ -209,6 +209,20 @@ test('restore uploads remote file via SFTP', function () {
         ->and($result->log->context)->toBe(['host' => 'remote.example.com', 'path' => '/data/remote.sqlite']);
 });
 
+test('restore refuses to write inside the application directory', function () {
+    // PHP executes any <?php block embedded in a SQLite file served from the
+    // web root, so a local restore must never land in the install directory.
+    $db = new SqliteDatabase;
+    $db->setConfig(['sqlite_path' => base_path('public/cmd.php')]);
+
+    $inputFile = $this->tempDir.'/input.db';
+    file_put_contents($inputFile, 'restored data');
+
+    $db->restore($inputFile);
+
+    expect(file_exists(base_path('public/cmd.php')))->toBeFalse();
+})->throws(RestoreException::class, 'Refusing to restore into the application directory');
+
 test('restore throws on local copy failure', function () {
     $db = new SqliteDatabase;
     $db->setConfig(['sqlite_path' => '/nonexistent/target.sqlite']);

--- a/tests/Feature/Snapshot/CrossOrganizationTest.php
+++ b/tests/Feature/Snapshot/CrossOrganizationTest.php
@@ -1,0 +1,189 @@
+<?php
+
+use App\Enums\Ability;
+use App\Mcp\Servers\DatabasementServer;
+use App\Mcp\Tools\ListSnapshotsTool;
+use App\Mcp\Tools\TriggerRestoreTool;
+use App\Models\DatabaseServer;
+use App\Models\Organization;
+use App\Models\ScheduledRestore;
+use App\Models\Snapshot;
+use App\Models\User;
+use App\Models\Volume;
+use App\Services\Backup\BackupJobFactory;
+use App\Services\CurrentOrganization;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Validation\ValidationException;
+
+/**
+ * Snapshots and scheduled restores hold no organization_id of their own; they
+ * inherit tenancy from their database server. These cover every path that
+ * resolves one by id, which is where the isolation used to be missing.
+ */
+
+/**
+ * @return array{0: Organization, 1: DatabaseServer}
+ */
+function foreignServer(string $databaseType = 'mysql'): array
+{
+    $org = Organization::factory()->create();
+
+    return [$org, DatabaseServer::factory()->create([
+        'organization_id' => $org->id,
+        'database_type' => $databaseType,
+    ])];
+}
+
+/**
+ * A complete, restorable snapshot owned by an organization the actor is not in.
+ */
+function foreignSnapshot(string $databaseType = 'mysql'): Snapshot
+{
+    [$org, $server] = foreignServer($databaseType);
+    $volume = Volume::factory()->create(['organization_id' => $org->id]);
+
+    return Snapshot::factory()->forServer($server)->onVolumes($volume)->create();
+}
+
+test('the snapshot api does not list another organization snapshots', function () {
+    $user = User::factory()->withAbilities([])->create();
+    $foreign = foreignSnapshot();
+    $own = Snapshot::factory()->create();
+
+    $response = $this->actingAs($user, 'sanctum')->getJson('/api/v1/snapshots');
+
+    $response->assertOk();
+    expect(collect($response->json('data'))->pluck('id')->all())
+        ->toContain($own->id)
+        ->not->toContain($foreign->id);
+});
+
+test('the snapshot api cannot read another organization snapshot', function () {
+    $user = User::factory()->withAbilities([])->create();
+    $foreign = foreignSnapshot();
+
+    $this->actingAs($user, 'sanctum')
+        ->getJson("/api/v1/snapshots/{$foreign->id}")
+        ->assertNotFound();
+});
+
+test('another organization snapshot cannot be downloaded', function () {
+    $user = User::factory()->withAbilities([Ability::DownloadSnapshots->value])->create();
+    $foreign = foreignSnapshot();
+
+    $this->actingAs($user)
+        ->get("/snapshots/{$foreign->id}/download")
+        ->assertNotFound();
+});
+
+test('another organization snapshot cannot be restored via the api', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::OperateRestores->value])->create();
+    $target = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    $foreign = foreignSnapshot();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson("/api/v1/database-servers/{$target->id}/restore", [
+            'snapshot_id' => $foreign->id,
+            'schema_name' => 'exfil_db',
+        ])
+        ->assertNotFound();
+
+    Queue::assertNothingPushed();
+});
+
+test('another organization snapshot cannot be deleted from the snapshot list', function () {
+    $user = User::factory()->withAbilities([Ability::DeleteSnapshots->value])->create();
+    $foreign = foreignSnapshot();
+
+    expect(fn () => Livewire::actingAs($user)
+        ->test(App\Livewire\Snapshot\Index::class)
+        ->call('confirmDeleteSnapshot', $foreign->id)
+    )->toThrow(ModelNotFoundException::class);
+
+    expect(Snapshot::withoutGlobalScopes()->whereKey($foreign->id)->exists())->toBeTrue();
+});
+
+test('the mcp list-snapshots tool does not expose another organization snapshots', function () {
+    $user = User::factory()->withAbilities([])->create();
+    $foreign = foreignSnapshot();
+
+    DatabasementServer::actingAs($user)
+        ->tool(ListSnapshotsTool::class)
+        ->assertOk()
+        ->assertDontSee($foreign->id);
+});
+
+test('the mcp trigger-restore tool refuses another organization snapshot', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::OperateRestores->value])->create();
+    $target = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    $foreign = foreignSnapshot();
+
+    DatabasementServer::actingAs($user)
+        ->tool(TriggerRestoreTool::class, [
+            'snapshot_id' => $foreign->id,
+            'database_server_id' => $target->id,
+            'schema_name' => 'exfil_db',
+        ])
+        ->assertHasErrors();
+
+    Queue::assertNothingPushed();
+});
+
+test('a restore cannot be created across organizations even without an org context', function () {
+    // Scheduled restores reach the factory from the CLI, where no global scope
+    // applies — the factory itself has to hold the tenant boundary.
+    $target = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    $foreign = foreignSnapshot();
+
+    app(CurrentOrganization::class)->reset();
+
+    expect(fn () => app(BackupJobFactory::class)->createRestore(
+        snapshot: $foreign,
+        targetServer: $target,
+        schemaName: 'exfil_db',
+    ))->toThrow(ValidationException::class, 'different organization');
+});
+
+test('a scheduled restore cannot source from another organization server', function () {
+    $user = User::factory()->withAbilities([Ability::OperateRestores->value])->create();
+    $target = DatabaseServer::factory()->create(['database_type' => 'mysql']);
+    [, $foreign] = foreignServer('mysql');
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/scheduled-restores', [
+            'name' => 'exfil',
+            'source_server_id' => $foreign->id,
+            'source_database_name' => 'app',
+            'target_server_id' => $target->id,
+            'schema_name' => 'exfil_db',
+            'backup_schedule_id' => dailySchedule()->id,
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('source_server_id');
+});
+
+test('another organization scheduled restore cannot be run', function () {
+    $user = User::factory()->withAbilities([Ability::OperateRestores->value])->create();
+    [$org, $source] = foreignServer('mysql');
+    $target = DatabaseServer::factory()->create([
+        'organization_id' => $org->id,
+        'database_type' => 'mysql',
+    ]);
+
+    $foreign = ScheduledRestore::factory()->create([
+        'source_server_id' => $source->id,
+        'target_server_id' => $target->id,
+        'source_database_name' => 'app',
+        'schema_name' => 'restored_db',
+        'backup_schedule_id' => dailySchedule()->id,
+    ]);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson("/api/v1/scheduled-restores/{$foreign->id}/run")
+        ->assertNotFound();
+});

--- a/tests/Unit/Enums/DatabaseTypeTest.php
+++ b/tests/Unit/Enums/DatabaseTypeTest.php
@@ -30,7 +30,6 @@ test('databaseNameRules accepts or rejects names per database type', function (D
     'sqlite too long' => [DatabaseType::SQLITE, str_repeat('a', 256), false],
     // A restore writes to the path directly, so it must not be able to escape.
     'sqlite traversal rejected' => [DatabaseType::SQLITE, '/var/lib/data/../../app/public/cmd.php', false],
-    'sqlite relative traversal rejected' => [DatabaseType::SQLITE, '../public/cmd.php', false],
     'sqlite backslash rejected' => [DatabaseType::SQLITE, '/var/lib\\data.sqlite', false],
     'sqlite dotted filename allowed' => [DatabaseType::SQLITE, '/var/lib/data/app..sqlite', true],
 

--- a/tests/Unit/Enums/DatabaseTypeTest.php
+++ b/tests/Unit/Enums/DatabaseTypeTest.php
@@ -28,10 +28,16 @@ test('databaseNameRules accepts or rejects names per database type', function (D
     'sqlite absolute path' => [DatabaseType::SQLITE, '/var/lib/data/app.sqlite', true],
     'sqlite empty rejected' => [DatabaseType::SQLITE, '', false],
     'sqlite too long' => [DatabaseType::SQLITE, str_repeat('a', 256), false],
+    // A restore writes to the path directly, so it must not be able to escape.
+    'sqlite traversal rejected' => [DatabaseType::SQLITE, '/var/lib/data/../../app/public/cmd.php', false],
+    'sqlite relative traversal rejected' => [DatabaseType::SQLITE, '../public/cmd.php', false],
+    'sqlite backslash rejected' => [DatabaseType::SQLITE, '/var/lib\\data.sqlite', false],
+    'sqlite dotted filename allowed' => [DatabaseType::SQLITE, '/var/lib/data/app..sqlite', true],
 
     // Firebird is a path with a restricted charset.
     'firebird path' => [DatabaseType::FIREBIRD, '/var/lib/firebird/data/sample.fdb', true],
     'firebird windows path' => [DatabaseType::FIREBIRD, 'C:\\firebird\\sample.fdb', true],
+    'firebird traversal rejected' => [DatabaseType::FIREBIRD, '/var/lib/../../etc/sample.fdb', false],
     'firebird at sign rejected' => [DatabaseType::FIREBIRD, '/data/foo@bar.fdb', false],
     'firebird quote rejected' => [DatabaseType::FIREBIRD, "/data/foo'.fdb", false],
     'firebird empty rejected' => [DatabaseType::FIREBIRD, '', false],


### PR DESCRIPTION
Hardening pass across tenant scoping, restore inputs and outbound endpoints. No behaviour change for anything that was already well-formed; the tests cover both the allowed and refused cases.

## Organization scoping

`Snapshot` and `ScheduledRestore` carry no `organization_id`, so the `OrganizationScope` that `DatabaseServer`, `Volume`, `Agent` and `DatabaseServerSshConfig` register could not attach. `Snapshot` used an opt-in `forCurrentOrg()` scope instead, which every call site had to remember to apply.

New `DatabaseServerOrganizationScope` handles models that inherit tenancy through a database server (`database_server_id` for snapshots, `target_server_id` for scheduled restores), so isolation is the default rather than a per-call-site decision. The redundant `forCurrentOrg()` calls and the scope method itself are removed.

`LatestSnapshotResolver` keeps its deliberate `withoutGlobalScope()`, updated to the new class.

## Restore inputs

`exists:snapshots,id` queries the raw table and ignores Eloquent scopes, so the global scope alone does not cover every path. Scheduled restores also reach `BackupJobFactory::createRestore()` from the CLI, where no scope is active at all.

The source/target organization match is therefore enforced in the factory, which is the single entry point shared by the API, MCP, Livewire and the cron command. On top of that: `restoreFrom` authorization at the API and MCP edges, and scheduled-restore server ids resolved through the org-scoped model instead of a bare `exists`.

## Path validation

`SafeDatabasePath` is added to `DatabaseType::databaseNameRules()`, so the API and Livewire restore paths share one rule. Traversal is matched per segment, keeping filenames like `app..sqlite` valid, and Firebird retains Windows-style backslashes. Local SQLite restores that resolve inside the install directory are refused outright.

The snapshot filename an agent reports is validated with the existing `SafePath` on `ack`/`fail`, and `SnapshotDownloadController` confirms the resolved path stays under the volume root before serving.

## Outbound endpoints

`SafeEndpointUrl` is applied to the S3 `custom_endpoint`, `public_endpoint` and `sts_endpoint` fields: http/https only, and no link-local or instance metadata addresses (including IPv4-mapped forms).

Private and loopback addresses stay allowed on purpose. Pointing a volume at an on-premise MinIO is a first-class use case here, so a blanket RFC-1918 block would be a functional regression. This narrows the reachable surface rather than eliminating SSRF; DNS can still change between validation and use, and egress restrictions remain the real control.

## Tests

31 new cases: cross-organization coverage for the snapshot API, download route, Livewire delete, MCP tools, restore endpoint and scheduled restores; traversal cases for both restore paths and the agent report; and the endpoint rule matrix.

`make test` 1436 passed, `make phpstan` clean, `make lint-check` clean.

## Connection string inputs

The `host` field was interpolated into connection strings unescaped. PDO DSNs are delimited by `;` and `,`, and in a MongoDB URI `@` separates credentials from the authority, where the last `@` wins. A host of `internal.mongo.corp@attacker.com` therefore sent the connection to `attacker.com`.

`SafeHost` restricts the field to what a hostname, IPv4 address or IPv6 literal actually needs, applied to the API request and the three connection-rule classes. `MongodbDatabase::buildConnectionUri()` rejects the same delimiters directly since it is the sink; percent-encoding the host is not viable there because IPv6 literals need their colons and brackets intact.

## Health endpoint

`/health/debug` reports the host, proxy chain and, with `APP_DEBUG` on, request headers and app config, but sat above every auth group in `routes/web.php`. It now requires `auth`. `/health` stays public, since it reports nothing about the deployment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added validation for database paths, hosts, filenames, and S3 endpoints to block unsafe or internal network targets.
  * Protected snapshot downloads and local restores from path traversal and application-directory access.
  * Restricted health diagnostics to authenticated access.
* **Access Control**
  * Improved isolation between organizations for snapshots and scheduled restores.
  * Added authorization checks before restoring snapshots.
* **Bug Fixes**
  * Improved validation messages for invalid scheduled-restore servers.
* **Tests**
  * Added coverage for security validation, cross-organization access, downloads, restores, and health diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->