### PR TITLE
Fix encrypted restore for non-SQL dump extensions (#551)

### DIFF
--- a/app/Enums/DatabaseType.php
+++ b/app/Enums/DatabaseType.php
@@ -214,6 +214,27 @@ enum DatabaseType: string
     }
 
     /**
+     * Every extension {@see dumpExtension()} can produce, across all types and
+     * dump formats. Consumers that have to recognise a dump file without
+     * knowing which type produced it (the encrypted archive is extracted before
+     * the type is known) match against this set.
+     *
+     * @return array<string>
+     */
+    public static function dumpExtensions(): array
+    {
+        $extensions = [];
+
+        foreach (self::cases() as $type) {
+            foreach ([null, 'custom'] as $format) {
+                $extensions[] = $type->dumpExtension($format);
+            }
+        }
+
+        return array_values(array_unique($extensions));
+    }
+
+    /**
      * @return array<array{id: string, name: string}>
      */
     public static function toSelectOptions(): array

--- a/app/Services/Backup/Compressors/EncryptedCompressor.php
+++ b/app/Services/Backup/Compressors/EncryptedCompressor.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Compressors;
 
 use App\Enums\CompressionType;
+use App\Enums\DatabaseType;
 use App\Services\Backup\ShellProcessor;
 
 /**
@@ -77,9 +78,19 @@ class EncryptedCompressor extends BaseCompressor
         return $command;
     }
 
+    /**
+     * 7-Zip restores the archived file under its original basename, so the
+     * extracted dump is always `dump.<extension>` (see BackupTask). The
+     * extension depends on the database type and dump format, neither of which
+     * is known here, so every extension the enum can produce is accepted.
+     */
     public function getDecompressedPath(string $inputPath): string
     {
-        $targets = ['dump.sql', 'dump.db'];
+        $targets = array_map(
+            static fn (string $extension): string => 'dump.'.$extension,
+            DatabaseType::dumpExtensions(),
+        );
+
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($inputPath, \FilesystemIterator::SKIP_DOTS)
         );

--- a/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
+++ b/tests/Feature/Services/Backup/Compressors/EncryptedCompressorTest.php
@@ -71,3 +71,28 @@ test('encrypted compressor removes stale archive before compressing', function (
 
     unlink($compressedPath);
 });
+
+test('encrypted compressor locates the extracted dump for every dump extension', function (string $extension) {
+    $outputDir = sys_get_temp_dir().'/encrypted-decompress-'.uniqid();
+    mkdir($outputDir, 0755, true);
+    file_put_contents($outputDir.'/dump.'.$extension, 'extracted dump');
+
+    $compressor = new EncryptedCompressor($this->shellProcessor, 6, 'secret123');
+
+    expect($compressor->getDecompressedPath($outputDir))->toBe($outputDir.'/dump.'.$extension);
+
+    unlink($outputDir.'/dump.'.$extension);
+    rmdir($outputDir);
+})->with(\App\Enums\DatabaseType::dumpExtensions());
+
+test('encrypted compressor reports a missing dump when nothing was extracted', function () {
+    $outputDir = sys_get_temp_dir().'/encrypted-decompress-empty-'.uniqid();
+    mkdir($outputDir, 0755, true);
+
+    $compressor = new EncryptedCompressor($this->shellProcessor, 6, 'secret123');
+
+    expect(fn () => $compressor->getDecompressedPath($outputDir))
+        ->toThrow(RuntimeException::class, 'Decompression failed: output file not found');
+
+    rmdir($outputDir);
+});

--- a/tests/Feature/Services/Backup/RestoreTaskTest.php
+++ b/tests/Feature/Services/Backup/RestoreTaskTest.php
@@ -504,3 +504,50 @@ test('execute runs post-restore script with restore variables after successful r
         ->and($lastEnv)->toHaveKey('RESTORE_SOURCE_DATABASE', 'sourcedb')
         ->and($lastEnv)->toHaveKey('RESTORE_SNAPSHOT_FILENAME', 'backup.sql.gz');
 });
