### PR TITLE
Reuse existing shared abstractions

### DIFF
--- a/app/Queries/AgentQuery.php
+++ b/app/Queries/AgentQuery.php
@@ -3,6 +3,7 @@
 namespace App\Queries;
 
 use App\Models\Agent;
+use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
 
 class AgentQuery
@@ -22,12 +23,8 @@ class AgentQuery
      */
     public static function applySort(Builder $query, array $sortBy): Builder
     {
-        $requested = $sortBy['column'] ?? 'created_at';
-        $column = in_array($requested, self::ALLOWED_SORT_COLUMNS, true)
-            ? $requested
-            : 'created_at';
-
-        $direction = strtolower($sortBy['direction'] ?? 'desc') === 'asc' ? 'asc' : 'desc';
+        $column = Formatters::sortColumn($sortBy['column'] ?? null, self::ALLOWED_SORT_COLUMNS);
+        $direction = Formatters::sortDirection($sortBy['direction'] ?? 'desc');
 
         return $query->orderBy($column, $direction);
     }

--- a/app/Queries/BackupJobQuery.php
+++ b/app/Queries/BackupJobQuery.php
@@ -112,7 +112,7 @@ class BackupJobQuery
             });
 
         $direction = Formatters::sortDirection($sortDirection);
-        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
+        $sortColumn = Formatters::sortColumn($sortColumn, self::ALLOWED_SORT_COLUMNS);
 
         // Handle sorting
         if ($sortColumn === 'snapshot_size') {

--- a/app/Queries/Concerns/OrdersByJobStatus.php
+++ b/app/Queries/Concerns/OrdersByJobStatus.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Queries\Concerns;
+
+use App\Models\BackupJob;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Snapshots and restores both carry their status on the related backup job, so
+ * sorting by it orders on a correlated subquery rather than a local column.
+ */
+trait OrdersByJobStatus
+{
+    /**
+     * @template TModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  Builder<TModel>  $query
+     * @param  string  $foreignKey  Qualified `backup_job_id` column, e.g. `snapshots.backup_job_id`.
+     * @param  'asc'|'desc'  $direction
+     * @return Builder<TModel>
+     */
+    protected static function orderByJobStatus(Builder $query, string $foreignKey, string $direction): Builder
+    {
+        return $query->orderBy(
+            BackupJob::select('status')->whereColumn('backup_jobs.id', $foreignKey),
+            $direction,
+        );
+    }
+}

--- a/app/Queries/DatabaseServerQuery.php
+++ b/app/Queries/DatabaseServerQuery.php
@@ -53,7 +53,7 @@ class DatabaseServerQuery
         string $sortColumn = 'created_at',
         string $sortDirection = 'desc'
     ): Builder {
-        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
+        $sortColumn = Formatters::sortColumn($sortColumn, self::ALLOWED_SORT_COLUMNS);
 
         return DatabaseServer::query()
             ->with(['backups.volumes', 'backups.backupSchedule', 'sshConfig', 'notificationChannels'])

--- a/app/Queries/RestoreQuery.php
+++ b/app/Queries/RestoreQuery.php
@@ -2,13 +2,15 @@
 
 namespace App\Queries;
 
-use App\Models\BackupJob;
 use App\Models\Restore;
+use App\Queries\Concerns\OrdersByJobStatus;
 use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
 
 class RestoreQuery
 {
+    use OrdersByJobStatus;
+
     private const ALLOWED_SORT_COLUMNS = [
         'created_at',
         'status',
@@ -66,13 +68,10 @@ class RestoreQuery
             });
 
         $direction = Formatters::sortDirection($sortDirection);
-        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
+        $sortColumn = Formatters::sortColumn($sortColumn, self::ALLOWED_SORT_COLUMNS);
 
         if ($sortColumn === 'status') {
-            return $query->orderBy(
-                BackupJob::select('status')->whereColumn('backup_jobs.id', 'restores.backup_job_id'),
-                $direction,
-            );
+            return self::orderByJobStatus($query, 'restores.backup_job_id', $direction);
         }
 
         return $query->orderBy($sortColumn, $direction);

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -2,8 +2,8 @@
 
 namespace App\Queries;
 
-use App\Models\BackupJob;
 use App\Models\Snapshot;
+use App\Queries\Concerns\OrdersByJobStatus;
 use App\Support\Formatters;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\QueryBuilder\AllowedFilter;
@@ -12,6 +12,8 @@ use Spatie\QueryBuilder\QueryBuilder;
 
 class SnapshotQuery
 {
+    use OrdersByJobStatus;
+
     private const ALLOWED_SORT_COLUMNS = [
         'started_at',
         'created_at',
@@ -100,13 +102,10 @@ class SnapshotQuery
             });
 
         $direction = Formatters::sortDirection($sortDirection);
-        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
+        $sortColumn = Formatters::sortColumn($sortColumn, self::ALLOWED_SORT_COLUMNS);
 
         if ($sortColumn === 'status') {
-            return $query->orderBy(
-                BackupJob::select('status')->whereColumn('backup_jobs.id', 'snapshots.backup_job_id'),
-                $direction,
-            );
+            return self::orderByJobStatus($query, 'snapshots.backup_job_id', $direction);
         }
 
         return $query->orderBy($sortColumn, $direction);

--- a/app/Queries/SnapshotQuery.php
+++ b/app/Queries/SnapshotQuery.php
@@ -102,7 +102,7 @@ class SnapshotQuery
             });
 
         $direction = Formatters::sortDirection($sortDirection);
