### PR TITLE
Fix job log stuck showing Running after the job fails

### DIFF
--- a/app/Models/BackupJob.php
+++ b/app/Models/BackupJob.php
@@ -155,7 +155,30 @@ class BackupJob extends Model implements BackupLogger
             'duration_ms' => $this->calculateDuration(),
             'error_message' => $exception->getMessage(),
             'error_trace' => $exception->getTraceAsString(),
+            'logs' => $this->logsWithDanglingRunningMarkedFailed(),
         ]);
+    }
+
+    /**
+     * A command log entry can be left at `status: 'running'` if the job dies
+     * between `startCommandLog()` and `ShellProcessor`'s finalize step (queue
+     * timeout, worker kill, uncaught fatal error). Without this, the log-modal
+     * UI keeps showing a "Running" spinner on that command forever, even
+     * though the job itself is already marked failed.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function logsWithDanglingRunningMarkedFailed(): array
+    {
+        $logs = $this->logs ?? [];
+
+        foreach ($logs as $index => $entry) {
+            if (($entry['status'] ?? null) === 'running') {
+                $logs[$index]['status'] = 'failed';
+            }
+        }
+
+        return $logs;
     }
 
     /**

--- a/tests/Feature/Models/BackupJobTest.php
+++ b/tests/Feature/Models/BackupJobTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\BackupJob;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('markFailed finalizes a command log left dangling at running status', function () {
+    $job = BackupJob::create(['status' => 'running']);
+
+    $index = $job->startCommandLog('pg_dump ...');
+    expect($job->getLogs()[$index]['status'])->toBe('running');
+
+    $job->markFailed(new Exception('worker was killed mid-command'));
+
+    $job->refresh();
+
+    expect($job->status->value)->toBe('failed')
+        ->and($job->getLogs()[$index]['status'])->toBe('failed');
+});
+
+test('markFailed leaves already-finalized command logs untouched', function () {
+    $job = BackupJob::create(['status' => 'running']);
+
+    $index = $job->startCommandLog('mysqldump ...');
+    $job->updateCommandLog($index, ['status' => 'completed', 'exit_code' => 0]);
+
+    $job->markFailed(new Exception('a later step failed'));
+
+    $job->refresh();
+
+    expect($job->getLogs()[$index]['status'])->toBe('completed');
+});


### PR DESCRIPTION
## Summary
- A command log entry started via `startCommandLog()` stays at `status: 'running'` if the job dies before `ShellProcessor`'s finalize step runs (queue timeout, worker kill, uncaught fatal error). The job itself gets marked Failed, but the last command row in the logs modal keeps showing a Running spinner forever.
- `BackupJob::markFailed()` now reconciles any log entry still at `'running'` to `'failed'` before saving, so the UI reflects the job's real state.

## Test plan
- [x] Added `tests/Feature/Models/BackupJobTest.php` covering: a dangling running log gets finalized to failed, and an already-finalized log (completed) is left untouched.
- [x] `make phpstan` clean
- [x] `make lint-fix` clean

Fixes #520

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed backup jobs now correctly mark any unfinished command log entries as failed.
  - Completed command log entries remain unchanged when a backup job fails.
  - Missing command logs are handled safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->