### PR TITLE
fix(backup): recognize all dump extensions when decompressing encrypted snapshots

### DIFF
--- a/app/Services/Backup/Compressors/EncryptedCompressor.php
+++ b/app/Services/Backup/Compressors/EncryptedCompressor.php
@@ -79,12 +79,14 @@ class EncryptedCompressor extends BaseCompressor
 
     public function getDecompressedPath(string $inputPath): string
     {
-        $targets = ['dump.sql', 'dump.db'];
+        // BackupTask always names the pre-compression dump file "dump.{extension}",
+        // where the extension varies by database type/format (DatabaseType::dumpExtension()).
+        // Matching the prefix avoids maintaining a list that drifts out of sync with that enum.
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($inputPath, \FilesystemIterator::SKIP_DOTS)
         );
         foreach ($iterator as $file) {
-            if ($file->isFile() && in_array($file->getFilename(), $targets, true)) {
+            if ($file->isFile() && str_starts_with($file->getFilename(), 'dump.')) {
                 return $file->getPathname();
             }
         }

--- a/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
+++ b/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
@@ -3,6 +3,7 @@
 use App\Enums\CompressionType;
 use App\Services\Backup\Compressors\CompressorFactory;
 use App\Services\Backup\Compressors\EncryptedCompressor;
+use App\Support\FilesystemSupport;
 use Tests\Support\TestShellProcessor;
 
 beforeEach(function () {
@@ -53,6 +54,37 @@ test('encrypted compressor executes compress and returns correct path', function
         ->and(file_exists($compressedPath))->toBeTrue();
 
     unlink($compressedPath);
+});
+
+test('encrypted compressor finds the decompressed dump regardless of extension', function (string $filename) {
+    $dir = sys_get_temp_dir().'/'.uniqid('encrypted_compressor_test_');
+    mkdir($dir);
+    file_put_contents($dir.'/'.$filename, 'dump contents');
+
+    $compressor = new EncryptedCompressor($this->shellProcessor, 6);
+
+    expect($compressor->getDecompressedPath($dir))->toBe($dir.'/'.$filename);
+
+    FilesystemSupport::cleanupDirectory($dir);
+})->with([
+    'plain SQL dump' => ['dump.sql'],
+    'SQLite dump' => ['dump.db'],
+    'PostgreSQL custom-format dump' => ['dump.dump'],
+    'MSSQL dump' => ['dump.dacpac'],
+    'Firebird dump' => ['dump.fbk'],
+    'MongoDB dump' => ['dump.archive'],
+]);
+
+test('encrypted compressor throws when no decompressed dump is found', function () {
+    $dir = sys_get_temp_dir().'/'.uniqid('encrypted_compressor_test_');
+    mkdir($dir);
+
+    $compressor = new EncryptedCompressor($this->shellProcessor, 6);
+
+    expect(fn () => $compressor->getDecompressedPath($dir))
+        ->toThrow(RuntimeException::class, 'Decompression failed: output file not found');
+
+    FilesystemSupport::cleanupDirectory($dir);
 });
 
 test('encrypted compressor removes stale archive before compressing', function () {


### PR DESCRIPTION
## Summary

- `EncryptedCompressor::getDecompressedPath()` only recognized `dump.sql` and `dump.db`, so restoring an encrypted PostgreSQL custom-format snapshot (`dump.dump`) failed with `Decompression failed: output file not found` before `pg_restore` ever ran.
- The fix matches any `dump.*` file instead of a hardcoded extension list, which also covers `dacpac`/`fbk`/`archive` dumps (MSSQL/Firebird/MongoDB) that the old list silently missed.

Closes #551

## Test plan

- [x] New Pest tests covering `getDecompressedPath()` for every dump extension produced by `DatabaseType::dumpExtension()` (sql, db, dump, dacpac, fbk, archive), plus the not-found case
- [x] `make test` (full suite, 1493 passed / 1 skipped)
- [x] `make phpstan`
- [x] `make lint-fix`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Backup decompression now recognizes dump files across a wider range of database formats and extensions.
  * Clearer error handling is provided when no decompressed backup file is found.

* **Tests**
  * Added coverage for multiple dump file extensions and missing output files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->