### PR TITLE
Add a free-text note to snapshots

### DIFF
--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -57,6 +57,13 @@ class Index extends Component
 
     public bool $showDownloadModal = false;
 
+    #[Locked]
+    public ?string $noteSnapshotId = null;
+
+    public string $noteInput = '';
+
+    public bool $showNoteModal = false;
+
     /**
      * @return array<int, array<string, mixed>>
      */
@@ -151,6 +158,37 @@ class Index extends Component
         }
 
         return Snapshot::with('files.volume')->find($this->downloadSnapshotId);
+    }
+
+    public function openNoteModal(string $snapshotId): void
+    {
+        $snapshot = Snapshot::findOrFail($snapshotId);
+
+        $this->authorize('update', $snapshot);
+
+        $this->noteSnapshotId = $snapshotId;
+        $this->noteInput = $snapshot->note ?? '';
+        $this->showNoteModal = true;
+    }
+
+    public function saveNote(): void
+    {
+        if (! $this->noteSnapshotId) {
+            return;
+        }
+
+        $snapshot = Snapshot::findOrFail($this->noteSnapshotId);
+
+        $this->authorize('update', $snapshot);
+
+        $this->validate(['noteInput' => ['nullable', 'string', 'max:2000']]);
+
+        $snapshot->update(['note' => $this->noteInput !== '' ? $this->noteInput : null]);
+
+        $this->noteSnapshotId = null;
+        $this->showNoteModal = false;
+
+        $this->success(__('Note saved successfully!'));
     }
 
     public function confirmDeleteSnapshot(string $snapshotId): void

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -37,6 +37,7 @@ class Snapshot extends Model
         'filename',
         'file_size',
         'checksum',
+        'note',
         'started_at',
         'database_name',
         'database_type',

--- a/app/Policies/SnapshotPolicy.php
+++ b/app/Policies/SnapshotPolicy.php
@@ -36,6 +36,16 @@ class SnapshotPolicy
     }
 
     /**
+     * Determine whether the user can edit the snapshot's note.
+     * Reuses the delete-snapshots ability: editing a note is snapshot
+     * housekeeping, the same trust level as removing the snapshot outright.
+     */
+    public function update(User $user, Snapshot $snapshot): bool
+    {
+        return $user->can(Ability::DeleteSnapshots->value);
+    }
+
+    /**
      * Determine whether the user can download the snapshot.
      * Requires the download-snapshots ability.
      */

--- a/database/migrations/2026_08_17_045835_add_note_to_snapshots_table.php
+++ b/database/migrations/2026_08_17_045835_add_note_to_snapshots_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->text('note')->nullable()->after('checksum');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->dropColumn('note');
+        });
+    }
+};

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -59,6 +59,19 @@
                                     <x-snapshot-volume-badge :file="$file" />
                                 @endif
                             @endforeach
+                            @can('update', $snapshot)
+                                <button
+                                    type="button"
+                                    wire:click="openNoteModal('{{ $snapshot->id }}')"
+                                    class="inline-flex items-center gap-1 text-xs {{ $snapshot->note ? 'text-base-content/70' : 'text-base-content/40' }} hover:text-primary"
+                                    title="{{ $snapshot->note ?: __('Add a note') }}"
+                                >
+                                    <x-icon name="o-pencil-square" class="w-3.5 h-3.5" />
+                                    @if($snapshot->note)
+                                        <span class="truncate max-w-40">{{ $snapshot->note }}</span>
+                                    @endif
+                                </button>
+                            @endcan
                             @if($fileMissing)
                                 <x-popover>
                                     <x-slot:trigger>
@@ -244,6 +257,20 @@
 
         <x-slot:actions>
             <x-button :label="__('Close')" @click="$wire.showDownloadModal = false" />
+        </x-slot:actions>
+    </x-modal>
+
+    <x-modal wire:model="showNoteModal" :title="__('Snapshot Note')" class="backdrop-blur">
+        <x-textarea
+            wire:model="noteInput"
+            :label="__('Note')"
+            :placeholder="__('e.g. Backup taken before the v1.37 upgrade')"
+            rows="3"
+        />
+
+        <x-slot:actions>
+            <x-button :label="__('Cancel')" @click="$wire.showNoteModal = false" />
+            <x-button :label="__('Save')" wire:click="saveNote" class="btn-primary" spinner="saveNote" />
         </x-slot:actions>
     </x-modal>
 

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -309,3 +309,48 @@ test('?job= from another org is forbidden when the user is not a member', functi
         ->test(Index::class)
         ->assertForbidden();
 });
+
+test('can add a note to a snapshot', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+
+    Livewire::test(Index::class)
+        ->call('openNoteModal', $snapshot->id)
+        ->assertSet('showNoteModal', true)
+        ->assertSet('noteSnapshotId', $snapshot->id)
+        ->set('noteInput', 'Backup vaultwarden version 1.37')
+        ->call('saveNote')
+        ->assertSet('showNoteModal', false);
+
+    expect($snapshot->fresh()->note)->toBe('Backup vaultwarden version 1.37');
+});
+
+test('opening the note modal prefills the existing note', function () {
+    $snapshot = Snapshot::factory()->withFile()->create(['note' => 'Existing note']);
+
+    Livewire::test(Index::class)
+        ->call('openNoteModal', $snapshot->id)
+        ->assertSet('noteInput', 'Existing note');
+});
+
+test('saving a blank note clears it', function () {
+    $snapshot = Snapshot::factory()->withFile()->create(['note' => 'Existing note']);
+
+    Livewire::test(Index::class)
+        ->call('openNoteModal', $snapshot->id)
+        ->set('noteInput', '')
+        ->call('saveNote');
+
+    expect($snapshot->fresh()->note)->toBeNull();
+});
+
+test('without delete-snapshots, editing a note is forbidden', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+
+    actingAs(User::factory()->withAbilities([])->create());
+
+    Livewire::test(Index::class)
+        ->call('openNoteModal', $snapshot->id)
+        ->assertForbidden();
+
+    expect($snapshot->fresh()->note)->toBeNull();
+});


### PR DESCRIPTION
## Summary
- Adds a nullable `note` column to `snapshots`, editable from the Snapshots list via a small pencil icon next to each row (shown truncated when set).
- Lets a user attach a short note to a snapshot, e.g. "Backup vaultwarden version 1.37", so it's easier to tell which snapshot to restore without cross-referencing timestamps.
- Editing is gated behind the `delete-snapshots` ability (`SnapshotPolicy::update`), the same trust level as removing a snapshot outright.

## Test plan
- [x] Added tests in `tests/Feature/Livewire/Snapshot/IndexTest.php`: adding a note, prefilling the modal with an existing note, clearing a note by saving blank, and the without-ability forbidden case.
- [x] `make phpstan` clean
- [x] `make lint-fix` clean

Fixes #480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to view, add, edit, and clear notes on snapshots.
  * Notes can be edited through a modal and support up to 2,000 characters.
  * Added success feedback after saving notes.

* **Bug Fixes**
  * Restricted note editing to authorized users.

* **Tests**
  * Added coverage for creating, editing, clearing, and permission-restricted snapshot notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->