-        $sortColumn = Formatters::sortColumn($sortColumn, self::ALLOWED_SORT_COLUMNS);
+        $sortColumn = Formatters::sortColumn($sortColumn, self::ALLOWED_SORT_COLUMNS, 'started_at');
 
         if ($sortColumn === 'status') {
             return self::orderByJobStatus($query, 'snapshots.backup_job_id', $direction);

--- a/app/Queries/VolumeQuery.php
+++ b/app/Queries/VolumeQuery.php
@@ -49,7 +49,7 @@ class VolumeQuery
         string $sortColumn = 'created_at',
         string $sortDirection = 'desc'
     ): Builder {
-        $sortColumn = in_array($sortColumn, self::ALLOWED_SORT_COLUMNS, true) ? $sortColumn : 'created_at';
+        $sortColumn = Formatters::sortColumn($sortColumn, self::ALLOWED_SORT_COLUMNS);
 
         return Volume::query()
             // Eager-load each volume's used storage. The archive size lives on

--- a/app/Support/Formatters.php
+++ b/app/Support/Formatters.php
@@ -131,9 +131,24 @@ class Formatters
      *
      * @return 'asc'|'desc'
      */
+    /**
+     * @return 'asc'|'desc'
+     */
     public static function sortDirection(string $direction): string
     {
         return strtolower($direction) === 'asc' ? 'asc' : 'desc';
+    }
+
+    /**
+     * Constrain a requested sort column to a whitelist. Sort columns reach the
+     * query builder from the URL, so an unknown one falls back rather than
+     * being interpolated.
+     *
+     * @param  list<string>  $allowed
+     */
+    public static function sortColumn(?string $requested, array $allowed, string $default = 'created_at'): string
+    {
+        return in_array($requested, $allowed, true) ? (string) $requested : $default;
     }
 
     /**

--- a/resources/views/components/delete-confirmation-modal.blade.php
+++ b/resources/views/components/delete-confirmation-modal.blade.php
@@ -1,7 +1,9 @@
-@props(['title', 'message', 'onConfirm', 'showKeepFiles' => false, 'snapshotCount' => 0])
+@props(['title', 'message' => '', 'onConfirm', 'showKeepFiles' => false, 'snapshotCount' => 0])
 
 <x-modal wire:model="showDeleteModal" :title="$title" class="backdrop-blur">
-    <p>{{ $message }}</p>
+    @if($message !== '')
+        <p>{{ $message }}</p>
+    @endif
 
     @if($snapshotCount > 0)
         <x-alert icon="o-exclamation-triangle" class="alert-warning mt-4">
@@ -9,14 +11,14 @@
         </x-alert>
     @endif
 
+    {{ $slot }}
+
     @if($showKeepFiles)
         <label class="flex items-start gap-3 mt-4 cursor-pointer">
             <input type="checkbox" wire:model="keepFiles" class="checkbox checkbox-sm mt-0.5" />
             <span class="text-sm">{{ __('Keep backup files on storage (only delete database records)') }}</span>
         </label>
     @endif
-
-    {{ $slot }}
 
     <x-slot:actions>
         <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />

--- a/resources/views/livewire/agent/index.blade.php
+++ b/resources/views/livewire/agent/index.blade.php
@@ -118,18 +118,15 @@
     </x-card>
 
     <!-- DELETE CONFIRMATION MODAL -->
-    <x-modal wire:model="showDeleteModal" :title="__('Delete Agent')" class="backdrop-blur">
-        <p>{{ __('Are you sure you want to delete this agent? This action cannot be undone.') }}</p>
-
+    <x-delete-confirmation-modal
+        :title="__('Delete Agent')"
+        :message="__('Are you sure you want to delete this agent? This action cannot be undone.')"
+        onConfirm="delete"
+    >
         @if($deleteServerCount > 0)
             <x-alert icon="o-exclamation-triangle" class="alert-warning mt-4">
                 {{ trans_choice(':count database server is assigned to this agent and will be unlinked.|:count database servers are assigned to this agent and will be unlinked.', $deleteServerCount, ['count' => $deleteServerCount]) }}
             </x-alert>
         @endif
-
-        <x-slot:actions>
-            <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
-            <x-button :label="__('Delete')" class="btn-error" wire:click="delete" />
-        </x-slot:actions>
-    </x-modal>
+    </x-delete-confirmation-modal>
 </div>

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -92,19 +92,14 @@
     </x-modal>
 
     {{-- Delete Confirmation --}}
-    <x-modal wire:model="showDeleteModal" :title="__('Delete Organization')">
+    <x-delete-confirmation-modal
+        :title="__('Delete Organization')"
+        onConfirm="deleteOrganization"
+        :showKeepFiles="true"
+    >
         <x-alert icon="o-exclamation-triangle" class="alert-warning">
             {{ __('All servers, volumes, agents and snapshots in this organization will be permanently deleted. This action cannot be undone.') }}
         </x-alert>
-
-        <label class="flex items-start gap-3 mt-4 cursor-pointer">
-            <input type="checkbox" wire:model="keepFiles" class="checkbox checkbox-sm mt-0.5" />
-            <span class="text-sm">{{ __('Keep backup files on storage (only delete database records)') }}</span>
-        </label>
-        <x-slot:actions>
-            <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
-            <x-button :label="__('Delete')" class="btn-error" wire:click="deleteOrganization" spinner="deleteOrganization" />
-        </x-slot:actions>
-    </x-modal>
+    </x-delete-confirmation-modal>
     @endcan
 </div>

--- a/resources/views/livewire/configuration/roles.blade.php
+++ b/resources/views/livewire/configuration/roles.blade.php
@@ -71,11 +71,9 @@
     </x-modal>
 
     <!-- DELETE MODAL -->
-    <x-modal wire:model="showDeleteModal" :title="__('Delete role')" class="backdrop-blur">
-        <p>{{ __('Are you sure you want to delete this role? Users who have only this role will lose its abilities.') }}</p>
-        <x-slot:actions>
-            <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
-            <x-button :label="__('Delete')" class="btn-error" wire:click="delete" spinner="delete" />
-        </x-slot:actions>
-    </x-modal>
+    <x-delete-confirmation-modal
+        :title="__('Delete role')"
+        :message="__('Are you sure you want to delete this role? Users who have only this role will lose its abilities.')"
+        onConfirm="delete"
+    />
 </div>

--- a/tests/Feature/Livewire/Restore/IndexTest.php
+++ b/tests/Feature/Livewire/Restore/IndexTest.php
@@ -4,11 +4,9 @@ use App\Enums\Ability;
 use App\Livewire\Restore\Index;
 use App\Models\BackupJob;
 use App\Models\DatabaseServer;
-use App\Models\Organization;
 use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Models\User;
-use App\Models\Volume;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Livewire\Livewire;
 
@@ -34,29 +32,6 @@ function makeRestore(array $attrs = []): Restore
         'snapshot_id' => $snapshot->id,
         'target_server_id' => $target->id,
         'schema_name' => $attrs['schema_name'] ?? 'restored_db',
-    ]);
-}
-
-/**
- * A completed restore owned by an organization the actor is not a member of.
- */
-function foreignRestore(): Restore
-{
-    $org = Organization::factory()->create();
-    $server = DatabaseServer::factory()->create([
-        'organization_id' => $org->id,
-        'database_type' => 'mysql',
-    ]);
-    $snapshot = Snapshot::factory()
-        ->forServer($server)
-        ->onVolumes(Volume::factory()->create(['organization_id' => $org->id]))
-        ->create();
-
-    return Restore::create([
-        'backup_job_id' => BackupJob::create(['status' => 'completed'])->id,
-        'snapshot_id' => $snapshot->id,
-        'target_server_id' => $server->id,
-        'schema_name' => 'victim_confidential_schema',
     ]);
 }
 

--- a/tests/Feature/Snapshot/CrossOrganizationTest.php
+++ b/tests/Feature/Snapshot/CrossOrganizationTest.php
@@ -5,11 +5,9 @@ use App\Mcp\Servers\DatabasementServer;
 use App\Mcp\Tools\ListSnapshotsTool;
 use App\Mcp\Tools\TriggerRestoreTool;
 use App\Models\DatabaseServer;
-use App\Models\Organization;
 use App\Models\ScheduledRestore;
 use App\Models\Snapshot;
 use App\Models\User;
-use App\Models\Volume;
 use App\Services\Backup\BackupJobFactory;
 use App\Services\CurrentOrganization;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -21,31 +19,6 @@ use Illuminate\Validation\ValidationException;
  * inherit tenancy from their database server. These cover every path that
  * resolves one by id, which is where the isolation used to be missing.
  */
-
-/**
- * @return array{0: Organization, 1: DatabaseServer}
- */
-function foreignServer(string $databaseType = 'mysql'): array
-{
-    $org = Organization::factory()->create();
-
-    return [$org, DatabaseServer::factory()->create([
-        'organization_id' => $org->id,
-        'database_type' => $databaseType,
-    ])];
-}
-
-/**
- * A complete, restorable snapshot owned by an organization the actor is not in.
- */
-function foreignSnapshot(string $databaseType = 'mysql'): Snapshot
-{
-    [$org, $server] = foreignServer($databaseType);
-    $volume = Volume::factory()->create(['organization_id' => $org->id]);
-
-    return Snapshot::factory()->forServer($server)->onVolumes($volume)->create();
-}
-
 test('the snapshot api does not list another organization snapshots', function () {
     $user = User::factory()->withAbilities([])->create();
     $foreign = foreignSnapshot();

--- a/tests/Feature/Support/FormattersTest.php
+++ b/tests/Feature/Support/FormattersTest.php
@@ -168,3 +168,13 @@ test('resolveDatePlaceholders uses display timezone for "now"', function () {
 
     \Carbon\Carbon::setTestNow();
 });
+
+test('sortColumn falls back when the requested column is not whitelisted', function (?string $requested, string $expected) {
+    // Sort columns arrive from the URL, so an unknown one must not reach the
+    // query builder.
+    expect(Formatters::sortColumn($requested, ['name', 'created_at']))->toBe($expected);
+})->with([
+    'allowed' => ['name', 'name'],
+    'not allowed' => ['id; drop table users', 'created_at'],
+    'null' => [null, 'created_at'],
+]);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -166,6 +166,50 @@ function createDatabaseServer(array $attributes = []): \App\Models\DatabaseServe
 }
 
 /**
+ * Create a DatabaseServer in an organization the acting user is not a member of.
+ * Returned with its organization so callers can put related records there too.
+ *
+ * @return array{0: \App\Models\Organization, 1: \App\Models\DatabaseServer}
+ */
+function foreignServer(string $databaseType = 'mysql'): array
+{
+    $org = \App\Models\Organization::factory()->create();
+
+    return [$org, \App\Models\DatabaseServer::factory()->create([
+        'organization_id' => $org->id,
+        'database_type' => $databaseType,
+    ])];
+}
+
+/**
+ * A complete, restorable snapshot owned by an organization the actor is not in.
+ */
+function foreignSnapshot(string $databaseType = 'mysql'): \App\Models\Snapshot
+{
+    [$org, $server] = foreignServer($databaseType);
+
+    return \App\Models\Snapshot::factory()
+        ->forServer($server)
+        ->onVolumes(\App\Models\Volume::factory()->create(['organization_id' => $org->id]))
+        ->create();
+}
+
+/**
+ * A completed restore owned by an organization the actor is not a member of.
+ */
+function foreignRestore(): \App\Models\Restore
+{
+    $snapshot = foreignSnapshot();
+
+    return \App\Models\Restore::create([
+        'backup_job_id' => \App\Models\BackupJob::create(['status' => 'completed'])->id,
+        'snapshot_id' => $snapshot->id,
+        'target_server_id' => $snapshot->database_server_id,
+        'schema_name' => 'victim_confidential_schema',
+    ]);
+}
+
+/**
  * Create a matching source + target DatabaseServer pair of the same type.
  *
  * @return array{0: \App\Models\DatabaseServer, 1: \App\Models\DatabaseServer}


### PR DESCRIPTION
Three follow-ups from the duplication sweep, one per commit so they can be reviewed independently.

Net: 108 added, 104 removed. Deliberately smaller than #517 — see the honest accounting below.

## 1. Reuse the delete confirmation modal (`04ed472`)

`x-delete-confirmation-modal` was used by six blades and hand-rolled by six others. I compared each of the six against the component rather than converting on sight, and only **three** actually match it: `agent/index`, `configuration/roles`, `configuration/organization`.

The component now takes an optional `message` so a caller can supply a warning alert through the slot instead of a plain paragraph, and `{{ $slot }}` moved above the keep-files checkbox to preserve the organization modal's ordering. No existing caller passed a slot, so nothing else moves.

**Left alone, with reasons:**

- `api-token/index` — cancel calls `closeDeleteModal()`, which also clears `deleteTokenId`. The component's cancel only hides the modal, so converting would leave a stale id. Its confirm button is also labelled "Revoke Token", not "Delete".
- `user/index` — hides the confirm button entirely via `@unless($deleteBlockReason)`. The component always renders it, so converting would offer a delete that the component knows is blocked.
- `settings/delete-user-form` — wraps a `<form wire:submit>` with password confirmation.

Each would need a prop serving exactly one caller, which trades duplication for a component that is harder to reason about.

## 2. Move the cross-org test fixtures into `Pest.php` (`19c3349`)

`foreignServer()` / `foreignSnapshot()` and `foreignRestore()` built the same graph in two different test files, declared as Pest globals inside those files so availability depended on file load order. They now sit beside `createDatabaseServer()` and `createRestoreServerPair()`, and `foreignRestore()` derives its target server from the snapshot rather than building a second one.

This is duplication I introduced across #511 and #516.

## 3. Share the query sort normalisation (`205a815`)

All six query classes repeated the same whitelist-or-fall-back for the sort column, and `AgentQuery` inlined its own copy of `sortDirection()` as well. Added `Formatters::sortColumn()` next to the `sortDirection()` it already sat beside.

`RestoreQuery` and `SnapshotQuery` also carried a byte-identical block ordering on the related backup job's status, differing only in `restores.` vs `snapshots.`; that moved to an `OrdersByJobStatus` concern.

Narrowing `sortDirection()`'s declared return to `'asc'|'desc'` is what lets the shared helper satisfy `orderBy()`'s parameter type — the inline copies had been sidestepping it.

**Not merged:** how each query *applies* its sort genuinely differs (status subquery, snapshot-size/duration/type mapping, plain column), as do the `applySearch()` bodies, which search different columns and relations per model. Those are polymorphism, not duplication.

## Honest accounting

I originally estimated six modals and "~25 lines" for the query work. The modals turned out to be three of six once I checked each properly, and the query saving is genuinely modest. This PR is a consistency improvement, not a big deletion like #517.

## Tests

`make test` 1487 passed, `make phpstan` clean, `make lint-check` clean.

The three converted blades are all rendered by existing component tests, so the suite exercises them. Added a `Formatters::sortColumn()` case covering the fall-back for a non-whitelisted column, since sort columns arrive from the URL.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Standardized and centralized sort-column validation across agents, backups, database servers, restores, snapshots, and volumes.
  - Status-based sorting for restores and snapshots is now consistent and shared.
  - Invalid or missing sort selections fall back to a consistent default.

- **User Interface**
  - Unified delete confirmation dialogs for agents, organizations, and roles using the shared component.
  - Delete dialogs now support optional messages and render content in a clearer order.
  - Organization deletion still includes the option to keep files.

- **Tests**
  - Added coverage for sort-column behavior and strengthened cross-organization sorting/isolation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->