### PR TITLE
feat(backup): add per-server excluded tables list

### DIFF
--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -8,6 +8,7 @@ use App\Enums\VolumeType;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\Volume;
+use App\Rules\ExcludedTableNames;
 use App\Rules\SafeDatabasePath;
 use App\Rules\SafeHost;
 use App\Rules\SafePath;
@@ -71,6 +72,8 @@ class SaveDatabaseServerRequest extends FormRequest
             $rules['username'] = 'required|string|max:255';
             $rules['password'] = 'nullable';
             $rules['dump_flags'] = ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'];
+            $rules['excluded_tables'] = ['nullable', 'array', 'max:'.ExcludedTableNames::MAX_NAMES];
+            $rules['excluded_tables.*'] = ['string', 'max:'.ExcludedTableNames::MAX_NAME_LENGTH, 'regex:'.ExcludedTableNames::PATTERN];
         }
 
         if ($type === 'postgres') {

--- a/app/Livewire/DatabaseServer/Form.php
+++ b/app/Livewire/DatabaseServer/Form.php
@@ -13,6 +13,7 @@ use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
 use App\Models\NotificationChannel;
+use App\Rules\ExcludedTableNames;
 use App\Services\Backup\Databases\DatabaseProvider;
 use App\Services\Backup\ShellProcessor;
 use App\Services\Backup\SyncBackupConfigurationsAction;
@@ -54,6 +55,12 @@ class Form extends \Livewire\Form
     public string $connection_options = '';
 
     public string $dump_flags = '';
+
+    /**
+     * Table names excluded from every database dumped for this server,
+     * comma- or newline-separated. Stored in extra_config as a list.
+     */
+    public string $excluded_tables = '';
 
     public string $dump_format = 'plain';
 
@@ -458,9 +465,10 @@ class Form extends \Livewire\Form
         $this->srv_enabled = (bool) $server->getExtraConfig('srv_enabled', false);
         $this->connection_options = $server->getExtraConfig('connection_options', '');
         $this->dump_flags = $server->getExtraConfig('dump_flags', '');
+        $this->excluded_tables = implode(', ', DatabaseServer::parseExcludedTables($server->getExtraConfig('excluded_tables')));
         $this->dump_format = $server->getExtraConfig('dump_format', 'plain');
         $this->dump_privileges = (bool) $server->getExtraConfig('dump_privileges', false);
-        $this->dump_config_open = ! empty($this->dump_flags) || $this->dump_format === 'custom' || $this->dump_privileges;
+        $this->dump_config_open = ! empty($this->dump_flags) || ! empty($this->excluded_tables) || $this->dump_format === 'custom' || $this->dump_privileges;
         $this->ssl_enabled = (bool) $server->getExtraConfig('ssl_enabled', false);
         $this->username = $server->username ?? '';
         $this->description = $server->description;
@@ -680,6 +688,14 @@ class Form extends \Livewire\Form
     }
 
     /**
+     * Check if current database type supports excluding individual tables.
+     */
+    public function supportsExcludedTables(): bool
+    {
+        return DatabaseServer::supportsExcludedTables($this->database_type);
+    }
+
+    /**
      * Get a preview of the dump command for the current database type.
      */
     public function getDumpCommandPreview(): string
@@ -694,6 +710,7 @@ class Form extends \Livewire\Form
             'port' => $type->defaultPort(),
             'database' => 'dbname',
             'dump_flags' => $this->dump_flags,
+            'excluded_tables' => $this->supportsExcludedTables() ? DatabaseServer::parseExcludedTables($this->excluded_tables) : [],
             'user' => 'user',
             'pass' => '********',
         ];
@@ -885,6 +902,7 @@ class Form extends \Livewire\Form
             'agent_id' => ['nullable', Rule::exists('agents', 'id')->where('organization_id', app(CurrentOrganization::class)->id())],
             'backups_enabled' => 'boolean',
             'dump_flags' => ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'],
