### PR TITLE
Scope Restore records to their organization

### DIFF
--- a/app/Livewire/Restore/Index.php
+++ b/app/Livewire/Restore/Index.php
@@ -106,11 +106,13 @@ class Index extends Component
             return null;
         }
 
-        // Bypass the OrganizationScope on DatabaseServer/Volume so cross-org
-        // deeplinks (e.g. a notification opened while the user is in another
-        // org) can still render source/target server context in the logs modal.
-        // The job-view policy already gates access to this data.
+        // Bypass the organization scopes so cross-org deeplinks (e.g. a
+        // notification opened while the user is in another org) can still
+        // render source/target server context in the logs modal. Read-only:
+        // BackupJobPolicy@view has already confirmed membership of the owning
+        // org in mountHandlesJobLogsModal(), and a non-member gets a 403 there.
         return BackupJob::with([
+            'restore' => fn ($q) => $q->withoutGlobalScopes(),
             'restore.snapshot.databaseServer' => fn ($q) => $q->withoutGlobalScopes(),
             'restore.snapshot.files.volume' => fn ($q) => $q->withoutGlobalScopes(),
             'restore.targetServer' => fn ($q) => $q->withoutGlobalScopes(),

--- a/app/Livewire/Restore/Modal.php
+++ b/app/Livewire/Restore/Modal.php
@@ -141,9 +141,10 @@ class Modal extends Component
         $snapshot = $restore->snapshot;
         $target = $restore->targetServer;
 
-        // OrganizationScope on DatabaseServer returns null for cross-org rows
-        // even though the FK is cascade-deleted — PHPDoc on the relation
-        // doesn't model that. This null check is the cross-org guard.
+        // Cross-org ids no longer reach here: Restore is org-scoped, so the
+        // findOrFail above 404s first. This handles the snapshot or target
+        // server having been deleted since the original run — the relations
+        // resolve to null, which PHPDoc doesn't model.
         // @phpstan-ignore booleanNot.alwaysFalse, booleanNot.alwaysFalse, booleanOr.alwaysFalse
         if (! $snapshot || ! $target) {
             $this->error(__('Cannot re-run: the original snapshot or target server no longer exists.'));

--- a/app/Models/Restore.php
+++ b/app/Models/Restore.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Scopes\DatabaseServerOrganizationScope;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,6 +16,10 @@ class Restore extends Model
 
     protected static function booted(): void
     {
+        // Tenancy is inherited from the server the restore wrote to, matching
+        // ScheduledRestore. Without it every by-id lookup crosses organizations.
+        static::addGlobalScope(new DatabaseServerOrganizationScope('target_server_id'));
+
         // Delete the associated job when restore is deleted
         static::deleting(function (Restore $restore) {
             $restore->job->delete();

--- a/app/Policies/BackupJobPolicy.php
+++ b/app/Policies/BackupJobPolicy.php
@@ -60,13 +60,18 @@ class BackupJobPolicy
     /**
      * Resolve the org that owns the job by walking either side of the
      * snapshot / restore relation and reading the related server's
-     * organization_id. The OrganizationScope on DatabaseServer is bypassed
-     * since the caller may be in a different org.
+     * organization_id.
+     *
+     * Every scope is bypassed on the way: this answers "who owns this job"
+     * precisely when the caller is in a different org, so a scoped read would
+     * make every foreign job look ownerless and deny members their own
+     * notification deeplinks. Only ownership is derived here; membership is
+     * then checked by the caller.
      */
     private function resolveOrganizationId(BackupJob $backupJob): ?string
     {
-        $snapshot = $backupJob->snapshot;
-        $restore = $backupJob->restore;
+        $snapshot = $backupJob->snapshot()->withoutGlobalScopes()->first();
+        $restore = $backupJob->restore()->withoutGlobalScopes()->first();
 
         $serverId = $snapshot
             ? $snapshot->database_server_id

--- a/app/Queries/RestoreQuery.php
+++ b/app/Queries/RestoreQuery.php
@@ -45,11 +45,8 @@ class RestoreQuery
         string $sortColumn = 'created_at',
         string $sortDirection = 'desc'
     ): Builder {
-        // The DatabaseServer model has an OrganizationScope global scope, so
-        // whereHas('targetServer') automatically filters to the current org.
         $query = Restore::query()
-            ->with(self::relationships())
-            ->whereHas('targetServer');
+            ->with(self::relationships());
 
         $query
             ->when($search, function (Builder $query) use ($search) {

--- a/tests/Feature/Livewire/Restore/IndexTest.php
+++ b/tests/Feature/Livewire/Restore/IndexTest.php
@@ -4,9 +4,12 @@ use App\Enums\Ability;
 use App\Livewire\Restore\Index;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
+use App\Models\Organization;
 use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Models\User;
+use App\Models\Volume;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
@@ -31,6 +34,29 @@ function makeRestore(array $attrs = []): Restore
         'snapshot_id' => $snapshot->id,
         'target_server_id' => $target->id,
         'schema_name' => $attrs['schema_name'] ?? 'restored_db',
+    ]);
+}
+
+/**
+ * A completed restore owned by an organization the actor is not a member of.
+ */
+function foreignRestore(): Restore
+{
+    $org = Organization::factory()->create();
+    $server = DatabaseServer::factory()->create([
+        'organization_id' => $org->id,
+        'database_type' => 'mysql',
+    ]);
+    $snapshot = Snapshot::factory()
+        ->forServer($server)
+        ->onVolumes(Volume::factory()->create(['organization_id' => $org->id]))
+        ->create();
+
+    return Restore::create([
+        'backup_job_id' => BackupJob::create(['status' => 'completed'])->id,
+        'snapshot_id' => $snapshot->id,
+        'target_server_id' => $server->id,
+        'schema_name' => 'victim_confidential_schema',
     ]);
 }
 
@@ -210,4 +236,31 @@ test('without operate-restores, opening a new restore is forbidden', function ()
     Livewire::test(Index::class)
         ->call('openNewRestore')
         ->assertForbidden();
+});
+
+test('another organization restore record is not listed', function () {
+    $own = makeRestore(['schema_name' => 'own_schema']);
+    $foreign = foreignRestore();
+
+    Livewire::test(Index::class)
+        ->assertSee('own_schema')
+        ->assertDontSee($foreign->schema_name);
+});
+
+test('another organization restore record cannot be deleted', function () {
+    // operate-restores is an ordinary operational ability, so holding it must
+    // not reach another tenant's restore history.
+    $foreign = foreignRestore();
+
+    expect(fn () => Livewire::test(Index::class)->call('confirmDeleteRestore', $foreign->id))
+        ->toThrow(ModelNotFoundException::class);
+
+    expect(Restore::withoutGlobalScopes()->whereKey($foreign->id)->exists())->toBeTrue();
+});
+
+test('another organization restore record cannot be re-run', function () {
+    $foreign = foreignRestore();
+
+    expect(fn () => Livewire::test(Index::class)->call('rerunRestore', $foreign->id))
+        ->toThrow(ModelNotFoundException::class);
 });

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -280,3 +280,32 @@ test('without download-snapshots, opening the copy picker is forbidden', functio
         ->call('openDownloadModal', $snapshot->id)
         ->assertForbidden();
 });
+
+test('?job= from another org opens the logs modal when the user is a member', function () {
+    // Both Snapshot and Restore are organization-scoped, so BackupJobPolicy has
+    // to bypass those scopes to work out who owns a job. Without that, a member
+    // following a notification deeplink into their other org is denied.
+    $otherOrg = \App\Models\Organization::factory()->create(['name' => 'OtherOrg']);
+    attachUserToOrg($this->user, $otherOrg, 'member');
+
+    $current = app(\App\Services\CurrentOrganization::class);
+    $current->set($otherOrg);
+    $server = DatabaseServer::factory()->create(['organization_id' => $otherOrg->id]);
+    $job = Snapshot::factory()->forServer($server)->create()->job;
+    $current->set(\App\Models\Organization::default());
+
+    Livewire::withQueryParams(['job' => $job->id])
+        ->test(Index::class)
+        ->assertSet('showLogsModal', true)
+        ->assertSet('selectedJobId', $job->id);
+});
+
+test('?job= from another org is forbidden when the user is not a member', function () {
+    $otherOrg = \App\Models\Organization::factory()->create();
+    $server = DatabaseServer::factory()->create(['organization_id' => $otherOrg->id]);
+    $job = Snapshot::factory()->forServer($server)->create()->job;
+
+    Livewire::withQueryParams(['job' => $job->id])
+        ->test(Index::class)
+        ->assertForbidden();
+});


### PR DESCRIPTION
Fixes the cross-organization gap in `Restore` reported in GHSA-xxfc-phj8-424w. The report is accurate and the root cause is exactly as described: this is a gap left by #511, which scoped `Snapshot` and `ScheduledRestore` but not `Restore`.

## The gap

`Restore` (the record of an executed restore) has the same `target_server_id` column and the same tenancy semantics as `ScheduledRestore`, but never adopted `DatabaseServerOrganizationScope`. `RestorePolicy` checks only the acting user's ability, never the record's organization, so nothing in the chain verified ownership.

The listing was safe (`RestoreQuery::buildFromParams()` filters via `whereHas('targetServer')`), but every by-id path was not: `confirmDeleteRestore()`, `deleteRestore()` and `rerunRestore()` all call `Restore::findOrFail()` unscoped. A holder of `operate-restores` (an ordinary operational grant, not an admin one) could delete another organization's restore history by id.

Registering the scope makes `findOrFail()` 404 for foreign ids, matching how `ScheduledRestore` is already protected. The now-redundant `whereHas('targetServer')` is dropped from the query so there is one mechanism rather than two.

There is no REST controller for `Restore`, so the Livewire paths were the whole exposure.

## A regression this surfaced, from #511

Fixing the scope broke an existing test: a notification deeplink (`?job=`) into another org that the user **is** a member of should render the logs modal with a warning, and is forbidden only for non-members.

The cause is `BackupJobPolicy::resolveOrganizationId()`. It works out which org owns a job by walking `$backupJob->snapshot` / `->restore` and reading the related server. That resolution has to see across organizations by design, since it runs precisely when the caller is in a different one. Once those relations are scoped, every foreign job resolves to "ownerless" and the policy denies it.

This already applied to `Snapshot`, which #511 scoped and shipped in 1.7.2, so **cross-org snapshot deeplinks have been silently denying members since that release**. There was no test covering it. Both relations now bypass their scopes in that method; only ownership is derived there, and membership is still checked by the caller immediately afterwards.

`Restore\Index::getSelectedJobProperty()` needed the same treatment for its `restore` eager-load, which was already bypassing scopes on the nested relations but not on `restore` itself.

## Tests

`make test` 1470 passed, `make phpstan` clean, `make lint-check` clean.

- Cross-org restore records: not listed, not deletable, not re-runnable (the delete case also asserts the record survives)
- Cross-org `?job=` deeplink on the snapshot index: allowed for a member, forbidden for a non-member

I verified the snapshot deeplink test fails with the policy fix reverted, so it genuinely pins the 1.7.2 regression rather than just passing alongside it.

## Note on the advisory

The report suggests optionally tightening `RestorePolicy::view()`/`delete()` to check the organization as well. I relied on the scope alone, which is the pattern already established for `Snapshot` and `ScheduledRestore` in this codebase, so foreign ids 404 before the policy is consulted. Happy to add explicit policy checks too if you would rather have the belt-and-braces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restore records are now correctly limited to the target server’s organization.
  * Restores belonging to other organizations no longer appear in listings or allow deletion or re-run actions.
  * Cross-organization log links now apply the appropriate authorization checks.
  * Authorized members can access valid restore logs, while unauthorized access is blocked.
  * Missing snapshots or target servers are handled gracefully as deleted records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->