### PR TITLE
feat: ability-scoped API tokens

### DIFF
--- a/app/Livewire/ApiToken/Index.php
+++ b/app/Livewire/ApiToken/Index.php
@@ -103,6 +103,24 @@ class Index extends Component
         $this->success(__('API token revoked successfully.'));
     }
 
+    /**
+     * Display-ready label for a token's access scope badge.
+     */
+    public function accessLabel(PersonalAccessToken $token): string
+    {
+        $abilities = $token->abilities ?? [];
+
+        if (in_array('*', $abilities, true)) {
+            return __('Full access');
+        }
+
+        return trans_choice(
+            '{0} No abilities|{1} :count ability|[2,*] :count abilities',
+            count($abilities),
+            ['count' => count($abilities)]
+        );
+    }
+
     public function canDelete(PersonalAccessToken $token): bool
     {
         $user = Auth::user();

--- a/app/Livewire/ApiToken/Index.php
+++ b/app/Livewire/ApiToken/Index.php
@@ -2,13 +2,13 @@
 
 namespace App\Livewire\ApiToken;
 
+use App\Enums\Ability;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Laravel\Sanctum\PersonalAccessToken;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Title;
-use Livewire\Attributes\Validate;
 use Livewire\Component;
 
 #[Title('API Tokens')]
@@ -16,8 +16,12 @@ class Index extends Component
 {
     use Toast;
 
-    #[Validate('required|string|max:255')]
     public string $tokenName = '';
+
+    public bool $fullAccess = true;
+
+    /** @var list<string> */
+    public array $tokenAbilities = [];
 
     public bool $showCreateModal = false;
 
@@ -39,17 +43,25 @@ class Index extends Component
     public function closeCreateModal(): void
     {
         $this->showCreateModal = false;
-        $this->tokenName = '';
+        $this->reset(['tokenName', 'fullAccess', 'tokenAbilities']);
     }
 
     public function createToken(): void
     {
-        $this->validate();
+        $this->validate([
+            'tokenName' => 'required|string|max:255',
+            'tokenAbilities' => 'array',
+            'tokenAbilities.*' => 'in:'.implode(',', Ability::names()),
+        ]);
 
-        $token = Auth::user()->createToken($this->tokenName);
+        $abilities = $this->fullAccess
+            ? ['*']
+            : array_values(array_intersect($this->tokenAbilities, Ability::names()));
+
+        $token = Auth::user()->createToken($this->tokenName, $abilities);
 
         $this->newToken = $token->plainTextToken;
-        $this->tokenName = '';
+        $this->reset(['tokenName', 'fullAccess', 'tokenAbilities']);
         $this->showCreateModal = false;
         $this->showTokenModal = true;
     }
@@ -116,6 +128,7 @@ class Index extends Component
 
         return view('livewire.api-token.index', [
             'tokens' => $query->get(),
+            'abilityGroups' => Ability::grouped(),
         ]);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -128,6 +128,24 @@ class User extends Authenticatable
     }
 
     /**
+     * Whether the current request's authentication covers the given ability.
+     *
+     * True for session/web auth (no access token) or a token granted `['*']`
+     * or the explicit ability; false for a real, scoped-out
+     * PersonalAccessToken. Sanctum's TransientToken (first-party SPA/session
+     * requests) always reports can() === true, so it naturally passes through
+     * as covered without needing special-casing. Wrapped in optional() because
+     * currentAccessToken() is null at runtime for plain session/web auth even
+     * though Sanctum's generic-based PHPDoc claims it's always non-null.
+     */
+    public function tokenCovers(string $ability): bool
+    {
+        $token = optional($this->currentAccessToken());
+
+        return ($token->can('*') ?? true) || ($token->can($ability) ?? true);
+    }
+
+    /**
      * The name of the role assigned to the user in an organization (built-in or
      * custom), or null if none.
      */

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -165,9 +165,19 @@ class AppServiceProvider extends ServiceProvider
         // policy abilities (create/update/delete/...) keep their own super-admin
         // handling. A Gate::before that returns null defers to Bouncer's grant
         // resolution — unlike a Gate::define, which would shadow it.
+        //
+        // This also enforces Sanctum token scoping for the catalogue: a real,
+        // scoped-out PersonalAccessToken is denied outright before Bouncer's
+        // role/direct-ability resolution ever runs, without touching the 12
+        // individual policy files. Session auth and legacy `['*']` tokens are
+        // unaffected (User::tokenCovers()).
         Gate::before(function (?User $user, string $ability): ?bool {
             if ($user?->isSuperAdmin() && in_array($ability, Ability::names(), true)) {
                 return true;
+            }
+
+            if ($user !== null && in_array($ability, Ability::names(), true) && ! $user->tokenCovers($ability)) {
+                return false;
             }
 
             return null;

--- a/resources/views/livewire/api-token/index.blade.php
+++ b/resources/views/livewire/api-token/index.blade.php
@@ -24,11 +24,7 @@
                         <div class="flex-1">
                             <div class="font-medium">
                                 {{ $token->name }}
-                                @if(in_array('*', $token->abilities ?? [], true))
-                                    <span class="badge badge-sm badge-ghost ml-1">{{ __('Full access') }}</span>
-                                @else
-                                    <span class="badge badge-sm badge-ghost ml-1">{{ trans_choice('{0} No abilities|{1} :count ability|[2,*] :count abilities', count($token->abilities ?? []), ['count' => count($token->abilities ?? [])]) }}</span>
-                                @endif
+                                <span class="badge badge-sm badge-ghost ml-1">{{ $this->accessLabel($token) }}</span>
                             </div>
                             <div class="text-sm text-base-content/70">
                                 @if($token->tokenable)

--- a/resources/views/livewire/api-token/index.blade.php
+++ b/resources/views/livewire/api-token/index.blade.php
@@ -22,7 +22,14 @@
                 @foreach($tokens as $token)
                     <div class="flex items-center justify-between p-4 bg-base-200 rounded-lg">
                         <div class="flex-1">
-                            <div class="font-medium">{{ $token->name }}</div>
+                            <div class="font-medium">
+                                {{ $token->name }}
+                                @if(in_array('*', $token->abilities ?? [], true))
+                                    <span class="badge badge-sm badge-ghost ml-1">{{ __('Full access') }}</span>
+                                @else
+                                    <span class="badge badge-sm badge-ghost ml-1">{{ trans_choice('{0} No abilities|{1} :count ability|[2,*] :count abilities', count($token->abilities ?? []), ['count' => count($token->abilities ?? [])]) }}</span>
+                                @endif
+                            </div>
                             <div class="text-sm text-base-content/70">
                                 @if($token->tokenable)
                                     <span class="font-medium">{{ $token->tokenable->name }}</span>
@@ -60,6 +67,20 @@
             placeholder="{{ __('e.g., CI/CD Pipeline, Backup Script') }}"
             hint="{{ __('A descriptive name to identify this token') }}"
         />
+
+        <label class="flex items-center gap-3 mt-4 cursor-pointer">
+            <x-toggle wire:model.live="fullAccess" class="toggle-primary" />
+            <span class="font-medium">{{ __('Full access') }}</span>
+        </label>
+
+        @unless($fullAccess)
+            <div class="mt-4">
+                <div class="text-sm text-base-content/70 mb-2">
+                    {{ __('Select the abilities this token is allowed to use.') }}
+                </div>
+                <x-ability-toggles :groups="$abilityGroups" model="tokenAbilities" />
+            </div>
+        @endunless
 
         <x-slot:actions>
             <x-button label="{{ __('Cancel') }}" wire:click="closeCreateModal" />

--- a/tests/Feature/Api/ApiTokenAbilitiesTest.php
+++ b/tests/Feature/Api/ApiTokenAbilitiesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Enums\Ability;
+use App\Jobs\ProcessBackupJob;
+use App\Models\User;
+use App\Support\BouncerScope;
+use Illuminate\Support\Facades\Queue;
+
+/**
+ * Exercises the Gate::before combination in
+ * AppServiceProvider::registerBouncer() that layers Sanctum token abilities on
+ * top of Bouncer's role/direct-ability resolution, via real HTTP requests with
+ * a genuine personal access token (matching ApiHttpAuthorizationTest's style).
+ */
+test('a token scoped to the required ability can call the gated endpoint', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::RunBackups->value])->create();
+    $server = createDatabaseServer(['database_names' => ['testdb']]);
+    $token = $user->createToken('scoped', [Ability::RunBackups->value])->plainTextToken;
+
+    BouncerScope::apply(null);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/database-servers/{$server->id}/backup")
+        ->assertStatus(202);
+
+    Queue::assertPushed(ProcessBackupJob::class);
+});
+
+test('a token not scoped to the required ability is denied even though the user holds it via Bouncer', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::RunBackups->value])->create();
+    $server = createDatabaseServer(['database_names' => ['testdb']]);
+    // The token only covers an unrelated ability — the user's Bouncer grant for
+    // run-backups must not leak through.
+    $token = $user->createToken('scoped', [Ability::DownloadSnapshots->value])->plainTextToken;
+
+    BouncerScope::apply(null);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/database-servers/{$server->id}/backup")
+        ->assertForbidden();
+
+    Queue::assertNothingPushed();
+});
+
+test('a full-access token still defers to Bouncer as before', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::RunBackups->value])->create();
+    $server = createDatabaseServer(['database_names' => ['testdb']]);
+    $token = $user->createToken('legacy')->plainTextToken;
+
+    BouncerScope::apply(null);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/database-servers/{$server->id}/backup")
+        ->assertStatus(202);
+
+    Queue::assertPushed(ProcessBackupJob::class);
+});
+
+test('a super admin token bypasses ability scoping for the catalogue', function () {
+    Queue::fake();
+
+    $superAdmin = User::factory()->superAdmin()->create();
+    $server = createDatabaseServer(['database_names' => ['testdb']]);
+    // Scoped to an unrelated ability — the super-admin bypass still applies.
+    $token = $superAdmin->createToken('scoped', [Ability::DownloadSnapshots->value])->plainTextToken;
+
+    BouncerScope::apply(null);
+
+    $this->withToken($token)
+        ->postJson("/api/v1/database-servers/{$server->id}/backup")
+        ->assertStatus(202);
+
+    Queue::assertPushed(ProcessBackupJob::class);
+});
+
+test('session auth is unaffected by token scoping', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::RunBackups->value])->create();
+    $server = createDatabaseServer(['database_names' => ['testdb']]);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson("/api/v1/database-servers/{$server->id}/backup")
+        ->assertStatus(202);
+
+    Queue::assertPushed(ProcessBackupJob::class);
+});

