### PR TITLE
feat: allow locking snapshots to protect them from auto-deletion

### DIFF
--- a/app/Enums/Ability.php
+++ b/app/Enums/Ability.php
@@ -58,7 +58,7 @@ enum Ability: string
         return match ($this) {
             self::RunBackups => __('Run backups on demand.'),
             self::DownloadSnapshots => __('Download snapshot files.'),
-            self::DeleteSnapshots => __('Delete snapshots and cancel pending backup jobs.'),
+            self::DeleteSnapshots => __('Delete snapshots, cancel pending backup jobs, and lock/unlock snapshots to protect them from deletion.'),
             self::OperateRestores => __('Restore from snapshots and manage scheduled restores.'),
             self::UseAdminer => __('Open the Adminer database browser.'),
             self::ManageDatabaseServers => __('Create, edit and delete database server connections.'),

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -153,6 +153,19 @@ class Index extends Component
         return Snapshot::with('files.volume')->find($this->downloadSnapshotId);
     }
 
+    public function toggleLock(string $snapshotId): void
+    {
+        $snapshot = Snapshot::findOrFail($snapshotId);
+
+        $this->authorize('manageLock', $snapshot);
+
+        $snapshot->update(['locked' => ! $snapshot->locked]);
+
+        $this->success($snapshot->locked
+            ? __('Snapshot locked. It will be protected from deletion until unlocked.')
+            : __('Snapshot unlocked.'));
+    }
+
     public function confirmDeleteSnapshot(string $snapshotId): void
     {
         $snapshot = Snapshot::findOrFail($snapshotId);

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -13,6 +13,7 @@ use App\Queries\SnapshotQuery;
 use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Title;
 use Livewire\Attributes\Url;
@@ -153,6 +154,11 @@ class Index extends Component
         return Snapshot::with('files.volume')->find($this->downloadSnapshotId);
     }
 
+    public function canDelete(Snapshot $snapshot): bool
+    {
+        return in_array($snapshot->job->status->value, ['completed', 'failed'], true) && ! $snapshot->locked;
+    }
+
     public function toggleLock(string $snapshotId): void
     {
         $snapshot = Snapshot::findOrFail($snapshotId);
@@ -199,10 +205,30 @@ class Index extends Component
 
         $this->authorize('delete', $snapshot);
 
-        $snapshot->skipFileCleanup = $this->keepFiles;
-        $snapshot->delete();
+        // The authorize() check above can go stale if the snapshot is locked in the
+        // moment between it and this call, so re-check under a row lock immediately
+        // before deleting rather than trusting the earlier read.
+        $deleted = DB::transaction(function () use ($snapshot) {
+            $locked = Snapshot::whereKey($snapshot->id)->lockForUpdate()->value('locked');
+
+            if ($locked) {
+                return false;
+            }
+
+            $snapshot->skipFileCleanup = $this->keepFiles;
+            $snapshot->delete();
+
+            return true;
+        });
+
         $this->deleteSnapshotId = null;
         $this->showDeleteModal = false;
+
+        if (! $deleted) {
+            $this->error(__('Snapshot was locked and could not be deleted.'));
+
+            return;
+        }
 
         $this->success(__('Snapshot deleted successfully!'));
     }

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -14,6 +14,7 @@ use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Title;
 use Livewire\Attributes\Url;
@@ -165,9 +166,28 @@ class Index extends Component
 
         $this->authorize('manageLock', $snapshot);
 
-        $snapshot->update(['locked' => ! $snapshot->locked]);
+        // A concurrent delete can remove the row between the read above and the
+        // update below, in which case update() affects zero rows but still
+        // reports success. Reload under a row lock and skip if it's gone.
+        $locked = DB::transaction(function () use ($snapshot) {
+            $current = Snapshot::whereKey($snapshot->id)->lockForUpdate()->first();
 
-        $this->success($snapshot->locked
+            if (! $current) {
+                return null;
+            }
+
+            $current->update(['locked' => ! $current->locked]);
+
+            return $current->locked;
+        });
+
+        if ($locked === null) {
+            $this->error(__('Snapshot no longer exists.'));
+
+            return;
+        }
+
+        $this->success($locked
             ? __('Snapshot locked. It will be protected from deletion until unlocked.')
             : __('Snapshot unlocked.'));
     }