+            'excluded_tables' => ['nullable', 'string', new ExcludedTableNames],
             'dump_format' => ['nullable', 'string', Rule::in(['plain', 'custom'])],
             'dump_privileges' => 'boolean',
             'ssl_enabled' => 'boolean',

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -351,7 +351,7 @@ class DatabaseServer extends Model
 
     /**
      * Move type-specific fields (auth_source, srv_enabled, connection_options,
-     * dump_flags, ssl_enabled) into extra_config.
+     * dump_flags, excluded_tables, ssl_enabled) into extra_config.
      * Clears stale keys when database type has changed.
      *
      * @param  array<string, mixed>  $data
@@ -372,6 +372,7 @@ class DatabaseServer extends Model
             ['srv_enabled',         fn ($v) => $type === DatabaseType::MONGODB->value && $v,                       fn () => true],
             ['connection_options',  fn ($v) => $type === DatabaseType::MONGODB->value && $v !== '' && $v !== null, fn ($v) => $v],
             ['dump_flags',          fn ($v) => $type !== DatabaseType::SQLITE->value && $v !== '' && $v !== null,  fn ($v) => $v],
+            ['excluded_tables',     fn ($v) => self::supportsExcludedTables($type) && self::parseExcludedTables($v) !== [], fn ($v) => self::parseExcludedTables($v)],
             ['dump_format',         fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v === 'custom',       fn () => 'custom'],
             ['dump_privileges',     fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v,                    fn () => true],
             ['ssl_enabled',         fn ($v) => in_array($type, [DatabaseType::MYSQL->value, DatabaseType::POSTGRESQL->value], true) && $v, fn () => true],
@@ -411,6 +412,42 @@ class DatabaseServer extends Model
         } else {
             unset($extraConfig[$key]);
         }
+    }
+
+    /**
+     * Whether a database type can exclude individual tables from its dump.
+     *
+     * Only the two table-based SQL types have a per-table exclusion flag:
+     * `mariadb-dump --ignore-table` and `pg_dump --exclude-table`.
+     */
+    public static function supportsExcludedTables(?string $type): bool
+    {
+        return in_array($type, [DatabaseType::MYSQL->value, DatabaseType::POSTGRESQL->value], true);
+    }
+
+    /**
+     * Normalize excluded table names into a clean list.
+     *
+     * Accepts the UI's comma- or newline-separated textarea string as well as
+     * an already-structured array (REST API, or a value round-tripped out of
+     * extra_config). Blank entries and duplicates are dropped; names are not
+     * validated here — see {@see \App\Rules\ExcludedTableNames}.
+     *
+     * @return list<string>
+     */
+    public static function parseExcludedTables(mixed $value): array
+    {
+        if (is_string($value)) {
+            $value = preg_split('/[,\r\n]+/', $value) ?: [];
+        }
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $names = array_map(trim(...), array_filter($value, is_string(...)));
+
+        return array_values(array_unique(array_filter($names, fn (string $name): bool => $name !== '')));
     }
 
     /**

--- a/app/Rules/ExcludedTableNames.php
+++ b/app/Rules/ExcludedTableNames.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\DatabaseServer;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Table names excluded from a dump are interpolated into `--ignore-table=` /
+ * `--exclude-table=` flags. They are escaped before reaching the shell, but a
+ * name carrying a dot, a space or a quote would still change which object the
+ * dump tool matches, so restrict them to unquoted SQL identifier characters.
+ *
+ * Validates the raw textarea string the UI submits, comma- or newline-
+ * separated. The REST API takes a JSON array instead and applies the same
+ * limits through the constants below.
+ */
+readonly class ExcludedTableNames implements ValidationRule
+{
+    /** Unquoted MySQL/PostgreSQL identifier characters. */
+    public const PATTERN = '/\A[A-Za-z0-9_$]+\z/';
+
+    public const MAX_NAME_LENGTH = 64;
+
+    public const MAX_NAMES = 200;
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        // Anything but a non-empty string is already covered by the
+        // accompanying nullable/string rules.
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        $names = DatabaseServer::parseExcludedTables($value);
+
+        if (count($names) > self::MAX_NAMES) {
+            $fail(__('The :attribute may not have more than :max table names.', ['max' => self::MAX_NAMES]));
+
+            return;
+        }
+
+        foreach ($names as $name) {
+            if (mb_strlen($name) > self::MAX_NAME_LENGTH) {
+                $fail(__('The table name :name may not be greater than :max characters.', ['name' => $name, 'max' => self::MAX_NAME_LENGTH]));
+
+                return;
+            }
+
+            if (preg_match(self::PATTERN, $name) !== 1) {
+                $fail(__('The table name :name may only contain letters, numbers, underscores and dollar signs.', ['name' => $name]));
+
+                return;
+            }
+        }
+    }
+}

