### PR TITLE
Share the index filter plumbing

### DIFF
--- a/app/Livewire/Agent/Index.php
+++ b/app/Livewire/Agent/Index.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Agent;
 
+use App\Livewire\Concerns\FiltersAndPaginates;
 use App\Models\Agent;
 use App\Queries\AgentQuery;
 use App\Traits\Toast;
@@ -16,7 +17,7 @@ use Livewire\WithPagination;
 #[Title('Agents')]
 class Index extends Component
 {
-    use AuthorizesRequests, Toast, WithPagination;
+    use AuthorizesRequests, FiltersAndPaginates, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -30,28 +31,6 @@ class Index extends Component
     public bool $showDeleteModal = false;
 
     public int $deleteServerCount = 0;
-
-    public function updatingSearch(): void
-    {
-        $this->resetPage();
-    }
-
-    /**
-     * @param  string|array<string, mixed>  $property
-     */
-    public function updated(string|array $property): void
-    {
-        if (! is_array($property) && $property != '') {
-            $this->resetPage();
-        }
-    }
-
-    public function clear(): void
-    {
-        $this->reset('search');
-        $this->resetPage();
-        $this->success(__('Filters cleared.'));
-    }
 
     /**
      * @return array<int, array<string, mixed>>
@@ -110,5 +89,13 @@ class Index extends Component
             'agents' => $query->paginate(10),
             'headers' => $this->headers(),
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function filterProperties(): array
+    {
+        return ['search'];
     }
 }

--- a/app/Livewire/Concerns/FiltersAndPaginates.php
+++ b/app/Livewire/Concerns/FiltersAndPaginates.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Livewire\Concerns;
+
+/**
+ * Shared filter plumbing for paginated index pages: changing a filter returns
+ * to page one, and "clear" resets every filter at once.
+ *
+ * The consuming component must:
+ *
+ * - use {@see \Livewire\WithPagination} (for `resetPage()`)
+ * - use {@see \App\Traits\Toast} (for the confirmation in `clear()`)
+ * - list its own filter properties in `filterProperties()`
+ */
+trait FiltersAndPaginates
+{
+    /**
+     * The `#[Url]` filter properties this page paginates over.
+     *
+     * @return list<string>
+     */
+    abstract protected function filterProperties(): array;
+
+    /**
+     * Only filter changes reset the page. Other public state (modal flags,
+     * selected ids) leaves the current page alone.
+     *
+     * @param  string|array<string, mixed>  $property
+     */
+    public function updated(string|array $property): void
+    {
+        if (is_string($property) && in_array($property, $this->filterProperties(), true)) {
+            $this->resetPage();
+        }
+    }
+
+    public function clear(): void
+    {
+        $this->reset($this->filterProperties());
+        $this->resetPage();
+        $this->success(__('Filters cleared.'));
+    }
+}

--- a/app/Livewire/DatabaseServer/Index.php
+++ b/app/Livewire/DatabaseServer/Index.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\DatabaseServer;
 
 use App\Enums\DatabaseType;
+use App\Livewire\Concerns\FiltersAndPaginates;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\NotificationChannel;
@@ -24,7 +25,7 @@ use Livewire\WithPagination;
 #[Title('Database Servers')]
 class Index extends Component
 {
-    use AuthorizesRequests, OpensAdminerForServer, RunsServerBackups, Toast, WithPagination;
+    use AuthorizesRequests, FiltersAndPaginates, OpensAdminerForServer, RunsServerBackups, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -45,28 +46,6 @@ class Index extends Component
     public int $deleteSnapshotCount = 0;
 
     public bool $keepFiles = false;
-
-    public function updatingSearch(): void
-    {
-        $this->resetPage();
-    }
-
-    /**
-     * @param  string|array<string, mixed>  $property
-     */
-    public function updated(string|array $property): void
-    {
-        if (! is_array($property) && $property != '') {
-            $this->resetPage();
-        }
-    }
-
-    public function clear(): void
-    {
-        $this->reset('search');
-        $this->resetPage();
-        $this->success(__('Filters cleared.'));
-    }
 
     /**
      * @return array<int, array<string, mixed>>
@@ -197,5 +176,13 @@ class Index extends Component
             'headers' => $this->headers(),
             'canAdminer' => Gate::allows('adminer', DatabaseServer::class),
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function filterProperties(): array
+    {
+        return ['search'];
     }
 }

--- a/app/Livewire/Restore/Index.php
+++ b/app/Livewire/Restore/Index.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Restore;
 
 use App\Enums\DatabaseType;
+use App\Livewire\Concerns\FiltersAndPaginates;
 use App\Livewire\Concerns\HandlesJobLogsModal;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
@@ -21,7 +22,7 @@ use Livewire\WithPagination;
 #[Title('Restores')]
 class Index extends Component
 {
-    use AuthorizesRequests, HandlesJobLogsModal, Toast, WithPagination;
+    use AuthorizesRequests, FiltersAndPaginates, HandlesJobLogsModal, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -54,38 +55,6 @@ class Index extends Component
     public function refreshAfterRestoreCreated(): void
     {
         $this->resetPage();
-    }
-
-    public function updatingSearch(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingStatusFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingSourceServerFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingTargetServerFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingDbTypeFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function clear(): void
-    {
-        $this->reset('search', 'statusFilter', 'sourceServerFilter', 'targetServerFilter', 'dbTypeFilter');
-        $this->resetPage();
-        $this->success(__('Filters cleared.'));
     }
 
     /**
@@ -217,10 +186,7 @@ class Index extends Component
      */
     public function dbTypeOptions(): array
     {
-        return collect(DatabaseType::cases())
-            ->map(fn (DatabaseType $t) => ['id' => $t->value, 'name' => $t->label()])
-            ->values()
-            ->all();
+        return DatabaseType::toSelectOptions();
     }
 
     public function render(): View
@@ -243,5 +209,13 @@ class Index extends Component
             'targetServerOptions' => $this->targetServerOptions(),
             'dbTypeOptions' => $this->dbTypeOptions(),
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function filterProperties(): array
+    {
+        return ['search', 'statusFilter', 'sourceServerFilter', 'targetServerFilter', 'dbTypeFilter'];
     }
 }

--- a/app/Livewire/ScheduledRestore/Index.php
+++ b/app/Livewire/ScheduledRestore/Index.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\ScheduledRestore;
 
 use App\Enums\DatabaseType;
+use App\Livewire\Concerns\FiltersAndPaginates;
 use App\Models\DatabaseServer;
 use App\Models\ScheduledRestore;
 use App\Traits\Toast;
@@ -20,7 +21,7 @@ use Livewire\WithPagination;
 #[Title('Scheduled Restores')]
 class Index extends Component
 {
-    use AuthorizesRequests, Toast, WithPagination;
+    use AuthorizesRequests, FiltersAndPaginates, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -52,38 +53,6 @@ class Index extends Component
     public function refreshAfterSave(): void
     {
         $this->resetPage();
-    }
-
-    public function updatingSearch(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingEnabledFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingSourceServerFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingTargetServerFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingDbTypeFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function clear(): void
-    {
-        $this->reset('search', 'enabledFilter', 'sourceServerFilter', 'targetServerFilter', 'dbTypeFilter');
-        $this->resetPage();
-        $this->success(__('Filters cleared.'));
     }
 
     /**
@@ -181,10 +150,7 @@ class Index extends Component
      */
     public function dbTypeOptions(): array
     {
-        return collect(DatabaseType::cases())
-            ->map(fn (DatabaseType $t) => ['id' => $t->value, 'name' => $t->label()])
-            ->values()
-            ->all();
+        return DatabaseType::toSelectOptions();
     }
 
     public function render(): View
@@ -213,5 +179,13 @@ class Index extends Component
             'serverOptions' => $this->serverOptions(),
             'dbTypeOptions' => $this->dbTypeOptions(),
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function filterProperties(): array
+    {
+        return ['search', 'enabledFilter', 'sourceServerFilter', 'targetServerFilter', 'dbTypeFilter'];
     }
 }

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Snapshot;
 
 use App\Enums\BackupJobStatus;
 use App\Enums\DatabaseType;
+use App\Livewire\Concerns\FiltersAndPaginates;
 use App\Livewire\Concerns\HandlesJobLogsModal;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
@@ -21,7 +22,7 @@ use Livewire\WithPagination;
 #[Title('Snapshots')]
 class Index extends Component
 {
-    use AuthorizesRequests, HandlesJobLogsModal, Toast, WithPagination;
+    use AuthorizesRequests, FiltersAndPaginates, HandlesJobLogsModal, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -55,38 +56,6 @@ class Index extends Component
     public ?string $downloadSnapshotId = null;
 
     public bool $showDownloadModal = false;
-
-    public function updatingSearch(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingStatusFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingServerFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingDbTypeFilter(): void
-    {
-        $this->resetPage();
-    }
-
-    public function updatingFileMissing(): void
-    {
-        $this->resetPage();
-    }
-
-    public function clear(): void
-    {
-        $this->reset('search', 'statusFilter', 'serverFilter', 'dbTypeFilter', 'fileMissing');
-        $this->resetPage();
-        $this->success(__('Filters cleared.'));
-    }
 
     /**
      * @return array<int, array<string, mixed>>
@@ -159,10 +128,7 @@ class Index extends Component
      */
     public function dbTypeOptions(): array
     {
-        return collect(DatabaseType::cases())
-            ->map(fn (DatabaseType $t) => ['id' => $t->value, 'name' => $t->label()])
-            ->values()
-            ->all();
+        return DatabaseType::toSelectOptions();
     }
 
     /**
@@ -271,5 +237,13 @@ class Index extends Component
             'serverOptions' => $this->serverOptions(),
             'dbTypeOptions' => $this->dbTypeOptions(),
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function filterProperties(): array
+    {
+        return ['search', 'statusFilter', 'serverFilter', 'dbTypeFilter', 'fileMissing'];
     }
 }

--- a/app/Livewire/User/Index.php
+++ b/app/Livewire/User/Index.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\User;
 
+use App\Livewire\Concerns\FiltersAndPaginates;
 use App\Models\User;
 use App\Services\CurrentOrganization;
 use App\Support\Formatters;
@@ -18,7 +19,7 @@ use Silber\Bouncer\Database\Role;
 #[Title('Users')]
 class Index extends Component
 {
-    use AuthorizesRequests, Toast, WithPagination;
+    use AuthorizesRequests, FiltersAndPaginates, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -56,28 +57,6 @@ class Index extends Component
     public function mount(): void
     {
         $this->authorize('viewAny', User::class);
-    }
-
-    public function updatingSearch(): void
-    {
-        $this->resetPage();
-    }
-
-    /**
-     * @param  string|array<string, mixed>  $property
-     */
-    public function updated(string|array $property): void
-    {
-        if (! is_array($property) && $property != '') {
-            $this->resetPage();
-        }
-    }
-
-    public function clear(): void
-    {
-        $this->reset(['search', 'roleFilter', 'statusFilter']);
-        $this->resetPage();
-        $this->success(__('Filters cleared.'));
     }
 
     /**
@@ -265,5 +244,13 @@ class Index extends Component
             'statusFilterOptions' => $this->statusFilterOptions(),
             'canManageOrgMembership' => auth()->user()->can('manageOrgMembership', User::class),
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function filterProperties(): array
+    {
+        return ['search', 'roleFilter', 'statusFilter'];
     }
 }

--- a/app/Livewire/Volume/Index.php
+++ b/app/Livewire/Volume/Index.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Volume;
 
+use App\Livewire\Concerns\FiltersAndPaginates;
 use App\Models\Snapshot;
 use App\Models\Volume;
 use App\Queries\VolumeQuery;
@@ -17,7 +18,7 @@ use Livewire\WithPagination;
 #[Title('Volumes')]
 class Index extends Component
 {
-    use AuthorizesRequests, Toast, WithPagination;
+    use AuthorizesRequests, FiltersAndPaginates, Toast, WithPagination;
 
     #[Url]
     public string $search = '';
@@ -33,28 +34,6 @@ class Index extends Component
     public int $deleteSnapshotCount = 0;
 
     public bool $keepFiles = false;
-
-    public function updatingSearch(): void
-    {
-        $this->resetPage();
-    }
-
-    /**
-     * @param  string|array<string, mixed>  $property
-     */
-    public function updated(string|array $property): void
-    {
-        if (! is_array($property) && $property != '') {
-            $this->resetPage();
-        }
-    }
-
-    public function clear(): void
-    {
-        $this->reset('search');
-        $this->resetPage();
-        $this->success(__('Filters cleared.'));
-    }
 
     /**
      * @return array<int, array<string, mixed>>
@@ -118,5 +97,13 @@ class Index extends Component
             'headers' => $this->headers(),
             'showAwsDeprecationWarning' => config('app.has_deprecated_aws_env'),
         ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function filterProperties(): array
+    {
+        return ['search'];
     }
 }

--- a/tests/Feature/Livewire/FiltersAndPaginatesTest.php
+++ b/tests/Feature/Livewire/FiltersAndPaginatesTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+
+/**
+ * The filter plumbing shared by every paginated index page. Covered once here
+ * rather than in each component's own test file.
+ */
+beforeEach(function () {
+    actingAs(User::factory()->superAdmin()->create());
+});
+
+test('changing a filter returns to the first page', function (string $component, string $filter) {
+    Livewire::test($component)
+        ->set('paginators.page', 3)
+        ->set($filter, 'anything')
+        ->assertSet('paginators.page', 1);
+})->with([
+    'restores' => [App\Livewire\Restore\Index::class, 'statusFilter'],
+    'scheduled restores' => [App\Livewire\ScheduledRestore\Index::class, 'sourceServerFilter'],
+    'snapshots' => [App\Livewire\Snapshot\Index::class, 'serverFilter'],
+    'database servers' => [App\Livewire\DatabaseServer\Index::class, 'search'],
+    'volumes' => [App\Livewire\Volume\Index::class, 'search'],
+    'agents' => [App\Livewire\Agent\Index::class, 'search'],
+    'users' => [App\Livewire\User\Index::class, 'roleFilter'],
+]);
+
+test('changing non-filter state leaves the current page alone', function () {
+    // Deleting from page 3 should not bounce the user back to page 1.
+    Livewire::test(App\Livewire\Volume\Index::class)
+        ->set('paginators.page', 3)
+        ->set('showDeleteModal', true)
+        ->assertSet('paginators.page', 3);
+});
+
+test('clear resets every filter and returns to the first page', function () {
+    Livewire::test(App\Livewire\Restore\Index::class)
+        ->set('search', 'x')
+        ->set('statusFilter', 'completed')
+        ->set('sourceServerFilter', 'a')
+        ->set('targetServerFilter', 'b')
+        ->set('dbTypeFilter', 'mysql')
+        ->set('paginators.page', 3)
+        ->call('clear')
+        ->assertSet('search', '')
+        ->assertSet('statusFilter', '')
+        ->assertSet('sourceServerFilter', '')
+        ->assertSet('targetServerFilter', '')
+        ->assertSet('dbTypeFilter', '')
+        ->assertSet('paginators.page', 1);
+});


### PR DESCRIPTION
Removes the duplication SonarCloud flagged on #516. The report named `Restore/Index` and `ScheduledRestore/Index`, but the same code was in seven components, so fixing only those two would have left the pattern half-applied.

## What was duplicated

Seven index pages each carried their own copy of the same filtering behaviour, in three different shapes:

- **19** per-property `updatingX()` hooks, every one of them just `resetPage()` (Restore, ScheduledRestore, Snapshot)
- a blanket `updated()` resetting the page on *any* property change (DatabaseServer, User, Volume, Agent)
- **7** `clear()` bodies, all `reset(<list>)` + `resetPage()` + `success(__('Filters cleared.'))`, differing only in the property list

Separately, **4** components reimplemented `dbTypeOptions()` even though `DatabaseType::toSelectOptions()` already existed and is identical.

## What replaces it

A `FiltersAndPaginates` concern, alongside the three that already live in `app/Livewire/Concerns/`. Each component declares its filter properties once:

```php
protected function filterProperties(): array
{
    return ['search', 'statusFilter', 'sourceServerFilter', 'targetServerFilter', 'dbTypeFilter'];
}
```

and inherits both `updated()` and `clear()`. The four `dbTypeOptions()` copies now delegate to the enum.

Net: **203 lines removed, 73 added.**

## One deliberate behaviour change

The four components that used the blanket `updated()` hook reset the page on *every* property change, including modal flags. They now reset only on filter changes, so deleting a volume from page three no longer bounces you back to page one. That is the behaviour the other three components already had.

No behaviour change for `search` or any other filter anywhere.

## Not folded in

- `Restore/Modal::dbTypeOptions()` genuinely differs (it excludes Redis), so it keeps its own.
- `serverOptions()` is only in two components and the variants differ (all servers vs only those with snapshots); a shared version would need parameterising for little gain.

## Tests

`make test` 1484 passed, `make phpstan` clean, `make lint-check` clean.

The existing 1475 passed untouched, which is the main evidence the refactor preserves behaviour. Added `FiltersAndPaginatesTest` to pin the shared behaviour directly: filter changes reset the page across all seven components, non-filter state does not, and `clear()` resets everything.

I verified those tests bite by stubbing the trait's condition to `false` — 7 of the 9 fail, so they are not passing vacuously.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized filtering and pagination behavior across agent, database server, restore, scheduled restore, snapshot, user, and volume listings.
  * Filter changes now return results to the first page automatically.
  * Added a clear-filters action that resets filter values, pagination, and confirms completion.

* **Bug Fixes**
  * Non-filter changes now preserve the current page.

* **Tests**
  * Added coverage for pagination resets, filter clearing, and page preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->