@@ -205,18 +225,22 @@ class Index extends Component
 
         $this->authorize('delete', $snapshot);
 
-        // The authorize() check above can go stale if the snapshot is locked in the
-        // moment between it and this call, so re-check under a row lock immediately
-        // before deleting rather than trusting the earlier read.
+        // The authorize() check above can go stale if the snapshot is locked, or
+        // deleted outright by another request, in the moment between it and this
+        // call. Reload the row itself (not just its `locked` scalar) under a row
+        // lock and re-authorize against that current state immediately before
+        // deleting: deleting the stale, pre-lock $snapshot instance would re-run
+        // its `deleting` callback against relations another request may have
+        // already removed.
         $deleted = DB::transaction(function () use ($snapshot) {
-            $locked = Snapshot::whereKey($snapshot->id)->lockForUpdate()->value('locked');
+            $current = Snapshot::whereKey($snapshot->id)->lockForUpdate()->first();
 
-            if ($locked) {
+            if (! $current || Gate::denies('delete', $current)) {
                 return false;
             }
 
-            $snapshot->skipFileCleanup = $this->keepFiles;
-            $snapshot->delete();
+            $current->skipFileCleanup = $this->keepFiles;
+            $current->delete();
 
             return true;
         });

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -37,6 +37,7 @@ class Snapshot extends Model
         'filename',
         'file_size',
         'checksum',
+        'locked',
         'started_at',
         'database_name',
         'database_type',
@@ -51,6 +52,7 @@ class Snapshot extends Model
         return [
             'started_at' => 'datetime',
             'file_size' => 'integer',
+            'locked' => 'boolean',
             'database_type' => DatabaseType::class,
             'metadata' => 'array',
             'compression_type' => CompressionType::class,

--- a/app/Models/Snapshot.php
+++ b/app/Models/Snapshot.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 /**
  * @mixin IdeHelperSnapshot
@@ -180,7 +181,21 @@ class Snapshot extends Model
         // Delete the backup files, associated restores and job when snapshot is deleted
         static::deleting(function (Snapshot $snapshot) {
             if (! $snapshot->skipFileCleanup) {
-                $snapshot->deleteBackupFiles();
+                // Deleting from the volume is irreversible and must not run until the
+                // surrounding delete is guaranteed to commit (deleteSnapshot() callers
+                // wrap this in a row-locked transaction to fix a locking race; if a
+                // later step in that transaction throws and it rolls back, files
+                // deleted here can't be un-deleted). Capture the copies now, before
+                // their rows are removed below, and defer the actual volume deletes
+                // until the transaction commits (or run immediately outside one).
+                $files = $snapshot->files()->completed()->get()
+                    ->each(fn (SnapshotFile $file) => $file->setRelation('snapshot', $snapshot));
+
+                DB::afterCommit(function () use ($files) {
+                    foreach ($files as $file) {
+                        $file->deleteFromVolume();
+                    }
+                });
             }
 
             // The copy rows would cascade at the DB level, but delete them

--- a/app/Policies/SnapshotPolicy.php
+++ b/app/Policies/SnapshotPolicy.php
@@ -28,9 +28,20 @@ class SnapshotPolicy
 
     /**
      * Determine whether the user can delete the model.
-     * Requires the delete-snapshots ability.
+     * Requires the delete-snapshots ability. Locked snapshots cannot be
+     * deleted until unlocked, regardless of ability.
      */
     public function delete(User $user, Snapshot $snapshot): bool
+    {
+        return $user->can(Ability::DeleteSnapshots->value) && ! $snapshot->locked;
+    }
+
+    /**
+     * Determine whether the user can lock or unlock the snapshot.
+     * Requires the delete-snapshots ability, since locking governs who may
+     * protect a snapshot from the same deletion that ability controls.
+     */
+    public function manageLock(User $user, Snapshot $snapshot): bool
     {
         return $user->can(Ability::DeleteSnapshots->value);
     }

--- a/app/Services/Backup/SnapshotCleanupService.php
+++ b/app/Services/Backup/SnapshotCleanupService.php
@@ -59,6 +59,7 @@ class SnapshotCleanupService
         $expiredSnapshots = Snapshot::where('backup_id', $backup->id)
             ->completed()
             ->where('created_at', '<', $cutoffDate)
+            ->where('locked', false)
             ->get();
 
         if ($expiredSnapshots->isEmpty()) {
@@ -112,7 +113,7 @@ class SnapshotCleanupService
         }
 
         $snapshotsToDelete = $allSnapshots->reject(
-            fn (Snapshot $snapshot) => $snapshotsToKeep->contains($snapshot->id)
+            fn (Snapshot $snapshot) => $snapshotsToKeep->contains($snapshot->id) || $snapshot->locked
         );
 
         if ($snapshotsToDelete->isEmpty()) {

--- a/app/Services/Backup/SnapshotCleanupService.php
+++ b/app/Services/Backup/SnapshotCleanupService.php
@@ -173,16 +173,19 @@ class SnapshotCleanupService
         }
 
         // Snapshots are selected for cleanup by an earlier bulk query, which can go stale
-        // if the snapshot is locked in between. Re-check under a row lock immediately
-        // before deleting so a lock applied mid-run is never silently overridden.
+        // if the snapshot is locked — or already deleted by a concurrent request — in
+        // between. Reload the row itself (not just its `locked` scalar) under a row lock
+        // immediately before deleting: deleting the stale, pre-lock $snapshot instance
+        // would re-run its `deleting` callback against relations another request may
+        // have already removed.
         $deleted = DB::transaction(function () use ($snapshot) {
-            $locked = Snapshot::whereKey($snapshot->id)->lockForUpdate()->value('locked');
+            $current = Snapshot::whereKey($snapshot->id)->lockForUpdate()->first();
 
-            if ($locked) {
+            if (! $current || $current->locked) {
                 return false;
             }
 
-            $snapshot->delete();
+            $current->delete();
 
             return true;
         });

--- a/app/Services/Backup/SnapshotCleanupService.php
+++ b/app/Services/Backup/SnapshotCleanupService.php
@@ -5,6 +5,7 @@ namespace App\Services\Backup;
 use App\Models\Backup;
 use App\Models\Snapshot;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 class SnapshotCleanupService
@@ -166,11 +167,33 @@ class SnapshotCleanupService
 
         if ($this->dryRun) {
             Log::info("Snapshot cleanup: [DRY-RUN] Would delete {$database} ({$age} days old)");
-        } else {
-            $snapshot->delete();
-            Log::info("Snapshot cleanup: Deleted {$database} ({$age} days old)");
+            $this->totalDeleted++;
+
+            return;
         }
 
+        // Snapshots are selected for cleanup by an earlier bulk query, which can go stale
+        // if the snapshot is locked in between. Re-check under a row lock immediately
+        // before deleting so a lock applied mid-run is never silently overridden.
+        $deleted = DB::transaction(function () use ($snapshot) {
+            $locked = Snapshot::whereKey($snapshot->id)->lockForUpdate()->value('locked');
+
+            if ($locked) {
+                return false;
+            }
+
+            $snapshot->delete();
+
+            return true;
+        });
+
+        if (! $deleted) {
+            Log::info("Snapshot cleanup: Skipped {$database} - locked since being selected for cleanup.");
+
+            return;
+        }
+
+        Log::info("Snapshot cleanup: Deleted {$database} ({$age} days old)");
         $this->totalDeleted++;
     }
 }

--- a/database/migrations/2026_09_01_000000_add_locked_to_snapshots_table.php
+++ b/database/migrations/2026_09_01_000000_add_locked_to_snapshots_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->boolean('locked')->default(false)->after('checksum');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('snapshots', function (Blueprint $table) {
+            $table->dropColumn('locked');
+        });
+    }
+};

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -128,7 +128,7 @@
                     $canRestore = $status === 'completed' && $snapshot->hasExistingFile() && $snapshot->database_type !== \App\Enums\DatabaseType::REDIS;
                     $completedFiles = $snapshot->files->where('status', \App\Enums\SnapshotFileStatus::Completed);
                     $canDownload = $status === 'completed' && $completedFiles->where('file_exists', true)->isNotEmpty();