--- a/tests/Feature/ApiToken/IndexTest.php
+++ b/tests/Feature/ApiToken/IndexTest.php
@@ -56,6 +56,17 @@ test('creating a scoped token rejects abilities outside the catalogue', function
     expect($user->tokens()->where('name', 'Bad Token')->exists())->toBeFalse();
 });
 
+test('the index lists a full-access badge and an ability-count badge for scoped tokens', function () {
+    $user = User::factory()->create();
+    $user->createToken('Legacy Token');
+    $user->createToken('Scoped Token', [Ability::RunBackups->value, Ability::DownloadSnapshots->value]);
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->assertSee(__('Full access'))
+        ->assertSee('2 abilities');
+});
+
 test('can revoke an existing token', function () {
     $user = User::factory()->create();
     $token = $user->createToken('Token to Delete');

--- a/tests/Feature/ApiToken/IndexTest.php
+++ b/tests/Feature/ApiToken/IndexTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\Ability;
 use App\Livewire\ApiToken\Index;
 use App\Models\User;
 use Livewire\Livewire;
@@ -12,7 +13,8 @@ test('can create a new api token and use it to authenticate', function () {
         ->set('tokenName', 'Test Token')
         ->call('createToken');
 
-    expect($user->tokens()->where('name', 'Test Token')->exists())->toBeTrue();
+    $token = $user->tokens()->where('name', 'Test Token')->firstOrFail();
+    expect($token->can('*'))->toBeTrue();
 
     // Use the created token to call the API
     $plainTextToken = $component->get('newToken');
@@ -20,6 +22,38 @@ test('can create a new api token and use it to authenticate', function () {
     $this->withHeader('Authorization', 'Bearer '.$plainTextToken)
         ->getJson(route('api.database-servers.index'))
         ->assertOk();
+});
+
+test('can create a scoped api token limited to the selected abilities', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->set('tokenName', 'Scoped Token')
+        ->set('fullAccess', false)
+        ->set('tokenAbilities', [Ability::RunBackups->value, Ability::DownloadSnapshots->value])
+        ->call('createToken');
+
+    $token = $user->tokens()->where('name', 'Scoped Token')->firstOrFail();
+
+    expect($token->can('*'))->toBeFalse()
+        ->and($token->can(Ability::RunBackups->value))->toBeTrue()
+        ->and($token->can(Ability::DownloadSnapshots->value))->toBeTrue()
+        ->and($token->can(Ability::ManageVolumes->value))->toBeFalse();
+});
+
+test('creating a scoped token rejects abilities outside the catalogue', function () {
+    $user = User::factory()->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->set('tokenName', 'Bad Token')
+        ->set('fullAccess', false)
+        ->set('tokenAbilities', ['not-a-real-ability'])
+        ->call('createToken')
+        ->assertHasErrors(['tokenAbilities.0']);
+
+    expect($user->tokens()->where('name', 'Bad Token')->exists())->toBeFalse();
 });
 
 test('can revoke an existing token', function () {

--- a/tests/Feature/ApiToken/IndexTest.php
+++ b/tests/Feature/ApiToken/IndexTest.php
@@ -56,15 +56,15 @@ test('creating a scoped token rejects abilities outside the catalogue', function
     expect($user->tokens()->where('name', 'Bad Token')->exists())->toBeFalse();
 });
 
-test('the index lists a full-access badge and an ability-count badge for scoped tokens', function () {
+test('accessLabel reports full access or the ability count per token, not just anywhere on the page', function () {
     $user = User::factory()->create();
-    $user->createToken('Legacy Token');
-    $user->createToken('Scoped Token', [Ability::RunBackups->value, Ability::DownloadSnapshots->value]);
+    $legacyToken = $user->createToken('Legacy Token')->accessToken;
+    $scopedToken = $user->createToken('Scoped Token', [Ability::RunBackups->value, Ability::DownloadSnapshots->value])->accessToken;
 
-    Livewire::actingAs($user)
-        ->test(Index::class)
-        ->assertSee(__('Full access'))
-        ->assertSee('2 abilities');
+    $component = Livewire::actingAs($user)->test(Index::class)->instance();
+
+    expect($component->accessLabel($legacyToken))->toBe(__('Full access'))
+        ->and($component->accessLabel($scopedToken))->toBe('2 abilities');
 });
 
 test('can revoke an existing token', function () {


### PR DESCRIPTION
## Summary

Tokens created from Settings → API Tokens previously always got Sanctum's default `['*']` ability, i.e. full access as the creator, forever. This lets users scope a token down to a subset of the existing `Ability` catalogue at creation time.

- `User::tokenCovers(string $ability): bool` — true for session/web auth or a token granted `['*']` or the explicit ability, false for a real, scoped-out token.
- A single `Gate::before` check in `AppServiceProvider::registerBouncer()` (next to the existing super-admin bypass) combines Sanctum token abilities with Bouncer's role/direct-ability resolution, without touching any of the 12 individual policy files.
- `App\Livewire\ApiToken\Index` gets a "Full access" toggle (default on, for familiar UX) and, when off, the same `ability-toggles` component used by the Roles screen, validated as a subset of `Ability::names()`.
- Legacy/full tokens need no migration: `['*']` already means "covers everything." Agent tokens (`App\Models\Agent`) are untouched, since agent routes don't go through policies.

## Test plan

- [x] New `tests/Feature/Api/ApiTokenAbilitiesTest.php`: scoped token succeeds/is denied against a real HTTP request with a genuine token, full-access token still defers to Bouncer, super-admin token bypasses scoping, session auth is unaffected.
- [x] Extended `tests/Feature/ApiToken/IndexTest.php`: creating a scoped token persists the correct ability set, invalid ability names are rejected by validation.
- [x] `make lint-fix`, `make phpstan`, `make test` (full suite, 1493 tests) all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create API tokens with full access or selected, validated abilities.
  * Token listings display each token’s access level.
  * Token creation forms reset after closing or creating a token.
  * Authorization now respects scoped token abilities, including full-access tokens.

* **Bug Fixes**
  * Prevented tokens without required abilities from accessing restricted actions.
  * Preserved super-admin and session-based access behavior.

* **Tests**
  * Added coverage for token creation, ability validation, scoped authorization, denied requests, and bypass scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->