### PR TITLE
chore(ci): drop Codacy coverage upload

### DIFF
--- a/.github/workflows/coverage-and-quality.yml
+++ b/.github/workflows/coverage-and-quality.yml
@@ -77,17 +77,6 @@ jobs:
           override_branch: ${{ github.event.workflow_run.head_branch }}
           override_pr: ${{ steps.pr.outputs.number }}
 
-      - name: Upload coverage to Codacy
-        # No commit override needed: the reporter reads the triggering
-        # commit from the workflow_run event payload (head_sha), so the
-        # coverage is attributed to the right commit even though this
-        # workflow runs detached from the original push/PR.
-        if: hashFiles('coverage.xml') != ''
-        uses: codacy/codacy-coverage-reporter-action@v1
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.xml
-
       - name: SonarQube Scan (main)
         # Analyse the main branch, using the coverage.xml and junit.xml
         # produced by the triggering `tests` run.


### PR DESCRIPTION
Removes the "Upload coverage to Codacy" step from the `coverage-and-quality` workflow.

Codecov and SonarQube uploads are unchanged. This was the only Codacy reference in the repo, so the `CODACY_PROJECT_TOKEN` secret is now unused and can be deleted from repo settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Codacy coverage uploads from the automated quality workflow.
  * Codecov reporting and SonarQube scans remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->