### PR TITLE
ci: restore Codecov and SonarQube reporting on fork PRs

### DIFF
--- a/.github/workflows/coverage-and-quality.yml
+++ b/.github/workflows/coverage-and-quality.yml
@@ -82,9 +82,12 @@ jobs:
           # Look the PR up by head ref against *this* repo: workflow_run carries
           # no pull_requests for forks, commits/{sha}/pulls doesn't resolve a
           # fork head, and the artifact is fork-writable so it can't be trusted.
+          # Emit nothing unless exactly one open PR matches; the same head can
+          # target two bases, and picking one arbitrarily would mislabel it.
           gh api "repos/${{ github.repository }}/pulls" -X GET \
-            -f state=all -f "head=$HEAD_OWNER:$HEAD_BRANCH" \
-            --jq '.[0] // empty | "number=\(.number)", "base=\(.base.ref)"' >> "$GITHUB_OUTPUT"
+            -f state=open -f "head=$HEAD_OWNER:$HEAD_BRANCH" \
+            --jq 'if length == 1 then (.[0] | "number=\(.number)", "base=\(.base.ref)") else empty end' \
+            >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage to Codecov
         if: hashFiles('coverage.xml') != ''

--- a/.github/workflows/coverage-and-quality.yml
+++ b/.github/workflows/coverage-and-quality.yml
@@ -7,7 +7,8 @@ on:
 
 permissions:
   contents: read
-  actions: read   # needed to download artifacts from the triggering run
+  actions: read         # download artifacts from the triggering run
+  pull-requests: read   # resolve the PR behind a fork's head branch
 
 jobs:
   upload:
@@ -16,18 +17,35 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' && github.event.workflow_run.conclusion != 'skipped' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source (read-only, for Codecov path resolution)
+      - name: Checkout source (read-only, for Codecov and SonarQube)
         # Codecov's CLI needs the source tree on disk to build its file
         # network and apply path fixups against the paths in coverage.xml.
         # SonarQube also needs the source tree (with full history) for