--- a/app/Services/Backup/DTO/DatabaseOperationResult.php
+++ b/app/Services/Backup/DTO/DatabaseOperationResult.php
@@ -19,4 +19,27 @@ readonly class DatabaseOperationResult
 
         return implode(' ', array_map('escapeshellarg', $tokens));
     }
+
+    /**
+     * Expand excluded table names into one repeated CLI flag per table, each
+     * escaped and prefixed with a space so the result can be concatenated onto
+     * an existing flag string.
+     *
+     * The qualifier prefixes every name, letting MySQL scope the exclusion to
+     * the schema being dumped (`--ignore-table=mydb.logs`) while PostgreSQL
+     * leaves it empty so the pattern matches the table in any schema.
+     *
+     * @param  mixed  $tables  Raw extra_config value; anything but a list of strings yields ''.
+     */
+    public static function escapeTableExclusions(string $flag, mixed $tables, string $qualifier = ''): string
+    {
+        if (! is_array($tables)) {
+            return '';
+        }
+
+        return implode('', array_map(
+            fn (string $table): string => ' '.escapeshellarg($flag.'='.$qualifier.$table),
+            array_filter($tables, is_string(...)),
+        ));
+    }
 }

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -107,6 +107,10 @@ class DatabaseProvider
             $dbConfig['dump_flags'] = $extra['dump_flags'];
         }
 
+        if (! empty($extra['excluded_tables'])) {
+            $dbConfig['excluded_tables'] = $extra['excluded_tables'];
+        }
+
         if (in_array($config->databaseType, [DatabaseType::MYSQL, DatabaseType::POSTGRESQL], true) && ! empty($extra['ssl_enabled'])) {
             $dbConfig['ssl_enabled'] = true;
         }

--- a/app/Services/Backup/Databases/MysqlDatabase.php
+++ b/app/Services/Backup/Databases/MysqlDatabase.php
@@ -83,6 +83,14 @@ class MysqlDatabase implements DatabaseInterface
             $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
         }
 
+        // mariadb-dump qualifies --ignore-table by schema, so the names are
+        // expanded against whichever database this dump targets.
+        $extraFlags .= DatabaseOperationResult::escapeTableExclusions(
+            '--ignore-table',
+            $this->config['excluded_tables'] ?? null,
+            $this->config['database'].'.',
+        );
+
         // Flags must come before the database name; mariadb-dump treats anything after it as table names
         $command = sprintf(
             '%s %s --host=%s --port=%s --user=%s --password=%s%s %s',

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -85,6 +85,13 @@ class PostgresqlDatabase implements DatabaseInterface
             $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
         }
 