+
+test('execute restores an encrypted custom-format PostgreSQL snapshot', function () {
+    config(['backup.encryption_key' => 'base64:dGVzdGtleXRlc3RrZXl0ZXN0a2V5dGVzdGtleXRlc3Q=']);
+
+    $mockProvider = buildMockRestoreProvider();
+    setupDownloadMock();
+
+    $restoreTask = new RestoreTask(
+        $mockProvider,
+        $this->shellProcessor,
+        $this->filesystemProvider,
+        $this->compressorFactory,
+        $this->sshTunnelService,
+        new PostScriptRunner,
+    );
+
+    $config = new RestoreConfig(
+        targetServer: new DatabaseConnectionConfig(
+            databaseType: DatabaseType::POSTGRESQL,
+            serverName: 'Target Server',
+            host: 'localhost',
+            port: 5432,
+            username: 'postgres',
+            password: 'secret',
+        ),
+        snapshotVolume: buildSnapshotVolumeConfig(),
+        snapshotFilename: 'backup.dump.7z',
+        snapshotFileSize: 1024,
+        snapshotCompressionType: CompressionType::ENCRYPTED,
+        snapshotDatabaseType: DatabaseType::POSTGRESQL,
+        snapshotDatabaseName: 'sourcedb',
+        schemaName: 'restored_db',
+        workingDirectory: $this->tempDir.'/restore-custom-'.uniqid(),
+        snapshotDumpFormat: 'custom',
+    );
+    mkdir($config->workingDirectory, 0755, true);
+
+    $logger = new InMemoryBackupLogger;
+    $restoreTask->execute($config, $logger);
+
+    $successLogs = collect($logger->getLogs())
+        ->where('level', 'success')
+        ->pluck('message')
+        ->toArray();
+
+    expect($successLogs)->toContain('Restore completed successfully');
+});

--- a/tests/Support/TestShellProcessor.php
+++ b/tests/Support/TestShellProcessor.php
@@ -87,17 +87,14 @@ class TestShellProcessor extends ShellProcessor
 
         // For 7z extraction: extract archive path and create decompressed file
         // Matches: 7z x -y -o'/path' [-p'password'] '/path/file.ext'
-        // 7z extracts to the internal filename (dump.sql or dump.db), not based on archive name
         if (preg_match('/^7z\s+x\s+-y\s+-o[\'"]?([^\s\'"]+)[\'"]?\s+(?:-p[\'"]?[^\s\'"]*[\'"]?\s+)?[\'"]?([^\s\'"]+)[\'"]?$/', $command, $matches)) {
             $outputDir = $matches[1];
             $archivePath = $matches[2];
-            // For .db.gz or .db.7z archives, create dump.db
-            // For .sql.gz or .7z archives, create dump.sql
-            if (str_contains($archivePath, '.db.')) {
-                $decompressedPath = rtrim($outputDir, '/').'/dump.db';
-            } else {
-                $decompressedPath = rtrim($outputDir, '/').'/dump.sql';
-            }
+            // 7z restores the archived basename, which BackupTask always wrote
+            // as dump.<extension>. The archive is named <name>.<extension>.7z,
+            // so the dump extension is the archive's second-to-last suffix.
+            $extension = pathinfo(basename($archivePath, '.7z'), PATHINFO_EXTENSION) ?: 'sql';
+            $decompressedPath = rtrim($outputDir, '/').'/dump.'.$extension;
             file_put_contents($decompressedPath, "-- Fake decompressed data\nCREATE TABLE test (id INT);\n");
         }
     }


### PR DESCRIPTION
Fixes #551.

## Problem

`EncryptedCompressor::getDecompressedPath()` looked for the extracted dump under a hardcoded list of two names:

```php
$targets = ['dump.sql', 'dump.db'];
```

`BackupTask` names the dump `dump.<DatabaseType::dumpExtension()>`, and 7-Zip restores that basename. A PostgreSQL custom-format backup therefore extracts as `dump.dump`, which is not in the list, so every restore of an encrypted custom-format snapshot failed with:

```
Restore failed: Decompression failed: output file not found
```

The reporter identified the custom-format case. The same list also misses `rdb` (Redis), `archive` (MongoDB), `dacpac` (MSSQL) and `fbk` (Firebird), so encrypted restores were broken for those types too.

## Fix

The target list is now derived from the enum via a new `DatabaseType::dumpExtensions()`, which enumerates every extension `dumpExtension()` can return across all types and dump formats. Adding a database type no longer requires remembering to update the compressor.

## Tests

- `RestoreTaskTest`: end to end restore of an encrypted custom-format PostgreSQL snapshot. Reverting the compressor change makes it fail with the exact error from the issue.
- `EncryptedCompressorTest`: `getDecompressedPath()` resolves `dump.<ext>` for every extension in the catalogue, and still throws when nothing was extracted.
- `TestShellProcessor`'s 7z simulation now derives the extracted filename from the archive suffix instead of assuming `.sql` or `.db`, matching what 7-Zip actually does.

Full suite: 1496 passed. PHPStan and Pint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Encrypted backups now support all database dump formats and extensions.
  * Restoring encrypted custom-format PostgreSQL snapshots now completes successfully.
  * Improved handling when an extracted backup file is missing.

* **Tests**
  * Added coverage for encrypted decompression across supported dump types.
  * Added restore coverage for encrypted custom-format PostgreSQL backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->