### PR TITLE
Allow choosing the PostgreSQL connection database

### DIFF
--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -152,6 +152,18 @@ enum DatabaseType: string
     }
 
     /**
+     * The charset a database name is held to on every type that names an
+     * identifier rather than a path. It is also the last line of defence for
+     * the PDO DSN, which interpolates a database name unescaped and treats `;`
+     * and `=` as structure: an identifier restricted to this set carries no
+     * character the DSN parser can act on.
+     *
+     * Anchored with \A and \z rather than ^ and $, which would let a trailing
+     * newline through.
+     */
+    public const string IDENTIFIER_PATTERN = '/\A[a-zA-Z0-9_]+\z/';
+
+    /**
      * Validation rules for a destination database name/path of this type.
      *
      * SQLite accepts any non-empty path. Firebird is a path too but with a
@@ -166,7 +178,7 @@ enum DatabaseType: string
         return match ($this) {
             self::SQLITE => ['required', 'string', 'max:255', new SafeDatabasePath],
             self::FIREBIRD => ['required', 'string', 'max:255', 'regex:/^[a-zA-Z0-9_\/\\\\.\-: ]+$/', new SafeDatabasePath(allowBackslashes: true)],
-            default => ['required', 'string', 'max:64', 'regex:/^[a-zA-Z0-9_]+$/'],
+            default => ['required', 'string', 'max:64', 'regex:'.self::IDENTIFIER_PATTERN],
         };
     }
 

--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -8,6 +8,7 @@ use App\Enums\VolumeType;
 use App\Models\Backup;
 use App\Models\DatabaseServer;
 use App\Models\Volume;
+use App\Rules\MaxBytes;
 use App\Rules\SafeDatabasePath;
 use App\Rules\SafeHost;
 use App\Rules\SafePath;
@@ -76,7 +77,7 @@ class SaveDatabaseServerRequest extends FormRequest
         if ($type === 'postgres') {
             $rules['dump_format'] = ['nullable', 'string', Rule::in(['plain', 'custom'])];
             $rules['dump_privileges'] = 'boolean';
-            $rules['connection_database'] = 'nullable|string|max:63';
+            $rules['connection_database'] = ['nullable', 'string', new MaxBytes(63)];
         }
 
         if (in_array($type, ['mongodb', 'redis'])) {

--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -76,6 +76,7 @@ class SaveDatabaseServerRequest extends FormRequest
         if ($type === 'postgres') {
             $rules['dump_format'] = ['nullable', 'string', Rule::in(['plain', 'custom'])];
             $rules['dump_privileges'] = 'boolean';
+            $rules['connection_database'] = 'nullable|string|max:63';
         }
 
         if (in_array($type, ['mongodb', 'redis'])) {

--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -77,7 +77,7 @@ class SaveDatabaseServerRequest extends FormRequest
         if ($type === 'postgres') {
             $rules['dump_format'] = ['nullable', 'string', Rule::in(['plain', 'custom'])];
             $rules['dump_privileges'] = 'boolean';
-            $rules['connection_database'] = ['nullable', 'string', new MaxBytes(63)];
+            $rules['connection_database'] = ['nullable', 'string', new MaxBytes(63), 'regex:'.DatabaseType::IDENTIFIER_PATTERN];
         }
 
         if (in_array($type, ['mongodb', 'redis'])) {

--- a/app/Livewire/DatabaseServer/Connection/PostgresConnectionRules.php
+++ b/app/Livewire/DatabaseServer/Connection/PostgresConnectionRules.php
@@ -8,7 +8,13 @@ class PostgresConnectionRules extends ClientServerConnectionRules
 {
     public function extraConfig(Form $form): array
     {
-        return $form->ssl_enabled ? ['ssl_enabled' => true] : [];
+        $extra = $form->ssl_enabled ? ['ssl_enabled' => true] : [];
+
+        if ($form->connection_database !== '') {
+            $extra['connection_database'] = $form->connection_database;
+        }
+
+        return $extra;
     }
 
     public function dumpPreviewConfig(Form $form): array

--- a/app/Livewire/DatabaseServer/Connection/PostgresConnectionRules.php
+++ b/app/Livewire/DatabaseServer/Connection/PostgresConnectionRules.php
@@ -10,8 +10,10 @@ class PostgresConnectionRules extends ClientServerConnectionRules
     {
         $extra = $form->ssl_enabled ? ['ssl_enabled' => true] : [];
 
-        if ($form->connection_database !== '') {
-            $extra['connection_database'] = $form->connection_database;
+        $connectionDatabase = trim($form->connection_database);
+
+        if ($connectionDatabase !== '') {
+            $extra['connection_database'] = $connectionDatabase;
         }
 
         return $extra;

--- a/app/Livewire/DatabaseServer/Form.php
+++ b/app/Livewire/DatabaseServer/Form.php
@@ -897,7 +897,7 @@ class Form extends \Livewire\Form
             'dump_format' => ['nullable', 'string', Rule::in(['plain', 'custom'])],
             'dump_privileges' => 'boolean',
             'ssl_enabled' => 'boolean',
-            'connection_database' => ['nullable', 'string', new MaxBytes(63)],
+            'connection_database' => ['nullable', 'string', new MaxBytes(63), 'regex:'.DatabaseType::IDENTIFIER_PATTERN],
             'notification_trigger' => ['required', 'string', Rule::in(array_column(NotificationTrigger::cases(), 'value'))],
             'notification_channel_selection' => ['required', 'string', Rule::in(array_column(NotificationChannelSelection::cases(), 'value'))],
             'notification_channel_ids' => ['array', Rule::requiredIf(

--- a/app/Livewire/DatabaseServer/Form.php
+++ b/app/Livewire/DatabaseServer/Form.php
@@ -13,6 +13,7 @@ use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
 use App\Models\NotificationChannel;
+use App\Rules\MaxBytes;
 use App\Services\Backup\Databases\DatabaseProvider;
 use App\Services\Backup\ShellProcessor;
 use App\Services\Backup\SyncBackupConfigurationsAction;
@@ -896,7 +897,7 @@ class Form extends \Livewire\Form
             'dump_format' => ['nullable', 'string', Rule::in(['plain', 'custom'])],
             'dump_privileges' => 'boolean',
             'ssl_enabled' => 'boolean',
-            'connection_database' => ['nullable', 'string', 'max:63'],
+            'connection_database' => ['nullable', 'string', new MaxBytes(63)],
             'notification_trigger' => ['required', 'string', Rule::in(array_column(NotificationTrigger::cases(), 'value'))],
             'notification_channel_selection' => ['required', 'string', Rule::in(array_column(NotificationChannelSelection::cases(), 'value'))],
             'notification_channel_ids' => ['array', Rule::requiredIf(

--- a/app/Livewire/DatabaseServer/Form.php
+++ b/app/Livewire/DatabaseServer/Form.php
@@ -68,6 +68,13 @@ class Form extends \Livewire\Form
 
     public bool $ssl_enabled = false;
 
+    /**
+     * PostgreSQL only. Database opened to test the connection and list the
+     * others. Empty falls back to `postgres`, which managed providers often do
+     * not grant CONNECT on. Stored in extra_config.
+     */
+    public string $connection_database = '';
+
     // SSH Tunnel Configuration
     public bool $ssh_enabled = false;
 