+        // Unqualified --exclude-table patterns match the table in every schema
+        // of the database being dumped.
+        $extraFlags .= DatabaseOperationResult::escapeTableExclusions(
+            '--exclude-table',
+            $this->config['excluded_tables'] ?? null,
+        );
+
         // Flags must come before the database name (last positional argument)
         $command = sprintf(
             '%sPGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s%s %s',

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -214,6 +214,36 @@ GRANT RDB$ADMIN TO databasement;
 Restore is performed with `gbak -rep`, which writes a fresh `.fdb` at the target path and replaces an existing file at that path if one is present. The user supplies the destination path during restore.
 :::
 
+## Dump Command Configuration
+
+Every server form has a **Dump Command Configuration** section that tunes the command Databasement runs to produce the dump. A live **Command preview** below the fields shows exactly what will be executed. The section is unavailable for SQLite, which is copied as a file rather than dumped.
+
+### Extra Dump Flags
+
+Free-form flags appended to the dump command, for example `--no-tablespaces --column-statistics=0`. Each whitespace-separated token is passed to the dump tool as a single argument.
+
+### Excluded Tables
+
+Tables listed here are left out of every database backed up for this server. Enter **table names only, without a schema prefix**, separated by commas or new lines:
+
+```text
+web_api_log, web_service_log
+audit_log
+```
+
+Databasement expands the list per dump, so one entry covers every database on the server:
+
+- **MySQL / MariaDB** — each database is dumped separately, so the names are qualified with the database being dumped: dumping `datasoft` adds `--ignore-table=datasoft.web_api_log --ignore-table=datasoft.web_service_log`, and dumping `red` adds the same flags with the `red.` prefix. This avoids having to maintain one flag per schema-table pair by hand, and it keeps working when a new database appears on the server.
+- **PostgreSQL** — the names are passed unqualified as `--exclude-table=web_api_log`, which matches the table in every schema of the database being dumped.
+
+Names must be plain identifiers (letters, digits, `_` and `$`, up to 64 characters), and at most 200 may be listed. Excluding a table that does not exist is harmless — both dump tools ignore unmatched names.
+
+:::warning Excluded tables are missing from the snapshot
+A restore recreates only what the dump contains. An excluded table is not dropped on the restore target, but it is not restored either — if the target does not already have it, the table will be absent after the restore.
+:::
+
+Excluded Tables is available for **MySQL / MariaDB** and **PostgreSQL**; the other supported engines have no per-table exclusion in their dump tools.
+
 ## Browsing Data with Adminer
 
 Databasement can launch [Adminer](https://www.adminer.org/) directly against a registered server to inspect schema and run queries from the browser. Supported for **MySQL**, **PostgreSQL**, and **SQLite** servers that connect without an SSH tunnel.

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -153,6 +153,16 @@ use App\Enums\DatabaseType;
                                     type="text"
                                 />
 
+                                @if($form->supportsExcludedTables())
+                                    <x-textarea
+                                        wire:model.live.debounce.300ms="form.excluded_tables"
+                                        :placeholder="__('e.g., web_api_log, web_service_log')"
+                                        :hint="__('Table names without schema prefix, separated by commas or new lines. Applied to every database in this server’s backup.')"
+                                        :label="__('Excluded Tables')"
+                                        rows="3"
+                                    />
+                                @endif
+
                                 @php $dumpPreview = $form->getDumpCommandPreview() @endphp
                                 @if($dumpPreview)
                                     <x-badge :value="__('Command preview')" class="badge-primary"/>

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -5,6 +5,7 @@
         use App\Enums\NotificationChannelSelection;
         use App\Enums\NotificationTrigger;
         use App\Livewire\DatabaseServer\BackupForm;
+        use App\Models\DatabaseServer;
 
         $sshConfig = $server->sshConfig;
         $agent = $server->agent;
@@ -13,8 +14,9 @@
         $sslEnabled = (bool) $server->getExtraConfig('ssl_enabled', false);
         $authSource = $server->getExtraConfig('auth_source');
         $dumpFlags = $server->getExtraConfig('dump_flags');
+        $excludedTables = DatabaseServer::parseExcludedTables($server->getExtraConfig('excluded_tables'));
         $dumpFormat = $isPostgres ? ($server->getExtraConfig('dump_format', 'plain')) : null;
-        $showDumpCard = $dumpFlags || ($isPostgres && $dumpFormat === 'custom');
+        $showDumpCard = $dumpFlags || $excludedTables || ($isPostgres && $dumpFormat === 'custom');
 
         $trigger = $server->notification_trigger;
         $selection = $server->notification_channel_selection;
@@ -415,6 +417,19 @@
                                 <div class="min-w-0">
                                     <div class="text-xs uppercase font-semibold opacity-60">{{ __('Extra flags') }}</div>
                                     <code class="mt-1 inline-block text-xs font-mono break-all px-1.5 py-0.5 rounded bg-base-200">{{ $dumpFlags }}</code>
+                                </div>
+                            </li>
+                        @endif
+                        @if($excludedTables)
+                            <li class="list-row">
+                                <x-icon name="o-no-symbol" class="w-4 h-4 opacity-60" />
+                                <div class="min-w-0">
+                                    <div class="text-xs uppercase font-semibold opacity-60">{{ __('Excluded Tables') }}</div>
+                                    <div class="mt-1 flex flex-wrap gap-1">
+                                        @foreach($excludedTables as $excludedTable)
+                                            <code class="text-xs font-mono break-all px-1.5 py-0.5 rounded bg-base-200">{{ $excludedTable }}</code>
+                                        @endforeach
+                                    </div>
                                 </div>
                             </li>
                         @endif

--- a/tests/Feature/Api/DatabaseServerCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerCrudApiTest.php
@@ -145,6 +145,39 @@ test('store moves auth_source and dump_flags to extra_config', function () {
         ->assertJsonPath('data.extra_config.dump_flags', '--single-transaction');
 });
 
+test('store moves excluded_tables to extra_config', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-servers', [
+            'name' => 'MySQL excluding logs',
+            'database_type' => 'mysql',
+            'host' => 'localhost',
+            'port' => 3306,
+            'username' => 'root',
+            'excluded_tables' => ['web_api_log', 'web_service_log'],
+            'backups_enabled' => false,
+        ])
+        ->assertCreated()
+        ->assertJsonPath('data.extra_config.excluded_tables', ['web_api_log', 'web_service_log']);
+});
+
+test('store rejects excluded table names that are not plain identifiers', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-servers', [
+            'name' => 'MySQL bad exclusions',
+            'database_type' => 'mysql',
+            'host' => 'localhost',
+            'port' => 3306,
+            'username' => 'root',
+            'excluded_tables' => ['logs; DROP TABLE users'],
+            'backups_enabled' => false,
+        ])
+        ->assertJsonValidationErrors('excluded_tables.0');
+});
+
 test('update preserves extra_config when keys are not sent', function () {
     $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
     $server = DatabaseServer::factory()->create([

--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -307,6 +307,64 @@ test('can create database server with dump flags', function () {
         ->toBe('--no-tablespaces --column-statistics=0');
 });
 
+test('can create database server with excluded tables', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.name', 'MySQL Excluding Logs')
+        ->set('form.database_type', 'mysql')
+        ->set('form.host', 'mysql.example.com')
+        ->set('form.port', 3306)
+        ->set('form.username', 'dbuser')
+        ->set('form.password', 'secret123')
+        ->set('form.excluded_tables', "web_api_log, web_service_log\naudit_log")
+        ->set('form.backups.0.database_names.0', 'myapp')
+        ->set('form.backups.0.volume_ids', [$volume->id])
+        ->set('form.backups.0.backup_schedule_id', dailySchedule()->id)
+        ->set('form.backups.0.retention_days', 14)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertRedirect(route('database-servers.index'));
+
+    $server = DatabaseServer::where('name', 'MySQL Excluding Logs')->first();
+
+    expect($server->getExtraConfig('excluded_tables'))
+        ->toBe(['web_api_log', 'web_service_log', 'audit_log']);
+});
+
+test('rejects excluded table names that are not plain identifiers', function (string $excluded) {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.name', 'MySQL Bad Exclusions')
+        ->set('form.database_type', 'mysql')
+        ->set('form.host', 'mysql.example.com')
+        ->set('form.port', 3306)
+        ->set('form.username', 'dbuser')
+        ->set('form.password', 'secret123')
+        ->set('form.excluded_tables', $excluded)
+        ->set('form.backups.0.database_names.0', 'myapp')
+        ->set('form.backups.0.volume_ids', [$volume->id])
+        ->set('form.backups.0.backup_schedule_id', dailySchedule()->id)
+        ->set('form.backups.0.retention_days', 14)
+        ->call('save')
+        ->assertHasErrors('form.excluded_tables');
+
+    expect(DatabaseServer::where('name', 'MySQL Bad Exclusions')->exists())->toBeFalse();
+})->with([
+    'space in name' => ['web api log'],
+    'statement terminator' => ['logs; DROP TABLE users'],
+    'sql comment' => ['logs --'],
+    'schema qualified' => ['datasoft.web_api_log'],
+    'shell substitution' => ['$(whoami)'],
+    'wildcard' => ['web_*'],
+    'over 64 characters' => ['a123456789012345678901234567890123456789012345678901234567890123456789'],
+]);
+
 test('can create mysql database server with ssl_enabled', function () {
     $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
     $volume = Volume::factory()->local()->create(['name' => 'Test Volume']);

--- a/tests/Feature/Models/DatabaseServerTest.php
+++ b/tests/Feature/Models/DatabaseServerTest.php
@@ -122,7 +122,7 @@ test('buildExtraConfig folds type-specific fields into extra_config', function (
     expect($data['extra_config'])->toEqual($expected);
 
     // Handled keys are always pulled out of $data.
-    foreach (['auth_source', 'dump_flags', 'dump_format', 'dump_privileges', 'ssl_enabled'] as $key) {
+    foreach (['auth_source', 'dump_flags', 'excluded_tables', 'dump_format', 'dump_privileges', 'ssl_enabled'] as $key) {
         expect($data)->not->toHaveKey($key);
     }
 })->with([
@@ -160,4 +160,30 @@ test('buildExtraConfig folds type-specific fields into extra_config', function (
     'clears stale config on type change when no replacement keys are provided' => [
         ['database_type' => 'mysql'], ['auth_source' => 'records'], 'mongodb', null,
     ],
+    'parses excluded_tables from the comma-separated form value' => [
+        ['database_type' => 'mysql', 'excluded_tables' => 'web_api_log, web_service_log'],
+        null, null, ['excluded_tables' => ['web_api_log', 'web_service_log']],
+    ],
+    'keeps excluded_tables already supplied as a list' => [
+        ['database_type' => 'postgres', 'excluded_tables' => ['audit_log']],
+        null, null, ['excluded_tables' => ['audit_log']],
+    ],
+    'drops excluded_tables for a type without per-table exclusion' => [
+        ['database_type' => 'mongodb', 'excluded_tables' => 'web_api_log'], null, null, null,
+    ],
+    'clears existing excluded_tables when the field is emptied' => [
+        ['database_type' => 'mysql', 'excluded_tables' => ''], ['excluded_tables' => ['audit_log']], null, null,
+    ],
+]);
+
+test('parseExcludedTables normalizes separators, blanks and duplicates', function (mixed $value, array $expected) {
+    expect(DatabaseServer::parseExcludedTables($value))->toBe($expected);
+})->with([
+    'comma separated' => ['web_api_log, web_service_log', ['web_api_log', 'web_service_log']],
+    'newline separated' => ["web_api_log\nweb_service_log", ['web_api_log', 'web_service_log']],
+    'mixed separators with blanks' => [" web_api_log ,,\r\n  web_service_log \n", ['web_api_log', 'web_service_log']],
+    'duplicates collapsed' => ['audit_log, audit_log', ['audit_log']],
+    'already a list' => [['audit_log'], ['audit_log']],
+    'empty string' => ['', []],
+    'null' => [null, []],
 ]);

--- a/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
@@ -141,6 +141,23 @@ test('makeFromConfig passes ssl_enabled from extra_config for mysql', function (
         ->not->toContain('--skip_ssl');
 });
 
+test('makeFromConfig expands excluded_tables from extra_config per dumped database', function (string $databaseName) {
+    $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
+        databaseType: DatabaseType::MYSQL,
+        serverName: 'MySQL Server',
+        host: 'db.example.com',
+        port: 3306,
+        username: 'root',
+        password: 'secret',
+        extraConfig: ['excluded_tables' => ['web_api_log', 'web_service_log']],
+    );
+
+    $database = (new DatabaseProvider)->makeFromConfig($config, $databaseName, 'db.example.com', 3306);
+
+    expect($database->dump('/tmp/test.sql')->command)
+        ->toContain("'--ignore-table={$databaseName}.web_api_log' '--ignore-table={$databaseName}.web_service_log'");
+})->with(['datasoft', 'red']);
+
 test('makeFromConfig passes ssl_enabled from extra_config for postgres', function () {
     $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
         databaseType: DatabaseType::POSTGRESQL,

--- a/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
@@ -58,6 +58,63 @@ test('dump includes extra dump flags', function () {
         ->and($result->command)->toEndWith("> '/tmp/dump.sql'");
 });
 
+/** The same excluded tables, dumped from two different schemas on one server. */
+function mysqlDatabaseExcluding(string $schema): MysqlDatabase
+{
+    $db = new MysqlDatabase;
+    $db->setConfig([
+        'host' => 'db.local',
+        'port' => 3306,
+        'user' => 'root',
+        'pass' => 'secret',
+        'database' => $schema,
+        'excluded_tables' => ['web_api_log', 'web_service_log'],
+    ]);
+
+    return $db;
+}
+
+test('dump qualifies excluded tables with the schema being dumped', function (string $schema) {
+    $result = mysqlDatabaseExcluding($schema)->dump('/tmp/dump.sql');
+
+    // One --ignore-table per table, prefixed with this dump's schema, before the database name
+    expect($result->command)->toContain("'--ignore-table={$schema}.web_api_log' '--ignore-table={$schema}.web_service_log' '{$schema}'")
+        ->and($result->command)->toEndWith("> '/tmp/dump.sql'");
+})->with(['datasoft', 'red']);
+
+test('dump combines excluded tables with extra dump flags', function () {
+    $db = new MysqlDatabase;
+    $db->setConfig([
+        'host' => 'db.local',
+        'port' => 3306,
+        'user' => 'root',
+        'pass' => 'secret',
+        'database' => 'myapp',
+        'dump_flags' => '--no-tablespaces',
+        'excluded_tables' => ['audit_log'],
+    ]);
+
+    expect($db->dump('/tmp/dump.sql')->command)
+        ->toContain("'--no-tablespaces' '--ignore-table=myapp.audit_log' 'myapp'");
+});
+
+test('dump adds no ignore-table flags when excluded tables are absent or empty', function (mixed $excluded) {
+    $db = new MysqlDatabase;
+    $db->setConfig(array_merge([
+        'host' => 'db.local',
+        'port' => 3306,
+        'user' => 'root',
+        'pass' => 'secret',
+        'database' => 'myapp',
+    ], $excluded === 'absent' ? [] : ['excluded_tables' => $excluded]));
+
+    expect($db->dump('/tmp/dump.sql')->command)->not->toContain('--ignore-table');
+})->with([
+    'absent' => 'absent',
+    'empty list' => [[]],
+    'null' => [null],
+]);
+
 /** A handler on a live server reporting $version, or an unreadable one for null. */
 function mysqlDatabaseReportingVersion(?string $version): MysqlDatabase
 {

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -40,6 +40,39 @@ test('dump includes extra dump flags', function () {
         ->and($result->command)->toEndWith("-f '/tmp/dump.sql'");
 });
 
+test('dump excludes tables from every schema of the dumped database', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+        'excluded_tables' => ['web_api_log', 'web_service_log'],
+    ]);
+
+    // Unqualified patterns match the table in any schema
+    expect($db->dump('/tmp/dump.sql')->command)
+        ->toContain("'--exclude-table=web_api_log' '--exclude-table=web_service_log' 'myapp'");
+});
+
+test('dump adds no exclude-table flags when excluded tables are absent or empty', function (mixed $excluded) {
+    $db = new PostgresqlDatabase;
+    $db->setConfig(array_merge([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'postgres',
+        'pass' => 'pg_secret',
+        'database' => 'myapp',
+    ], $excluded === 'absent' ? [] : ['excluded_tables' => $excluded]));
+
+    expect($db->dump('/tmp/dump.sql')->command)->not->toContain('--exclude-table');
+})->with([
+    'absent' => 'absent',
+    'empty list' => [[]],
+    'null' => [null],
+]);
+
 test('restore builds correct psql command', function () {
     $result = $this->db->restore('/tmp/restore.sql');
 


### PR DESCRIPTION
Excluding log tables from a dump previously meant writing one --ignore-table=schema.table flag per schema/table pair into Extra Dump Flags. On a server with many schemas that list runs into thousands of characters, exceeds the field's 500-character limit, and has to be rewritten by hand whenever a schema is added.

Excluded Tables takes bare table names and expands them per dump, so one entry covers every database on the server:

- MySQL/MariaDB dumps each database separately, so names are qualified with the database being dumped (--ignore-table=datasoft.web_api_log).
- PostgreSQL passes them unqualified (--exclude-table=web_api_log), which matches the table in every schema of the dumped database.

Stored in extra_config alongside dump_flags rather than in a dedicated column, so it reaches remote agents (their job payload carries extra_config only) and shares buildExtraConfig() with the REST API.

Names are restricted to unquoted identifier characters, which keeps them safe as command arguments on top of the existing escapeshellarg pass.

Verified locally: full test suite green (1520 tests, 4184 assertions), Pint clean, and `docker build` succeeds. PHPStan reports 5 errors, all of them pre-existing on `main` (in `ApiToken/Index.php` and `OrganizationMergeService.php`) and untouched by this change.

The new UI strings are left untranslated, matching the rest of the Dump Command Configuration panel, which has no locale entries today. Happy to add `el`/`es`/`fr`/`zh_TW` translations if you would prefer them in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added excluded-table configuration for MySQL, MariaDB, and PostgreSQL database backups.
  - Enter table names using commas or new lines; configured tables are omitted from backup dumps.
  - Displayed excluded tables in database server settings and dump configuration previews.

- **Bug Fixes**
  - Added validation to reject invalid table names, duplicates, excessive entries, and overly long names.
  - Ensured exclusions are safely applied to generated backup commands.

- **Documentation**
  - Documented supported database types, formatting rules, limits, and restore behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->