### PR TITLE
Add optional PostgreSQL client binary directory config

### DIFF
--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -73,6 +73,20 @@ class PostgresqlDatabase implements DatabaseInterface
         return ! empty($this->config['ssl_enabled']) ? 'PGSSLMODE=require ' : '';
     }
 
+    /**
+     * Resolve a PostgreSQL client tool (psql, pg_dump, pg_restore) to an
+     * invocable command name. Bare by default (relies on $PATH); prefixed
+     * with `backup.postgresql_client_bin_dir` when configured, so hosts with
+     * several PostgreSQL client versions installed can pin an unambiguous
+     * absolute path instead of relying on the tool to locate itself via $PATH.
+     */
+    private function binary(string $name): string
+    {
+        $binDir = config('backup.postgresql_client_bin_dir');
+
+        return $binDir ? rtrim((string) $binDir, '/').'/'.$name : $name;
+    }
+
     public function dump(string $outputPath): DatabaseOperationResult
     {
         $options = $this->withPrivilegeOptions(self::DUMP_OPTIONS);
@@ -87,9 +101,10 @@ class PostgresqlDatabase implements DatabaseInterface
 
         // Flags must come before the database name (last positional argument)
         $command = sprintf(
-            '%sPGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s%s %s',
+            '%sPGPASSWORD=%s %s %s --host=%s --port=%s --username=%s%s %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
+            $this->binary('pg_dump'),
             implode(' ', $options),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
@@ -107,9 +122,10 @@ class PostgresqlDatabase implements DatabaseInterface
     {
         if (($this->config['dump_format'] ?? 'plain') === 'custom') {
             return new DatabaseOperationResult(command: sprintf(
-                '%sPGPASSWORD=%s pg_restore %s --host=%s --port=%s --username=%s --dbname=%s %s',
+                '%sPGPASSWORD=%s %s %s --host=%s --port=%s --username=%s --dbname=%s %s',
                 $this->sslEnvPrefix(),
                 escapeshellarg($this->config['pass']),
+                $this->binary('pg_restore'),
                 implode(' ', $this->withPrivilegeOptions(self::RESTORE_CUSTOM_FORMAT_OPTIONS)),
                 escapeshellarg($this->config['host']),
                 escapeshellarg((string) $this->config['port']),
@@ -120,9 +136,10 @@ class PostgresqlDatabase implements DatabaseInterface
         }
 
         return new DatabaseOperationResult(command: sprintf(
-            '%sPGPASSWORD=%s psql --host=%s --port=%s --username=%s %s -f %s',
+            '%sPGPASSWORD=%s %s --host=%s --port=%s --username=%s %s -f %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
+            $this->binary('psql'),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
             escapeshellarg($this->config['user']),
@@ -307,9 +324,10 @@ class PostgresqlDatabase implements DatabaseInterface
     private function getQueryCommand(string $query): string
     {
         return sprintf(
-            '%sPGPASSWORD=%s psql --host=%s --port=%s --user=%s %s -t -c %s',
+            '%sPGPASSWORD=%s %s --host=%s --port=%s --user=%s %s -t -c %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
+            $this->binary('psql'),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
             escapeshellarg($this->config['user']),

--- a/config/backup.php
+++ b/config/backup.php
@@ -15,4 +15,22 @@ return [
     */
 
     'encryption_key' => env('BACKUP_ENCRYPTION_KEY', env('APP_KEY')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | PostgreSQL Client Binary Directory
+    |--------------------------------------------------------------------------
+    |
+    | Optional absolute path to the directory containing psql/pg_dump/pg_restore.
+    | Leave unset to invoke them by bare name and rely on $PATH (the default).
+    |
+    | On hosts with several PostgreSQL client versions installed side by side
+    | (e.g. native installs from the PGDG yum/apt repos), psql can intermittently
+    | fail with "could not find own program executable" while resolving itself
+    | via $PATH. Pinning an explicit directory here makes every invocation use
+    | one unambiguous absolute path instead.
+    |
+    */
+
+    'postgresql_client_bin_dir' => env('POSTGRES_CLIENT_BIN_DIR'),
 ];

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -237,6 +237,60 @@ test('testConnection returns success with version and SSL info', function () {
         ->and($result['details']['output'])->toContain('PostgreSQL 16.2');
 });
 
+test('dump uses bare pg_dump by default', function () {
+    expect($this->db->dump('/tmp/dump.sql')->command)->toContain(' pg_dump ');
+});
+
+test('dump uses the configured client bin dir when set', function () {
+    config(['backup.postgresql_client_bin_dir' => '/usr/pgsql-18/bin']);
+
+    expect($this->db->dump('/tmp/dump.sql')->command)->toContain(' /usr/pgsql-18/bin/pg_dump ')
+        ->and($this->db->dump('/tmp/dump.sql')->command)->not->toContain(' pg_dump ');
+});
+
+test('restore uses the configured client bin dir for psql when set', function () {
+    config(['backup.postgresql_client_bin_dir' => '/usr/pgsql-18/bin']);
+
+    expect($this->db->restore('/tmp/restore.sql')->command)->toContain(' /usr/pgsql-18/bin/psql ');
+});
+
+test('restore uses the configured client bin dir for pg_restore when set', function () {
+    config(['backup.postgresql_client_bin_dir' => '/usr/pgsql-18/bin']);
+
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'dump_format' => 'custom',
+    ]);
+
+    expect($db->restore('/tmp/snapshot.sql')->command)->toContain(' /usr/pgsql-18/bin/pg_restore ');
+});
+
+test('a trailing slash on the configured bin dir does not produce a double slash', function () {
+    config(['backup.postgresql_client_bin_dir' => '/usr/pgsql-18/bin/']);
+
+    expect($this->db->dump('/tmp/dump.sql')->command)->toContain(' /usr/pgsql-18/bin/pg_dump ')
+        ->and($this->db->dump('/tmp/dump.sql')->command)->not->toContain('bin//pg_dump');
+});
+
+test('testConnection query command uses the configured client bin dir for psql when set', function () {
+    config(['backup.postgresql_client_bin_dir' => '/usr/pgsql-18/bin']);
+
+    Process::preventStrayProcesses();
+    Process::fake([
+        '*version*' => Process::result(output: 'PostgreSQL 16.2'),
+        '*ssl*' => Process::result(output: 'yes'),
+    ]);
+
+    $this->db->testConnection();
+
+    Process::assertRan(fn ($process) => str_contains($process->command, '/usr/pgsql-18/bin/psql'));
+});
+
 test('testConnection returns failure when process fails', function () {
     Process::fake([
         '*' => Process::result(exitCode: 1, errorOutput: 'connection refused'),


### PR DESCRIPTION
## Summary
- Addresses reports of `psql` intermittently failing with `could not find a "psql" to execute ... psql: error: could not find own program executable` on native (non-Docker) hosts with several PostgreSQL client versions installed side by side (e.g. PGDG yum/apt repos). `psql`/`pg_dump`/`pg_restore` resolve their own executable via `$PATH` at startup (`find_my_exec`), which is the fragile branch involved in this class of error.
- Adds an optional `POSTGRES_CLIENT_BIN_DIR` env var (`config/backup.php`, `backup.postgresql_client_bin_dir`). When set, every `psql`/`pg_dump`/`pg_restore` invocation uses that absolute path directly instead of relying on `$PATH` self-resolution.
- Unset (the default) keeps current behavior exactly — bare command names, relying on `$PATH` as today.

## Test plan
- [x] Added tests in `tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php` covering: default bare-name behavior, dump/restore/pg_restore/testConnection all honoring the configured bin dir, and no double-slash when the configured path has a trailing slash.
- [x] All pre-existing command-string assertion tests still pass unchanged (config defaults to null).
- [x] `make phpstan` clean
- [x] `make lint-fix` clean

Fixes #535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional configuration setting to specify the directory containing PostgreSQL client tools.
  * Backup, restore, and connection checks can now use explicitly configured PostgreSQL binaries.

* **Documentation**
  * Documented default PATH-based behavior and explicit binary directory configuration.

* **Bug Fixes**
  * Improved support for PostgreSQL installations where client tools are not available in the default PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->