@@ -462,6 +469,7 @@ class Form extends \Livewire\Form
         $this->dump_privileges = (bool) $server->getExtraConfig('dump_privileges', false);
         $this->dump_config_open = ! empty($this->dump_flags) || $this->dump_format === 'custom' || $this->dump_privileges;
         $this->ssl_enabled = (bool) $server->getExtraConfig('ssl_enabled', false);
+        $this->connection_database = $server->getExtraConfig('connection_database', '');
         $this->username = $server->username ?? '';
         $this->description = $server->description;
         $this->agent_id = $server->agent_id;
@@ -888,6 +896,7 @@ class Form extends \Livewire\Form
             'dump_format' => ['nullable', 'string', Rule::in(['plain', 'custom'])],
             'dump_privileges' => 'boolean',
             'ssl_enabled' => 'boolean',
+            'connection_database' => ['nullable', 'string', 'max:63'],
             'notification_trigger' => ['required', 'string', Rule::in(array_column(NotificationTrigger::cases(), 'value'))],
             'notification_channel_selection' => ['required', 'string', Rule::in(array_column(NotificationChannelSelection::cases(), 'value'))],
             'notification_channel_ids' => ['array', Rule::requiredIf(

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -375,7 +375,7 @@ class DatabaseServer extends Model
             ['dump_format',         fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v === 'custom',       fn () => 'custom'],
             ['dump_privileges',     fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v,                    fn () => true],
             ['ssl_enabled',         fn ($v) => in_array($type, [DatabaseType::MYSQL->value, DatabaseType::POSTGRESQL->value], true) && $v, fn () => true],
-            ['connection_database', fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v !== '' && $v !== null, fn ($v) => $v],
+            ['connection_database', fn ($v) => $type === DatabaseType::POSTGRESQL->value && is_string($v) && trim($v) !== '', fn ($v) => trim($v)],
         ];
 
         foreach ($rules as [$key, $keep, $store]) {

--- a/app/Models/DatabaseServer.php
+++ b/app/Models/DatabaseServer.php
@@ -351,7 +351,7 @@ class DatabaseServer extends Model
 
     /**
      * Move type-specific fields (auth_source, srv_enabled, connection_options,
-     * dump_flags, ssl_enabled) into extra_config.
+     * dump_flags, ssl_enabled, connection_database) into extra_config.
      * Clears stale keys when database type has changed.
      *
      * @param  array<string, mixed>  $data
@@ -375,6 +375,7 @@ class DatabaseServer extends Model
             ['dump_format',         fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v === 'custom',       fn () => 'custom'],
             ['dump_privileges',     fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v,                    fn () => true],
             ['ssl_enabled',         fn ($v) => in_array($type, [DatabaseType::MYSQL->value, DatabaseType::POSTGRESQL->value], true) && $v, fn () => true],
+            ['connection_database', fn ($v) => $type === DatabaseType::POSTGRESQL->value && $v !== '' && $v !== null, fn ($v) => $v],
         ];
 
         foreach ($rules as [$key, $keep, $store]) {

--- a/app/Rules/MaxBytes.php
+++ b/app/Rules/MaxBytes.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Bound a string by its byte length rather than its character count.
+ *
+ * Laravel's `max` rule measures characters (mb_strlen), which is the wrong
+ * unit for limits the database enforces in bytes: PostgreSQL truncates any
+ * identifier past NAMEDATALEN-1 (63 bytes), so a 63-character name written in
+ * a multi-byte script passes `max:63` and is then silently cut short.
+ */
+readonly class MaxBytes implements ValidationRule
+{
+    public function __construct(private int $max) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value)) {
+            return;
+        }
+
+        if (strlen($value) > $this->max) {
+            $fail(__('The :attribute may not be greater than :max bytes.', ['max' => $this->max]));
+        }
+    }
+}

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -117,6 +117,10 @@ class DatabaseProvider
             $dbConfig['probe_server_version'] = true;
         }
 