-        # relevant analysis. Safe in this secret-bearing context because we
-        # never execute the checked-out code — we only let the tools read it.
+        # relevant analysis. `allow-unsafe-pr-checkout` opts out of the guard
+        # checkout v7.0.1 added, which otherwise fails every fork PR: that
+        # guard targets *executing* fork code, and this job only reads it.
         uses: actions/checkout@v7
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           persist-credentials: false
+          allow-unsafe-pr-checkout: true
+
+      - name: Pin scanner config to the base repo
+        # Fork-controlled after the checkout, and the scanner honours what it
+        # finds — sonar.host.url would redirect SONAR_TOKEN. Fail loudly if the
+        # fetch fails rather than let the scan run on the fork's version.
+        if: ${{ github.event.workflow_run.head_repository.full_name != github.repository }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_SHA: ${{ github.sha }}   # workflow_run: tip of this repo's default branch
+        run: |
+          set -euo pipefail
+          # Stage via temp file so a failed fetch can't leave a truncated config.
+          gh api "repos/${{ github.repository }}/contents/sonar-project.properties?ref=$BASE_SHA" \
+            -H "Accept: application/vnd.github.raw" > "$RUNNER_TEMP/sonar.properties"
+          mv "$RUNNER_TEMP/sonar.properties" sonar-project.properties
 
       - name: Download coverage artifact
         # Producer uses `if-no-files-found: ignore`, so the artifact may be
@@ -40,20 +58,33 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read PR metadata
-        id: pr
+      - name: Resolve upload metadata
+        id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_OWNER: ${{ github.event.workflow_run.head_repository.owner.login }}
+          IS_FORK: ${{ github.event.workflow_run.head_repository.full_name != github.repository }}
+          EVENT: ${{ github.event.workflow_run.event }}
         run: |
-          if [ -f pr-number.txt ]; then
-            number=$(cat pr-number.txt)
-            echo "number=$number" >> "$GITHUB_OUTPUT"
-            # Resolve the PR's base branch for SonarQube PR analysis. The
-            # workflow_run payload doesn't reliably carry it, so query the API
-            # and fall back to the default branch if anything goes wrong.
-            base=$(gh pr view "$number" --repo "${{ github.repository }}" --json baseRefName -q .baseRefName 2>/dev/null || true)
-            echo "base=${base:-main}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          # Codecov labels fork branches `owner:branch`; a bare name would
+          # register a phantom branch on this repo.
+          if [ "$IS_FORK" = true ]; then
+            echo "branch=$HEAD_OWNER:$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=$HEAD_BRANCH" >> "$GITHUB_OUTPUT"
           fi
+
+          [ "$EVENT" = pull_request ] || exit 0
+
+          # Look the PR up by head ref against *this* repo: workflow_run carries
+          # no pull_requests for forks, commits/{sha}/pulls doesn't resolve a
+          # fork head, and the artifact is fork-writable so it can't be trusted.
+          gh api "repos/${{ github.repository }}/pulls" -X GET \
+            -f state=all -f "head=$HEAD_OWNER:$HEAD_BRANCH" \
+            --jq '.[0] // empty | "number=\(.number)", "base=\(.base.ref)"' >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage to Codecov
         if: hashFiles('coverage.xml') != ''
@@ -63,8 +94,8 @@ jobs:
           report_type: coverage
           files: coverage.xml
           override_commit: ${{ github.event.workflow_run.head_sha }}
-          override_branch: ${{ github.event.workflow_run.head_branch }}
-          override_pr: ${{ steps.pr.outputs.number }}
+          override_branch: ${{ steps.meta.outputs.branch }}
+          override_pr: ${{ steps.meta.outputs.number }}
 
       - name: Upload test results to Codecov
         if: hashFiles('junit.xml') != ''
@@ -74,8 +105,8 @@ jobs:
           report_type: test_results
           files: junit.xml
           override_commit: ${{ github.event.workflow_run.head_sha }}
-          override_branch: ${{ github.event.workflow_run.head_branch }}
-          override_pr: ${{ steps.pr.outputs.number }}
+          override_branch: ${{ steps.meta.outputs.branch }}
+          override_pr: ${{ steps.meta.outputs.number }}
 
       - name: SonarQube Scan (main)
         # Analyse the main branch, using the coverage.xml and junit.xml
@@ -95,9 +126,9 @@ jobs:
       - name: SonarQube Scan (pull request)
         # Analyse pull requests so SonarQube decorates the PR with its Quality
         # Gate and inline issues. The `pull_requests` payload is unreliable in
-        # workflow_run, so we drive this off the PR number from the artifact and
-        # the base branch resolved above.
-        if: ${{ github.event.workflow_run.event == 'pull_request' && steps.pr.outputs.number != '' && hashFiles('coverage.xml') != '' }}
+        # workflow_run, so we drive this off the PR number and base branch
+        # resolved above.
+        if: ${{ github.event.workflow_run.event == 'pull_request' && steps.meta.outputs.number != '' && hashFiles('coverage.xml') != '' }}
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
@@ -105,7 +136,7 @@ jobs:
           # PR analysis params take precedence over branch analysis. Pin the
           # revision to the triggering commit since we run detached.
           args: >-
-            -Dsonar.pullrequest.key=${{ steps.pr.outputs.number }}
+            -Dsonar.pullrequest.key=${{ steps.meta.outputs.number }}
             -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
-            -Dsonar.pullrequest.base=${{ steps.pr.outputs.base }}
+            -Dsonar.pullrequest.base=${{ steps.meta.outputs.base }}
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,10 +132,6 @@ jobs:
       - name: Run Tests
         run: php artisan test --parallel --coverage-clover=coverage.xml --log-junit junit.xml
 
-      - name: Save PR metadata
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
-
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@v7
@@ -144,6 +140,5 @@ jobs:
           path: |
             coverage.xml
             junit.xml
-            pr-number.txt
           retention-days: 1
           if-no-files-found: ignore


### PR DESCRIPTION
## Problem

Codecov reports nothing on fork PRs (for example #526, where Codecov shows "Missing Head Commit"), and SonarQube never runs on them either.

The cause is not the `override_commit` / `override_branch` / `override_pr` inputs. The job fails at its **first step**:

```
##[error]Refusing to check out fork pull request code from a 'workflow_run' workflow.
... To opt in ... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

Every later step is skipped, so no upload ever happens. `actions/checkout` v7.0.1 (2026-07-20) added this guard; the first failing run here is 2026-07-24. All 12 recent failures are fork PRs, while `main` and same repo branches still pass.

## Fix

Opt back in with `allow-unsafe-pr-checkout: true`. The guard targets *executing* fork code, and this job has no install, build or test step: Codecov's CLI and the Sonar scanner only read the tree.

Then close the two ways a fork could actually steer that job:

1. **Pin `sonar-project.properties` to the base repo.** After the checkout it is fork controlled, and the scanner honours what it finds, including `sonar.host.url`, which would redirect `SONAR_TOKEN` to an attacker. Fails loudly rather than scanning with the fork's version.
2. **Resolve the PR number from the API instead of `pr-number.txt`.** This was a pre-existing hole: a fork PR ships its own `tests.yml`, so the artifact's contents were attacker controlled input flowing into `$GITHUB_OUTPUT` (multi-line output injection) and on into the Sonar CLI `args`.

The lookup uses `pulls?head=owner:branch` against this repo, keyed off the trusted `workflow_run` payload. Two alternatives were tested and rejected:

- `workflow_run.pull_requests` is `[]` for forks (confirmed on run 31101360641).
- `commits/{sha}/pulls` on this repo returns nothing for a fork PR head. Using it would have silently disabled Sonar PR analysis on every fork PR.
- Querying the fork repo does work, but the fork is attacker controlled: they could open a PR inside their own fork and feed us its number and base ref.

Fork branches are also labelled `owner:branch` for Codecov so they do not register phantom branches here.

## Verification

Static analysis and live API probes only. The workflow itself has not executed, so the first fork PR after merge is the real test.

| Check | Result |
|---|---|
| actionlint, both files | clean |
| shellcheck (`-s bash`), both `run:` blocks | clean |
| `pulls?head=` for fork PR / same repo PR / no PR | `526 main` / `518 main` / empty, exit 0 |
| `github.sha` on a workflow_run equals main tip | confirmed on run 31101718891 |
| pre-commit (pint, phpstan, 1487 tests) | passed |

Untrusted values (`HEAD_BRANCH`, `HEAD_OWNER`) are passed via `env:`, never inline `${{ }}` in shell, so a hostile branch name cannot inject.

## Trade-offs worth a second opinion

- Fork code now sits in a job holding `SONAR_TOKEN` and `CODECOV_TOKEN`. Nothing executes it, but both tools *parse* attacker controlled files. That parse surface is not a regression: this job already ingested fork produced `coverage.xml` before this change.
- A fork supplied `codecov.yml` is accepted. It cannot redirect the upload or leak the token, only shape that commit's own report, and a fork already fully controls `coverage.xml`, so it grants no new capability. Pinning it was tried and dropped because distinguishing a 404 from a rate limit would have meant deleting a legitimate config on a transient error.
- `set -euo pipefail` means a transient GitHub API failure fails the whole job, including the Codecov upload, and `workflow_run` re-runs are manual. Deliberate (loud over silent), but easy to flip to graceful degradation.
- Fork coverage numbers remain self reported, since a fork controls both `tests.yml` and the resulting `coverage.xml`. Treat fork coverage deltas as advisory, not as a merge gate.

## Note on #526

This takes effect immediately on merge for existing fork PRs: `workflow_run` always uses the default branch's copy of the workflow, so no rebase is needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved pull request validation for changes submitted from forks, including more reliable branch and pull request detection.
  * Updated code coverage and quality analysis to use accurate pull request and target-branch information.
  * Removed obsolete pull request metadata from test coverage artifacts.
  * Improved consistency of automated checks for contributions originating outside the main repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->