### PR TITLE
feat(backup): default dump_privileges for new PostgreSQL servers via env

### DIFF
--- a/app/Livewire/DatabaseServer/Create.php
+++ b/app/Livewire/DatabaseServer/Create.php
@@ -22,6 +22,8 @@ class Create extends Component
     {
         $this->authorize('viewForm', DatabaseServer::class);
 
+        $this->form->dump_privileges = (bool) config('backup.default_dump_privileges');
+
         $dailyScheduleId = BackupSchedule::where('name', 'Daily')->value('id');
         $this->form->addBackup($dailyScheduleId);
     }

--- a/config/backup.php
+++ b/config/backup.php
@@ -15,4 +15,18 @@ return [
     */
 
     'encryption_key' => env('BACKUP_ENCRYPTION_KEY', env('APP_KEY')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default: Backup Ownership & Privilege Information (PostgreSQL)
+    |--------------------------------------------------------------------------
+    |
+    | Seeds the "Backup ownership and privilege information" checkbox when
+    | creating a new PostgreSQL server. Existing servers are never changed by
+    | this setting; it only affects the form default, which admins can still
+    | toggle per server.
+    |
+    */
+
+    'default_dump_privileges' => env('BACKUP_DEFAULT_DUMP_PRIVILEGES', false),
 ];

--- a/docs/docs/self-hosting/configuration/backup.md
+++ b/docs/docs/self-hosting/configuration/backup.md
@@ -26,6 +26,16 @@ echo "base64:$(openssl rand -base64 32)"
 If you change the encryption key, you will not be able to restore backups that were encrypted with the previous key. Keep your encryption key safe and backed up separately.
 :::
 
+## PostgreSQL Ownership & Privileges Default
+
+New PostgreSQL servers default to stripping `OWNER`/`GRANT`/`REVOKE` statements from dumps (`--no-owner --no-privileges`), toggled per server via **Backup ownership and privilege information** in the server form. To have new servers default to preserving that information instead (useful for declarative/Helm deployments where you don't want to click through the UI for every server):
+
+```bash
+BACKUP_DEFAULT_DUMP_PRIVILEGES=true
+```
+
+This only changes the form's default value for servers created afterward. It does not retroactively change existing servers, and admins can still override it per server.
+
 ## Hook Scripts
 
 Run a shell script after **every successful backup** and after **every successful restore**. Configure both from **Configuration → Backup → Hook Scripts** in the web UI — that screen also lists every variable available to each script.

--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -71,15 +71,34 @@ test('can create database server', function (array $config) {
     ]);
 })->with('database server configs');
 
-test('dump_privileges defaults from config for new postgresql servers', function () {
-    config(['backup.default_dump_privileges' => true]);
+test('dump_privileges defaults from config for new postgresql servers', function (bool $configured, bool $expected) {
+    config(['backup.default_dump_privileges' => $configured]);
 
     $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
 
     Livewire::actingAs($user)
         ->test(Create::class)
-        ->assertSet('form.dump_privileges', true);
-});
+        ->assertSet('form.dump_privileges', $expected)
+        ->set('form.name', 'Postgres Dump Privileges Server')
+        ->set('form.database_type', 'postgres')
+        ->set('form.host', 'postgres.example.com')
+        ->set('form.port', 5432)
+        ->set('form.username', 'dbuser')
+        ->set('form.password', 'secret123')
+        ->set('form.backups.0.database_names.0', 'myapp_production')
+        ->set('form.backups.0.volume_ids', [$volume->id])
+        ->set('form.backups.0.backup_schedule_id', dailySchedule()->id)
+        ->call('save')
+        ->assertRedirect(route('database-servers.index'));
+
+    $server = DatabaseServer::where('name', 'Postgres Dump Privileges Server')->first();
+
+    expect($server->getExtraConfig('dump_privileges', false))->toBe($expected);
+})->with([
+    'configured true' => [true, true],
+    'configured false (default)' => [false, false],
+]);
 
 test('can create database server with backups disabled', function () {
     // Acts as the allow case for manage-database-servers: a user whose only

--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -71,6 +71,16 @@ test('can create database server', function (array $config) {
     ]);
 })->with('database server configs');
 
+test('dump_privileges defaults from config for new postgresql servers', function () {
+    config(['backup.default_dump_privileges' => true]);
+
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->assertSet('form.dump_privileges', true);
+});
+
 test('can create database server with backups disabled', function () {
     // Acts as the allow case for manage-database-servers: a user whose only
     // grant is that ability can complete a create end-to-end.


### PR DESCRIPTION
## Summary
- Adds `BACKUP_DEFAULT_DUMP_PRIVILEGES` env var (`config/backup.php`) to seed the "Backup ownership and privilege information" checkbox for new PostgreSQL servers, useful for declarative/Helm deployments that don't want to configure this per server through the UI.
- Only affects the create form's default value; existing servers are never changed, and admins can still toggle it per server.
- Documents the env var in `docs/.../configuration/backup.md`.

Addresses the first ask in #525 ("Allow configuring this option from Helm values").

The second ask in that issue (explicit control over database-level ownership reassignment during restore) already exists today via the restore wizard's "owner user" field (`ALTER DATABASE ... OWNER TO` + `REASSIGN OWNED BY` in `PostgresqlDatabase::transferOwnership()`), independent of `dump_privileges`. Leaving that as-is here.

## Test plan
- [x] `make test-filter FILTER=CreateTest` (42 passed, including a new test asserting the config value flows into `form.dump_privileges`)
- [x] `make phpstan`
- [x] `make lint-fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable default for including PostgreSQL ownership and privilege statements in backups.
  * The option is disabled by default and can be enabled for new servers with `BACKUP_DEFAULT_DUMP_PRIVILEGES=true`.
  * The setting applies only to newly created servers and can be overridden individually.

* **Documentation**
  * Documented the new backup configuration option, default behavior, and per-server override.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->