+        if ($config->databaseType === DatabaseType::POSTGRESQL) {
+            $dbConfig['connection_database'] = self::connectionDatabase($extra);
+        }
+
         if ($config->databaseType === DatabaseType::POSTGRESQL
             && ($snapshotDumpFormat ?? $extra['dump_format'] ?? null) === 'custom') {
             $dbConfig['dump_format'] = 'custom';
@@ -298,10 +302,28 @@ class DatabaseProvider
         }
 
         return match ($server->database_type) {
-            DatabaseType::POSTGRESQL => 'postgres',
+            DatabaseType::POSTGRESQL => self::connectionDatabase($server->extra_config ?? []),
             DatabaseType::MSSQL => 'master',
             DatabaseType::FIREBIRD => $server->resolveDatabaseNames()[0] ?? '',
             default => '',
         };
+    }
+
+    /**
+     * PostgreSQL refuses a connection that names no database, so testing a
+     * connection and listing the catalogue both have to open one. `postgres` is
+     * the conventional choice, but managed providers (Heroku, RDS, Neon, …)
+     * routinely withhold CONNECT on it, so a server can name another database
+     * through extra_config.connection_database.
+     *
+     * @param  array<string, mixed>  $extraConfig
+     */
+    public static function connectionDatabase(array $extraConfig): string
+    {
+        $configured = $extraConfig['connection_database'] ?? null;
+
+        return is_string($configured) && $configured !== ''
+            ? $configured
+            : PostgresqlDatabase::DEFAULT_CONNECTION_DATABASE;
     }
 }

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -320,10 +320,6 @@ class DatabaseProvider
      */
     public static function connectionDatabase(array $extraConfig): string
     {
-        $configured = $extraConfig['connection_database'] ?? null;
-
-        return is_string($configured) && $configured !== ''
-            ? $configured
-            : PostgresqlDatabase::DEFAULT_CONNECTION_DATABASE;
+        return PostgresqlDatabase::resolveConnectionDatabase($extraConfig);
     }
 }

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -11,6 +11,12 @@ use Illuminate\Support\Facades\Process;
 
 class PostgresqlDatabase implements DatabaseInterface
 {
+    /**
+     * Database opened when the server names none of its own. Conventional on a
+     * self-hosted cluster; managed providers often withhold CONNECT on it.
+     */
+    public const string DEFAULT_CONNECTION_DATABASE = 'postgres';
+
     /** @var array<string, mixed> */
     private array $config;
 
@@ -149,6 +155,18 @@ class PostgresqlDatabase implements DatabaseInterface
 
     public function prepareForRestore(string $schemaName, BackupLogger $logger, bool $forceDatabase = false): void
     {
+        // DROP DATABASE runs over the connection database, so it can never
+        // target the database that connection is open on. Servers with a single
+        // reachable database hit this when both point at it. Checked up front:
+        // the failure is a configuration conflict, not a connection problem.
+        if ($forceDatabase && $schemaName === $this->connectionDatabase()) {
+            throw new ConnectionException(sprintf(
+                'Cannot recreate database "%s": it is also the connection database this server connects through. '
+                .'Point the connection database at another database, or restore without database recreation.',
+                $schemaName,
+            ));
+        }
+
         try {
             $pdo = $this->createPdo();
 
@@ -281,9 +299,24 @@ class PostgresqlDatabase implements DatabaseInterface
         ];
     }
 
+    /**
+     * Admin connection, used for work that cannot run inside the target
+     * database itself (enumerating databases, dropping and recreating one).
+     * Defaults to `postgres` unless the server names another database it
+     * can actually reach.
+     */
     protected function createPdo(): \PDO
     {
-        return $this->createPdoForDatabase('postgres');
+        return $this->createPdoForDatabase($this->connectionDatabase());
+    }
+
+    private function connectionDatabase(): string
+    {
+        $configured = $this->config['connection_database'] ?? null;
+
+        return is_string($configured) && $configured !== ''
+            ? $configured
+            : self::DEFAULT_CONNECTION_DATABASE;
     }
 
     protected function createPdoForDatabase(string $database): \PDO

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -312,9 +312,23 @@ class PostgresqlDatabase implements DatabaseInterface
 
     private function connectionDatabase(): string
     {
-        $configured = $this->config['connection_database'] ?? null;
+        return self::resolveConnectionDatabase($this->config);
+    }
 
-        return is_string($configured) && $configured !== ''
+    /**
+     * The database a connection opens on, falling back to `postgres` when the
+     * server names none. Whitespace-only input is treated as naming none: a
+     * blank dbname reaches libpq as a database that cannot exist, so trimming
+     * here keeps a stray space from turning into an opaque connection error.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public static function resolveConnectionDatabase(array $config): string
+    {
+        $configured = $config['connection_database'] ?? null;
+        $configured = is_string($configured) ? trim($configured) : '';
+
+        return $configured !== ''
             ? $configured
             : self::DEFAULT_CONNECTION_DATABASE;
     }

--- a/lang/el.json
+++ b/lang/el.json
@@ -794,5 +794,7 @@
   "Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).": "Αλλάξτε το μόνο για κυρίαρχα cloud (π.χ., core.usgovcloudapi.net, core.chinacloudapi.cn).",
   "Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.": "Τα Backups θα αποθηκεύονται ως blobs στο καθορισμένο container. Το κλειδί λογαριασμού βρίσκεται στα «Κλειδιά πρόσβασης» του λογαριασμού Azure Storage σας.",
   "Custom Blob Endpoint": "Προσαρμοσμένο Blob endpoint",
-  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Για αποθήκευση συμβατή με Azure (εξομοιωτής Azurite, self-hosted gateways). Υπερισχύει της κατάληξης endpoint."
+  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Για αποθήκευση συμβατή με Azure (εξομοιωτής Azurite, self-hosted gateways). Υπερισχύει της κατάληξης endpoint.",
+  "Connection database": "Βάση δεδομένων σύνδεσης",
+  "Opened to test the connection and list databases.": "Ανοίγει για τον έλεγχο της σύνδεσης και την προβολή των βάσεων δεδομένων."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -797,5 +797,7 @@
   "Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).": "Cámbialo solo para nubes soberanas (ej.: core.usgovcloudapi.net, core.chinacloudapi.cn).",
   "Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.": "Los Backups se almacenarán como blobs en el contenedor especificado. La clave de cuenta se encuentra en «Claves de acceso» de tu cuenta de Azure Storage.",
   "Custom Blob Endpoint": "Endpoint de Blob personalizado",
-  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Para almacenamiento compatible con Azure (emulador Azurite, pasarelas autoalojadas). Sustituye al sufijo del endpoint."
+  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Para almacenamiento compatible con Azure (emulador Azurite, pasarelas autoalojadas). Sustituye al sufijo del endpoint.",
+  "Connection database": "Base de datos de conexión",
+  "Opened to test the connection and list databases.": "Se abre para probar la conexión y listar las bases de datos."
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -799,5 +799,7 @@
   "Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).": "À modifier uniquement pour les clouds souverains (ex. : core.usgovcloudapi.net, core.chinacloudapi.cn).",
   "Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.": "Les Backups seront stockés sous forme de blobs dans le conteneur spécifié. La clé de compte se trouve dans « Clés d’accès » de votre compte de stockage Azure.",
   "Custom Blob Endpoint": "Point de terminaison Blob personnalisé",
-  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Pour le stockage compatible Azure (émulateur Azurite, passerelles auto-hébergées). Remplace le suffixe du point de terminaison."
+  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Pour le stockage compatible Azure (émulateur Azurite, passerelles auto-hébergées). Remplace le suffixe du point de terminaison.",
+  "Connection database": "Base de connexion",
+  "Opened to test the connection and list databases.": "Ouverte pour tester la connexion et lister les bases."
 }

--- a/lang/zh_TW.json
+++ b/lang/zh_TW.json
@@ -799,5 +799,7 @@
   "Change only for sovereign clouds (e.g., core.usgovcloudapi.net, core.chinacloudapi.cn).": "僅在主權雲環境下變更（例如：core.usgovcloudapi.net、core.chinacloudapi.cn）。",
   "Backups will be stored as blobs in the specified container. The account key can be found under Access keys in your Azure Storage account.": "Backup 將以 blob 形式儲存在指定的容器中。帳戶金鑰可在您的 Azure 儲存體帳戶中的「存取金鑰」下找到。",
   "Custom Blob Endpoint": "自訂 Blob 端點",
-  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "適用於 Azure 相容的儲存服務（Azurite 模擬器、自架閘道）。會覆寫端點後綴。"
+  "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "適用於 Azure 相容的儲存服務（Azurite 模擬器、自架閘道）。會覆寫端點後綴。",
+  "Connection database": "連線資料庫",
+  "Opened to test the connection and list databases.": "用於測試連線及列出資料庫。"
 }

--- a/resources/views/livewire/database-server/connection/postgres.blade.php
+++ b/resources/views/livewire/database-server/connection/postgres.blade.php
@@ -2,8 +2,18 @@
 
 @include('livewire.database-server.connection._client-server-fields', ['form' => $form, 'isEdit' => $isEdit])
 
-<x-checkbox
-    wire:model.live="form.ssl_enabled"
-    :label="__('Use SSL')"
-    :hint="__('Forces TLS (sslmode=require) for servers that enforce encrypted connections, such as Neon or Amazon RDS. The server certificate is not verified.')"
-/>
+<div class="grid gap-4 md:grid-cols-2 md:items-start">
+    <x-checkbox
+        class="md:mt-9"
+        wire:model.live="form.ssl_enabled"
+        :label="__('Use SSL')"
+        :hint="__('Forces TLS (sslmode=require) for servers that enforce encrypted connections, such as Neon or Amazon RDS. The server certificate is not verified.')"
+    />
+
+    <x-input
+        wire:model.blur="form.connection_database"
+        :label="__('Connection database')"
+        placeholder="postgres"
+        :hint="__('Opened to test the connection and list databases.')"
+    />
+</div>

--- a/tests/Feature/Api/DatabaseServerCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerCrudApiTest.php
@@ -407,6 +407,33 @@ test('update syncs backup configuration', function () {
         ->and($server->backups->first()->retention_policy)->toBe('forever');
 });
 
+test('a connection database cannot smuggle extra parameters into the dsn', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $server = DatabaseServer::factory()->create(['database_type' => 'postgres']);
+    $volume = Volume::factory()->local()->create();
+    $schedule = BackupSchedule::firstOrCreate(['name' => 'Daily'], ['expression' => '0 2 * * *']);
+
+    // The value is interpolated into a PDO DSN, where `;` starts another
+    // keyword=value pair rather than being part of the database name.
+    $this->actingAs($user, 'sanctum')
+        ->putJson("/api/v1/database-servers/{$server->id}", [
+            'name' => $server->name,
+            'database_type' => 'postgres',
+            'host' => $server->host,
+            'port' => $server->port,
+            'username' => $server->username,
+            'connection_database' => 'app_db;host=attacker.example.com',
+            'backups' => [[
+                'database_selection_mode' => 'all',
+                'volume_id' => $volume->id,
+                'backup_schedule_id' => $schedule->id,
+                'retention_policy' => 'forever',
+            ]],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['connection_database']);
+});
+
 test('update returns validation errors', function () {
     $user = User::factory()->create();
     $server = DatabaseServer::factory()->create();

--- a/tests/Feature/DatabaseServer/CreateTest.php
+++ b/tests/Feature/DatabaseServer/CreateTest.php
@@ -614,3 +614,35 @@ test('without manage-database-servers, the create screen is forbidden', function
         ->test(Create::class)
         ->assertForbidden();
 });
+
+test('postgres connection database round-trips through the form', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $volume = Volume::factory()->local()->create();
+
+    Livewire::actingAs($user)
+        ->test(Create::class)
+        ->set('form.database_type', 'postgres')
+        ->assertSee('Connection database')
+        ->set('form.name', 'Managed PG')
+        ->set('form.host', 'pg.example.com')
+        ->set('form.port', 5432)
+        ->set('form.username', 'dbuser')
+        ->set('form.password', 'secret123')
+        ->set('form.connection_database', 'app_db')
+        ->set('form.backups.0.volume_ids', [$volume->id])
+        ->set('form.backups.0.backup_schedule_id', dailySchedule()->id)
+        ->set('form.backups.0.retention_days', 14)
+        ->set('form.backups.0.database_names.0', 'app_db')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $server = DatabaseServer::where('name', 'Managed PG')->firstOrFail();
+
+    expect($server->getExtraConfig('connection_database'))->toBe('app_db')
+        ->and(DatabaseProvider::connectionDatabase($server->extra_config))->toBe('app_db');
+
+    // The edit form must hydrate it back, otherwise saving again silently drops it.
+    Livewire::actingAs($user)
+        ->test(\App\Livewire\DatabaseServer\Edit::class, ['server' => $server])
+        ->assertSet('form.connection_database', 'app_db');
+});

--- a/tests/Feature/Models/DatabaseServerTest.php
+++ b/tests/Feature/Models/DatabaseServerTest.php
@@ -146,6 +146,12 @@ test('buildExtraConfig folds type-specific fields into extra_config', function (
     'drops empty connection_database' => [
         ['database_type' => 'postgres', 'connection_database' => ''], null, null, null,
     ],
+    'drops whitespace-only connection_database' => [
+        ['database_type' => 'postgres', 'connection_database' => '   '], null, null, null,
+    ],
+    'trims surrounding whitespace from connection_database' => [
+        ['database_type' => 'postgres', 'connection_database' => ' app_db '], null, null, ['connection_database' => 'app_db'],
+    ],
     'drops connection_database for non-postgres types' => [
         ['database_type' => 'mysql', 'connection_database' => 'app_db'], null, null, null,
     ],

--- a/tests/Feature/Models/DatabaseServerTest.php
+++ b/tests/Feature/Models/DatabaseServerTest.php
@@ -122,7 +122,7 @@ test('buildExtraConfig folds type-specific fields into extra_config', function (
     expect($data['extra_config'])->toEqual($expected);
 
     // Handled keys are always pulled out of $data.
-    foreach (['auth_source', 'dump_flags', 'dump_format', 'dump_privileges', 'ssl_enabled'] as $key) {
+    foreach (['auth_source', 'dump_flags', 'dump_format', 'dump_privileges', 'ssl_enabled', 'connection_database'] as $key) {
         expect($data)->not->toHaveKey($key);
     }
 })->with([
@@ -139,6 +139,15 @@ test('buildExtraConfig folds type-specific fields into extra_config', function (
     ],
     'keeps ssl_enabled for postgres' => [
         ['database_type' => 'postgres', 'ssl_enabled' => true], null, null, ['ssl_enabled' => true],
+    ],
+    'keeps connection_database for postgres' => [
+        ['database_type' => 'postgres', 'connection_database' => 'app_db'], null, null, ['connection_database' => 'app_db'],
+    ],
+    'drops empty connection_database' => [
+        ['database_type' => 'postgres', 'connection_database' => ''], null, null, null,
+    ],
+    'drops connection_database for non-postgres types' => [
+        ['database_type' => 'mysql', 'connection_database' => 'app_db'], null, null, null,
     ],
     'drops field not relevant to the type' => [
         ['database_type' => 'sqlite', 'dump_flags' => '--anything'], null, null, null,

--- a/tests/Feature/Rules/MaxBytesTest.php
+++ b/tests/Feature/Rules/MaxBytesTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Rules\MaxBytes;
+use Illuminate\Support\Facades\Validator;
+
+test('MaxBytes bounds a value by its byte length, not its character count', function (string $value, bool $valid) {
+    $passes = Validator::make(
+        ['connection_database' => $value],
+        ['connection_database' => [new MaxBytes(63)]],
+    )->passes();
+
+    expect($passes)->toBe($valid);
+})->with([
+    // PostgreSQL truncates an identifier past NAMEDATALEN-1, counted in bytes,
+    // so Laravel's character-based `max:63` lets a name through that the server
+    // then silently cuts short.
+    '63 ascii bytes' => [str_repeat('a', 63), true],
+    '64 ascii bytes' => [str_repeat('a', 64), false],
+    '31 two-byte characters, 62 bytes' => [str_repeat('é', 31), true],
+    '32 two-byte characters, 64 bytes' => [str_repeat('é', 32), false],
+]);

--- a/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
@@ -291,7 +291,9 @@ test('connectionDatabase falls back to postgres', function (array $extraConfig, 
     'unset' => [[], 'postgres'],
     'empty string' => [['connection_database' => ''], 'postgres'],
     'null' => [['connection_database' => null], 'postgres'],
+    'whitespace only' => [['connection_database' => "  \t "], 'postgres'],
     'configured' => [['connection_database' => 'app_db'], 'app_db'],
+    'configured with surrounding whitespace' => [['connection_database' => ' app_db '], 'app_db'],
 ]);
 
 test('makeFromConfig passes connection_database to the postgres handler', function () {

--- a/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
+++ b/tests/Feature/Services/Backup/Databases/DatabaseProviderTest.php
@@ -250,6 +250,67 @@ test('testConnectionForServer delegates to handler testConnection', function (st
     'firebird uses empty database name when no paths set' => ['firebird', ''],
 ]);
 
+test('postgres connection test opens the configured connection database', function () {
+    // Reproduces issues #545/#549: a managed instance that denies CONNECT on
+    // `postgres`, where the user can only reach their own database.
+    $mockHandler = Mockery::mock(\App\Services\Backup\Databases\DatabaseInterface::class);
+    $mockHandler->shouldReceive('testConnection')
+        ->once()
+        ->andReturn(['success' => true, 'message' => 'Connection successful', 'details' => []]);
+
+    $mockSshService = Mockery::mock(SshTunnelService::class);
+    $mockSshService->shouldReceive('close')->once();
+
+    $provider = Mockery::mock(DatabaseProvider::class, [new SftpFilesystem, $mockSshService])
+        ->makePartial();
+    $provider->shouldReceive('makeForServer')
+        ->once()
+        ->with(
+            Mockery::type(DatabaseServer::class),
+            'app_db',
+            Mockery::type('string'),
+            Mockery::type('int')
+        )
+        ->andReturn($mockHandler);
+
+    $server = DatabaseServer::forConnectionTest([
+        'database_type' => 'postgres',
+        'host' => 'db.example.com',
+        'port' => 5432,
+        'username' => 'user',
+        'password' => 'pass',
+        'extra_config' => ['connection_database' => 'app_db'],
+    ]);
+
+    expect($provider->testConnectionForServer($server)['success'])->toBeTrue();
+});
+
+test('connectionDatabase falls back to postgres', function (array $extraConfig, string $expected) {
+    expect(DatabaseProvider::connectionDatabase($extraConfig))->toBe($expected);
+})->with([
+    'unset' => [[], 'postgres'],
+    'empty string' => [['connection_database' => ''], 'postgres'],
+    'null' => [['connection_database' => null], 'postgres'],
+    'configured' => [['connection_database' => 'app_db'], 'app_db'],
+]);
+
+test('makeFromConfig passes connection_database to the postgres handler', function () {
+    $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
+        databaseType: DatabaseType::POSTGRESQL,
+        serverName: 'PG Server',
+        host: 'pg.example.com',
+        port: 5432,
+        username: 'postgres',
+        password: 'secret',
+        extraConfig: ['connection_database' => 'app_db'],
+    );
+
+    $database = (new DatabaseProvider)->makeFromConfig($config, 'myapp', 'pg.example.com', 5432);
+
+    expect((new ReflectionClass($database))->getProperty('config')->getValue($database))
+        ->toHaveKey('connection_database', 'app_db');
+});
+
 test('makeFromConfig builds correct config for SQLite with SSH array', function () {
     $config = new \App\Services\Backup\DTO\DatabaseConnectionConfig(
         databaseType: DatabaseType::SQLITE,

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -1,7 +1,9 @@
 <?php
 
+use App\Exceptions\Backup\ConnectionException;
 use App\Services\Backup\Databases\PostgresqlDatabase;
 use App\Services\Backup\DTO\DatabaseOperationResult;
+use App\Services\Backup\InMemoryBackupLogger;
 use Illuminate\Support\Facades\Process;
 
 beforeEach(function () {
@@ -246,4 +248,68 @@ test('testConnection returns failure when process fails', function () {
 
     expect($result['success'])->toBeFalse()
         ->and($result['message'])->toContain('connection refused');
+});
+
+test('admin connections use the configured connection database', function (?string $configured, string $expected) {
+    $db = new class extends PostgresqlDatabase
+    {
+        public string $connectedTo = '';
+
+        protected function createPdoForDatabase(string $database): PDO
+        {
+            $this->connectedTo = $database;
+
+            throw new PDOException('connection stubbed');
+        }
+    };
+
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'app',
+        'pass' => 'pg_secret',
+        // The target database, deliberately different from the connection one:
+        // listDatabases() must not connect here.
+        'database' => 'myapp',
+        'connection_database' => $configured,
+    ]);
+
+    expect(fn () => $db->listDatabases())->toThrow(PDOException::class)
+        ->and($db->connectedTo)->toBe($expected);
+})->with([
+    'configured' => ['app_db', 'app_db'],
+    'empty falls back' => ['', 'postgres'],
+    'null falls back' => [null, 'postgres'],
+]);
+
+test('prepareForRestore refuses to recreate the connection database', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'app',
+        'pass' => 'pg_secret',
+        'database' => 'app_db',
+        'connection_database' => 'app_db',
+    ]);
+
+    // No connection is opened: the conflict is decided before createPdo().
+    expect(fn () => $db->prepareForRestore('app_db', new InMemoryBackupLogger, forceDatabase: true))
+        ->toThrow(ConnectionException::class, 'it is also the connection database');
+});
+
+test('prepareForRestore allows recreating a database other than the connection one', function () {
+    $db = new PostgresqlDatabase;
+    $db->setConfig([
+        'host' => '127.0.0.1',
+        'port' => 1,
+        'user' => 'app',
+        'pass' => 'pg_secret',
+        'database' => 'other_db',
+        'connection_database' => 'app_db',
+    ]);
+
+    // Passes the guard and fails later, on the connection itself.
+    expect(fn () => $db->prepareForRestore('other_db', new InMemoryBackupLogger, forceDatabase: true))
+        ->toThrow(ConnectionException::class, 'Failed to prepare database');
 });


### PR DESCRIPTION
Fixes #545, fixes #549.

## Problem

Connection tests and database listing always opened the `postgres` database. Managed providers (Heroku, Amazon RDS, Neon) routinely withhold `CONNECT` on it, so a role that can only reach its own database gets stuck at:

```
Connection failed
psql: error: FATAL: permission denied for database "postgres"
DETAIL: User does not have CONNECT privilege.
```

The connection test is also what populates the database selector, so those users could not pick their database either.

## Why a field is needed

PostgreSQL refuses a connection that names no database, and libpq defaults the name to the username, which usually does not exist. Verified locally against a role with `CONNECT` revoked:

| attempt | result |
| --- | --- |
| `psql -d postgres` | `FATAL: permission denied for database "postgres"` |
| `psql` with no `-d` | `FATAL: database "limited" does not exist` |
| `psql -d template1` | `FATAL: permission denied for database "template1"` (revocable too) |
| `psql -d appdb` | works |

It does not have to be `postgres`, though. `pg_database` is a shared catalogue readable from any database on the cluster, so both the version probe and the listing work from elsewhere:

```
psql -d appdb -c 'select datname from pg_database'
-> databasement, appdb, postgres, ...   (all of them)
```

## Change

An optional **Connection database** field on the PostgreSQL connection section, stored in `extra_config` and defaulting to `postgres`. It sits beside "Use SSL":

```
┌─ Use SSL ───────────────────┬─ Connection database ───────┐
│ ☐ Use SSL                   │ [postgres              ]    │
│   Forces TLS (sslmode=...)  │ Opened to test the          │
│                             │ connection and list         │
│                             │ databases.                  │
└─────────────────────────────┴─────────────────────────────┘
```

It is honoured in both places that open a database the user does not choose:

- `DatabaseProvider::getConnectionDatabaseName()`, used by the connection test and `listDatabasesForServer()`
- `PostgresqlDatabase::createPdo()`, the admin connection behind `listDatabases()` and `prepareForRestore()`. This was hardcoded to `postgres` too, so it would have failed the same way on these servers.

Also accepted by the API for `postgres` servers, and translated into all four locales.

### Restore guard

Dropping the database the connection is open on can never work, so `prepareForRestore()` now reports that conflict up front rather than letting Postgres fail with `cannot drop the currently open database`. This is reachable once a user points the connection database at the single database they also restore into.

## Verification

Against a real role with `CONNECT` revoked on `postgres`:

| scenario | result |
| --- | --- |
| default (`postgres`) | `permission denied for database "postgres"` |
| connection database set to `appdb` | `Connection successful` |
| listing databases via `appdb` | all 6 returned, including `postgres` |

Plus unit and feature coverage: the field round-trips through the create and edit forms, `extra_config` folding for postgres only, the connection test and `makeFromConfig` passing it through, the admin PDO fallback, and both sides of the restore guard.

Pint clean, PHPStan 0 errors, 1502 tests passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional PostgreSQL “Connection database” field for connection testing and database listing.
  * Configured databases are now used when connecting, with `postgres` as the default.
  * Added localized labels and descriptions for the new setting.

* **Bug Fixes**
  * Prevented restore operations from attempting to recreate the database currently used for the connection.
  * Improved support for PostgreSQL environments where access to the default database is restricted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->