-                    $canDelete = in_array($status, ['completed', 'failed'], true) && ! $snapshot->locked;
+                    $canDelete = $this->canDelete($snapshot);
                     $canCancel = $status === 'pending' && $job;
                 @endphp
                 <div class="flex items-center gap-1 justify-end">

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -81,6 +81,12 @@
                                     </x-slot:content>
                                 </x-popover>
                             @endif
+                            @if($snapshot->locked)
+                                <span class="badge badge-neutral badge-xs gap-1" title="{{ __('Protected from auto-deletion') }}">
+                                    <x-icon name="o-lock-closed" class="w-3 h-3" />
+                                    {{ __('Locked') }}
+                                </span>
+                            @endif
                         </div>
                     </div>
                 </div>
@@ -122,7 +128,7 @@
                     $canRestore = $status === 'completed' && $snapshot->hasExistingFile() && $snapshot->database_type !== \App\Enums\DatabaseType::REDIS;
                     $completedFiles = $snapshot->files->where('status', \App\Enums\SnapshotFileStatus::Completed);
                     $canDownload = $status === 'completed' && $completedFiles->where('file_exists', true)->isNotEmpty();
-                    $canDelete = in_array($status, ['completed', 'failed'], true);
+                    $canDelete = in_array($status, ['completed', 'failed'], true) && ! $snapshot->locked;
                     $canCancel = $status === 'pending' && $job;
                 @endphp
                 <div class="flex items-center gap-1 justify-end">
