### PR TITLE
fix: close out running command logs when a job fails

### DIFF
--- a/app/Models/BackupJob.php
+++ b/app/Models/BackupJob.php
@@ -155,7 +155,27 @@ class BackupJob extends Model implements BackupLogger
             'duration_ms' => $this->calculateDuration(),
             'error_message' => $exception->getMessage(),
             'error_trace' => $exception->getTraceAsString(),
+            'logs' => $this->logsWithRunningCommandsClosed('failed'),
         ]);
+    }
+
+    /**
+     * Close out any command log entries still marked "running", so a job that fails
+     * before its last command finishes (e.g. an exception escaping mid-execution, or
+     * a timed-out job recovered by RecoverStuckJobsCommand) doesn't leave the logs
+     * modal showing a permanently spinning command.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function logsWithRunningCommandsClosed(string $status): array
+    {
+        return array_map(function (array $log) use ($status) {
+            if (($log['type'] ?? null) === 'command' && ($log['status'] ?? null) === 'running') {
+                $log['status'] = $status;
+            }
+
+            return $log;
+        }, $this->logs ?? []);
     }
 
     /**

--- a/tests/Feature/Models/BackupJobTest.php
+++ b/tests/Feature/Models/BackupJobTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\BackupJob;
+
+test('markFailed closes out any command log still marked running', function () {
+    $backupJob = BackupJob::create([
+        'status' => 'running',
+    ]);
+
+    $backupJob->startCommandLog('pg_dump --clean --if-exists --no-owner');
+
+    $backupJob->markFailed(new Exception('SSH tunnel dropped mid-command'));
+
+    $logs = $backupJob->fresh()->getLogs();
+
+    expect($logs)->toHaveCount(1)
+        ->and($logs[0]['status'])->toBe('failed');
+});
+
+test('markFailed leaves already-finished command logs untouched', function () {
+    $backupJob = BackupJob::create([
+        'status' => 'running',
+    ]);
+
+    $index = $backupJob->startCommandLog('pg_dump --clean --if-exists --no-owner');
+    $backupJob->updateCommandLog($index, [
+        'status' => 'completed',
+        'exit_code' => 0,
+    ]);
+
+    $backupJob->markFailed(new Exception('post-script failed'));
+
+    $logs = $backupJob->fresh()->getLogs();
+
+    expect($logs[0]['status'])->toBe('completed')
+        ->and($logs[0]['exit_code'])->toBe(0);
+});


### PR DESCRIPTION
## Summary
- Fixes #520: after a job fails, the Job Logs modal could still show a command entry spinning as "running" forever.
- Root cause: the modal's spinner is driven solely by each command log entry's own `status` field, which is never synced with the parent job's overall status. `BackupJob::markFailed()` only updated the job's own status/error columns, so if an exception escaped `ShellProcessor::process()` mid-command (or `RecoverStuckJobsCommand` recovered a timed-out job), the last command's log entry stayed `status: running` indefinitely even though the job showed Failed.
- Fix: `markFailed()` now also closes out any command log entry still marked `running` (flips it to `failed`) in the same DB write, via a new `logsWithRunningCommandsClosed()` helper. This covers every caller of `markFailed()` (`ProcessBackupJob`, `ProcessRestoreJob`, `RecoverStuckJobsCommand`) in one place.

## Test plan
- [x] New tests in `tests/Feature/Models/BackupJobTest.php`: a running command log is closed out to `failed` when the job fails; an already-finished command log is left untouched.
- [x] Full suite (1489 tests) passing
- [x] phpstan passing
- [x] pint passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Failed backup jobs now correctly mark any in-progress command entries as failed.
  * Existing completed command statuses and exit codes remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->