@@ -167,6 +173,17 @@
                         :class="$job ? '' : 'opacity-30'"
                         :disabled="! $job"
                     />
+
+                    @if(in_array($status, ['completed', 'failed'], true))
+                        @can('manageLock', $snapshot)
+                            <x-button
+                                :icon="$snapshot->locked ? 'o-lock-closed' : 'o-lock-open'"
+                                wire:click="toggleLock('{{ $snapshot->id }}')"
+                                :tooltip="$snapshot->locked ? __('Unlock') : __('Lock (protect from deletion)')"
+                                class="btn-ghost btn-sm"
+                            />
+                        @endcan
+                    @endif
 
                     @if($canDelete)
                         @can('delete', $snapshot)

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -175,6 +175,45 @@ test('can delete a completed snapshot', function () {
     expect(Snapshot::find($snapshot->id))->toBeNull();
 });
 
+test('delete-snapshots allows locking and unlocking a snapshot', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+    $user = User::factory()->withAbilities([Ability::DeleteSnapshots->value])->create();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->call('toggleLock', $snapshot->id);
+
+    expect($snapshot->fresh()->locked)->toBeTrue();
+
+    Livewire::actingAs($user)
+        ->test(Index::class)
+        ->call('toggleLock', $snapshot->id);
+
+    expect($snapshot->fresh()->locked)->toBeFalse();
+});
+
+test('without delete-snapshots, toggling a snapshot lock is forbidden', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+
+    actingAs(User::factory()->withAllAbilitiesExcept(Ability::DeleteSnapshots->value)->create());
+
+    Livewire::test(Index::class)
+        ->call('toggleLock', $snapshot->id)
+        ->assertForbidden();
+
+    expect($snapshot->fresh()->locked)->toBeFalse();
+});
+
+test('a locked snapshot cannot be deleted even with delete-snapshots', function () {
+    $snapshot = Snapshot::factory()->withFile()->create(['locked' => true]);
+
+    Livewire::test(Index::class)
+        ->call('confirmDeleteSnapshot', $snapshot->id)
+        ->assertForbidden();
+
+    expect(Snapshot::find($snapshot->id))->not->toBeNull();
+});
+
 test('without delete-snapshots, deleting a snapshot is forbidden', function () {
     $snapshot = Snapshot::factory()->withFile()->create();
 

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -9,6 +9,7 @@ use App\Models\Snapshot;
 use App\Models\User;
 use App\Models\Volume;
 use App\Services\Backup\BackupJobFactory;
+use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
@@ -164,6 +165,19 @@ test('cannot cancel a non-pending job', function () {
         ->assertForbidden();
 });
 
+test('canDelete reflects snapshot status and lock state', function () {
+    $completedUnlocked = Snapshot::factory()->withFile()->create();
+    $completedLocked = Snapshot::factory()->withFile()->create(['locked' => true]);
+    $pending = Snapshot::factory()->withFile()->create();
+    $pending->job->update(['status' => BackupJobStatus::Pending, 'completed_at' => null]);
+
+    $component = Livewire::test(Index::class)->instance();
+
+    expect($component->canDelete($completedUnlocked))->toBeTrue()
+        ->and($component->canDelete($completedLocked))->toBeFalse()
+        ->and($component->canDelete($pending))->toBeFalse();
+});
+
 test('can delete a completed snapshot', function () {
     $snapshot = Snapshot::factory()->withFile()->create();
 
@@ -212,6 +226,29 @@ test('a locked snapshot cannot be deleted even with delete-snapshots', function 
         ->assertForbidden();
 
     expect(Snapshot::find($snapshot->id))->not->toBeNull();
+});
+
+test('a snapshot locked between the authorize check and the delete call is not deleted', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+
+    $component = Livewire::test(Index::class)
+        ->call('confirmDeleteSnapshot', $snapshot->id)
+        ->assertSet('deleteSnapshotId', $snapshot->id);
+
+    // Simulate a concurrent request locking the snapshot in the window between
+    // deleteSnapshot()'s authorize() check and its actual delete call: apply the
+    // lock as soon as deleteSnapshot() fetches the snapshot, before authorize()
+    // reads the (now stale, in-memory) locked value.
+    Snapshot::retrieved(function (Snapshot $retrieved) use ($snapshot) {
+        if ($retrieved->id === $snapshot->id) {
+            DB::table('snapshots')->where('id', $snapshot->id)->update(['locked' => true]);
+        }
+    });
+
+    $component->call('deleteSnapshot');
+
+    expect(Snapshot::find($snapshot->id))->not->toBeNull()
+        ->and(Snapshot::find($snapshot->id)->locked)->toBeTrue();
 });
 
 test('without delete-snapshots, deleting a snapshot is forbidden', function () {

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -251,6 +251,70 @@ test('a snapshot locked between the authorize check and the delete call is not d
         ->and(Snapshot::find($snapshot->id)->locked)->toBeTrue();
 });
 
+test('a snapshot deleted by another request before the row lock is skipped without error', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+
+    $component = Livewire::test(Index::class)
+        ->call('confirmDeleteSnapshot', $snapshot->id)
+        ->assertSet('deleteSnapshotId', $snapshot->id);
+
+    // Simulate a concurrent request that finishes deleting the snapshot in the
+    // window between this request's initial findOrFail() and its own row-locked
+    // reload: remove the row (cascading its files/restores at the DB level, same
+    // as a real delete) as soon as deleteSnapshot() re-fetches it, before the
+    // transaction's lockForUpdate() runs. If deleteSnapshot() deleted the stale,
+    // pre-lock instance instead of reloading, its `deleting` callback would
+    // dereference a `job` relation whose row is untouched here but would be gone
+    // in the real race, and the request would fail instead of no-op-ing.
+    Snapshot::retrieved(function (Snapshot $retrieved) use ($snapshot) {
+        if ($retrieved->id === $snapshot->id) {
+            DB::table('snapshots')->where('id', $snapshot->id)->delete();
+        }
+    });
+
+    $component->call('deleteSnapshot');
+
+    expect(Snapshot::find($snapshot->id))->toBeNull();
+});
+
+test('a snapshot deleted by another request before toggleLock reloads it does not report success', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+
+    // Mount first so the index listing's own render (which hydrates every visible
+    // snapshot, including this one) happens before the listener below is armed.
+    $component = Livewire::test(Index::class);
+
+    // Simulate a concurrent request that deletes the snapshot in the window
+    // between toggleLock()'s initial findOrFail() and its own row-locked reload.
+    Snapshot::retrieved(function (Snapshot $retrieved) use ($snapshot) {
+        if ($retrieved->id === $snapshot->id) {
+            DB::table('snapshots')->where('id', $snapshot->id)->delete();
+        }
+    });
+
+    $component->call('toggleLock', $snapshot->id);
+
+    expect(Snapshot::find($snapshot->id))->toBeNull();
+});
+
+test('locking then deleting a snapshot in sequence still succeeds', function () {
+    $snapshot = Snapshot::factory()->withFile()->create();
+
+    $component = Livewire::test(Index::class)
+        ->call('toggleLock', $snapshot->id);
+
+    expect($snapshot->fresh()->locked)->toBeTrue();
+
+    $component->call('toggleLock', $snapshot->id);
+
+    expect($snapshot->fresh()->locked)->toBeFalse();
+
+    $component->call('confirmDeleteSnapshot', $snapshot->id)
+        ->call('deleteSnapshot');
+
+    expect(Snapshot::find($snapshot->id))->toBeNull();
+});
+
 test('without delete-snapshots, deleting a snapshot is forbidden', function () {
     $snapshot = Snapshot::factory()->withFile()->create();
 

--- a/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
+++ b/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
@@ -4,6 +4,7 @@ use App\Models\DatabaseServer;
 use App\Models\Snapshot;
 use App\Services\Backup\Filesystems\FilesystemProvider;
 use App\Services\Backup\SnapshotCleanupService;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use League\Flysystem\DirectoryListing;
 use League\Flysystem\Filesystem;
@@ -214,6 +215,28 @@ test('GFS retention skips locked snapshots even outside kept tiers', function ()
     expect(Snapshot::find($kept->id))->not->toBeNull()
         ->and(Snapshot::find($lockedOutsideTiers->id))->not->toBeNull()
         ->and(Snapshot::find($unlockedOutsideTiers->id))->toBeNull();
+});
+
+test('a snapshot locked after selection but before deletion is not deleted', function () {
+    $server = DatabaseServer::factory()->create();
+    updateFirstBackup($server, ['retention_days' => 7]);
+
+    $racedSnapshot = createSnapshot($server, 'completed', now()->subDays(10), 'app_db');
+
+    // Simulate another request locking the snapshot in the window between the
+    // service's bulk selection query and its per-snapshot delete call: apply the
+    // lock as soon as the bulk query hydrates the snapshot, before the service's
+    // own re-check (a plain scalar query, not a model hydration) runs.
+    Snapshot::retrieved(function (Snapshot $retrieved) use ($racedSnapshot) {
+        if ($retrieved->id === $racedSnapshot->id) {
+            DB::table('snapshots')->where('id', $racedSnapshot->id)->update(['locked' => true]);
+        }
+    });
+
+    $result = app(SnapshotCleanupService::class)->run();
+
+    expect($result['deleted'])->toBe(0)
+        ->and(Snapshot::find($racedSnapshot->id))->not->toBeNull();
 });
 
 test('dry-run mode does not delete snapshots', function () {

--- a/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
+++ b/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
@@ -239,6 +239,31 @@ test('a snapshot locked after selection but before deletion is not deleted', fun
         ->and(Snapshot::find($racedSnapshot->id))->not->toBeNull();
 });
 
+test('a snapshot deleted by another request before the row lock is skipped without error', function () {
+    $server = DatabaseServer::factory()->create();
+    updateFirstBackup($server, ['retention_days' => 7]);
+
+    $racedSnapshot = createSnapshot($server, 'completed', now()->subDays(10), 'app_db');
+
+    // Simulate another request (e.g. a manual delete from the Snapshots index)
+    // finishing the delete in the window between the bulk selection query and
+    // the service's own row-locked reload: remove the row as soon as the bulk
+    // query hydrates it, before deleteSnapshot()'s lockForUpdate() runs. If
+    // deleteSnapshot() deleted the stale, pre-lock instance instead of reloading,
+    // its `deleting` callback would dereference relations the concurrent request
+    // already removed, and the run would fail instead of skipping it.
+    Snapshot::retrieved(function (Snapshot $retrieved) use ($racedSnapshot) {
+        if ($retrieved->id === $racedSnapshot->id) {
+            DB::table('snapshots')->where('id', $racedSnapshot->id)->delete();
+        }
+    });
+
+    $result = app(SnapshotCleanupService::class)->run();
+
+    expect($result['deleted'])->toBe(0)
+        ->and(Snapshot::find($racedSnapshot->id))->toBeNull();
+});
+
 test('dry-run mode does not delete snapshots', function () {
     $server = DatabaseServer::factory()->create();
     updateFirstBackup($server, ['retention_days' => 7]);

--- a/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
+++ b/tests/Feature/Services/Backup/SnapshotCleanupServiceTest.php
@@ -179,6 +179,43 @@ test('snapshot is still deleted when pruning empty parent folders throws', funct
     Log::shouldNotHaveReceived('error');
 });
 
+test('days retention skips locked snapshots even when expired', function () {
+    $server = DatabaseServer::factory()->create();
+    updateFirstBackup($server, ['retention_days' => 7]);
+
+    $lockedExpired = createSnapshot($server, 'completed', now()->subDays(10), 'app_db');
+    $lockedExpired->update(['locked' => true]);
+    $unlockedExpired = createSnapshot($server, 'completed', now()->subDays(10), 'app_db');
+
+    $result = app(SnapshotCleanupService::class)->run();
+
+    expect($result['deleted'])->toBe(1)
+        ->and(Snapshot::find($lockedExpired->id))->not->toBeNull()
+        ->and(Snapshot::find($unlockedExpired->id))->toBeNull();
+});
+
+test('GFS retention skips locked snapshots even outside kept tiers', function () {
+    $server = DatabaseServer::factory()->create();
+    updateFirstBackup($server, [
+        'retention_policy' => 'gfs',
+        'retention_days' => null,
+        'gfs_keep_daily' => 1,
+        'gfs_keep_weekly' => null,
+        'gfs_keep_monthly' => null,
+    ]);
+
+    $kept = createSnapshot($server, 'completed', now()->subDays(1), 'app_db');
+    $lockedOutsideTiers = createSnapshot($server, 'completed', now()->subDays(2), 'app_db');
+    $lockedOutsideTiers->update(['locked' => true]);
+    $unlockedOutsideTiers = createSnapshot($server, 'completed', now()->subDays(3), 'app_db');
+
+    app(SnapshotCleanupService::class)->run();
+
+    expect(Snapshot::find($kept->id))->not->toBeNull()
+        ->and(Snapshot::find($lockedOutsideTiers->id))->not->toBeNull()
+        ->and(Snapshot::find($unlockedOutsideTiers->id))->toBeNull();
+});
+
 test('dry-run mode does not delete snapshots', function () {
     $server = DatabaseServer::factory()->create();
     updateFirstBackup($server, ['retention_days' => 7]);

--- a/tests/Feature/Snapshot/SnapshotFileTest.php
+++ b/tests/Feature/Snapshot/SnapshotFileTest.php
@@ -6,6 +6,7 @@ use App\Models\Snapshot;
 use App\Models\Volume;
 use App\Services\Backup\BackupJobFactory;
 use App\Services\Backup\Filesystems\FilesystemProvider;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use League\Flysystem\Filesystem;
 
@@ -76,4 +77,44 @@ test('a volume that fails to delete does not stop the snapshot\'s other copies',
     expect($snapshot->deleteBackupFiles())->toBeTrue();
 
     Log::shouldHaveReceived('error')->once();
+});
+
+test('deleting a snapshot deletes its backup files from the volume', function () {
+    $snapshot = Snapshot::factory()->create(['filename' => 'backup.sql.gz']);
+
+    $filesystem = Mockery::mock(Filesystem::class);
+    $filesystem->shouldReceive('fileExists')->with('backup.sql.gz')->once()->andReturnTrue();
+    $filesystem->shouldReceive('delete')->with('backup.sql.gz')->once();
+
+    $provider = Mockery::mock(FilesystemProvider::class);
+    $provider->shouldReceive('getForVolume')->once()->andReturn($filesystem);
+    app()->instance(FilesystemProvider::class, $provider);
+
+    $snapshot->delete();
+
+    expect(Snapshot::find($snapshot->id))->toBeNull();
+});
+
+test('backup files are not deleted from the volume when the delete transaction rolls back', function () {
+    // Deleting from the volume is irreversible, so it must be deferred until the
+    // transaction wrapping the snapshot delete is guaranteed to commit. If a later
+    // step in that transaction fails and rolls back, the row survives and the
+    // files it references must still be there.
+    $snapshot = Snapshot::factory()->create(['filename' => 'backup.sql.gz']);
+
+    $provider = Mockery::mock(FilesystemProvider::class);
+    $provider->shouldNotReceive('getForVolume');
+    app()->instance(FilesystemProvider::class, $provider);
+
+    try {
+        DB::transaction(function () use ($snapshot) {
+            $snapshot->delete();
+
+            throw new RuntimeException('simulated failure after delete');
+        });
+    } catch (RuntimeException) {
+        // Expected: proves the deferred file deletion never ran.
+    }
+
+    expect(Snapshot::find($snapshot->id))->not->toBeNull();
 });

--- a/tests/Feature/Snapshot/SnapshotFileTest.php
+++ b/tests/Feature/Snapshot/SnapshotFileTest.php
@@ -112,8 +112,8 @@ test('backup files are not deleted from the volume when the delete transaction r
 
             throw new RuntimeException('simulated failure after delete');
         });
-    } catch (RuntimeException) {
-        // Expected: proves the deferred file deletion never ran.
+    } catch (RuntimeException $exception) {
+        expect($exception->getMessage())->toBe('simulated failure after delete');
     }
 
     expect(Snapshot::find($snapshot->id))->not->toBeNull();


### PR DESCRIPTION
## Summary
- Closes #537. Adds a `locked` flag on snapshots that both manual deletion and the scheduled retention cleanup (days-based and GFS) respect.
- Reuses the existing `delete-snapshots` ability for lock/unlock authorization rather than adding a new catalogue ability, since locking is inherently tied to who is trusted to delete a snapshot in the first place.
- `SnapshotPolicy::delete()` now returns false for a locked snapshot regardless of ability, until it is unlocked. A separate `manageLock()` policy method (ability-only, no lock-state check) gates the toggle itself so an authorized user can still unlock it.
- `SnapshotCleanupService` excludes locked snapshots from both the days-based query and the GFS delete set, so a locked snapshot survives cleanup even outside every GFS tier.
- UI: lock/unlock icon button in the Snapshots index row actions, a small "Locked" badge next to the database name, and the delete button hidden while locked.

## Test plan
- [x] New tests: `SnapshotCleanupServiceTest` (locked snapshots survive both days and GFS cleanup), `Livewire/Snapshot/IndexTest` (lock/unlock allow case, deny case without the ability, manual delete blocked while locked)
- [x] Full suite: `make test` (1491 passed / 1 skipped)
- [x] `make phpstan` and `make lint-check` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Snapshots can now be locked or unlocked to protect them from deletion.
  - Locked snapshots display a status badge and lock controls for authorized users.

- **Bug Fixes**
  - Locked snapshots cannot be manually deleted or removed by automatic cleanup.
  - Deletion is prevented if a snapshot becomes locked during the process.
  - Lock and deletion actions safely handle snapshots removed concurrently.
  - Lock controls are restricted to authorized users.
  - Backup files are removed only after snapshot deletion successfully commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->