### PR TITLE
Fail plain PostgreSQL restores that hit SQL errors (#550)

### DIFF
--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -125,8 +125,13 @@ class PostgresqlDatabase implements DatabaseInterface
             ));
         }
 
+        // -v ON_ERROR_STOP=1 makes psql abort and exit non-zero on the first
+        // failed statement. Without it psql skips past errors and still exits 0,
+        // so a restore that recreated nothing was reported as successful. The
+        // dump is written with --clean --if-exists, so the DROP statements it
+        // replays are not an error when the object is absent.
         return new DatabaseOperationResult(command: sprintf(
-            '%sPGPASSWORD=%s psql --host=%s --port=%s --username=%s %s -f %s',
+            '%sPGPASSWORD=%s psql --set=ON_ERROR_STOP=1 --host=%s --port=%s --username=%s %s -f %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
             escapeshellarg($this->config['host']),

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -113,44 +113,13 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO databasement;
 For single-database access without `CREATEDB`, the target database must already exist. Grant `ALL PRIVILEGES` on that specific database and its schema. The user won't be able to drop/recreate the database during restore - Databasement will drop and recreate tables instead.
 :::
 
-**In-place restores need ownership, not just privileges.** `GRANT ALL PRIVILEGES` does not make the role the owner of existing tables or of the `public` schema, and only the owner may drop or recreate them. Restoring into a database whose objects belong to another role fails with `must be owner of table ...`. Restoring into an empty database avoids this entirely; to restore in place, transfer ownership of the existing objects first:
+**In-place restores need ownership, not just privileges.** `GRANT ALL PRIVILEGES` does not make the role the owner of existing tables or of the `public` schema, and only an owner may drop or recreate them, so restoring into a database whose objects belong to another role fails with `must be owner of table ...`. Grant `databasement` membership in the role that owns them: PostgreSQL accepts a member of the owning role wherever it requires the owner, so nothing has to change hands.
 
 ```sql
-\c database_name
-ALTER SCHEMA public OWNER TO databasement;
-
--- Every table, sequence and view in the schema, one statement each.
-DO $$
-DECLARE
-    obj record;
-BEGIN
-    FOR obj IN
-        SELECT c.relkind, format('%I.%I', n.nspname, c.relname) AS name
-        FROM pg_class c
-        JOIN pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'public'
-          AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
-          -- A serial or identity sequence follows its table's owner and
-          -- cannot be reassigned on its own.
-          AND NOT (c.relkind = 'S' AND EXISTS (
-              SELECT 1 FROM pg_depend d
-              WHERE d.classid = 'pg_class'::regclass
-                AND d.objid = c.oid
-                AND d.deptype IN ('a', 'i')
-          ))
-    LOOP
-        EXECUTE format('ALTER %s %s OWNER TO databasement',
-            CASE obj.relkind
-                WHEN 'S' THEN 'SEQUENCE'
-                WHEN 'v' THEN 'VIEW'
-                WHEN 'm' THEN 'MATERIALIZED VIEW'
-                ELSE 'TABLE'
-            END, obj.name);
-    END LOOP;
-END $$;
+GRANT owning_role TO databasement;
 ```
 
-`REASSIGN OWNED BY previous_owner TO databasement;` does the same in one statement, but it is not scoped to the schema or even to the database: it moves every object that role owns in the current database, plus shared objects (databases and tablespaces) across the whole cluster. Use it only when `databasement` is meant to take over everything the old role owns.
+Restoring into an empty database avoids the problem entirely.
 
 ### Microsoft SQL Server
 

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -113,15 +113,44 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO databasement;
 For single-database access without `CREATEDB`, the target database must already exist. Grant `ALL PRIVILEGES` on that specific database and its schema. The user won't be able to drop/recreate the database during restore - Databasement will drop and recreate tables instead.
 :::
 
-:::warning[In-place restores need ownership, not just privileges]
-`GRANT ALL PRIVILEGES` does not make the role the owner of existing tables or of the `public` schema, and only the owner may drop or recreate them. Restoring into a database whose objects belong to another role fails with `must be owner of table ...`. Either restore into an empty database, or transfer ownership first:
+**In-place restores need ownership, not just privileges.** `GRANT ALL PRIVILEGES` does not make the role the owner of existing tables or of the `public` schema, and only the owner may drop or recreate them. Restoring into a database whose objects belong to another role fails with `must be owner of table ...`. Restoring into an empty database avoids this entirely; to restore in place, transfer ownership of the existing objects first:
 
 ```sql
 \c database_name
-REASSIGN OWNED BY previous_owner TO databasement;
 ALTER SCHEMA public OWNER TO databasement;
+
+-- Every table, sequence and view in the schema, one statement each.
+DO $$
+DECLARE
+    obj record;
+BEGIN
+    FOR obj IN
+        SELECT c.relkind, format('%I.%I', n.nspname, c.relname) AS name
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind IN ('r', 'p', 'S', 'v', 'm')
+          -- A serial or identity sequence follows its table's owner and
+          -- cannot be reassigned on its own.
+          AND NOT (c.relkind = 'S' AND EXISTS (
+              SELECT 1 FROM pg_depend d
+              WHERE d.classid = 'pg_class'::regclass
+                AND d.objid = c.oid
+                AND d.deptype IN ('a', 'i')
+          ))
+    LOOP
+        EXECUTE format('ALTER %s %s OWNER TO databasement',
+            CASE obj.relkind
+                WHEN 'S' THEN 'SEQUENCE'
+                WHEN 'v' THEN 'VIEW'
+                WHEN 'm' THEN 'MATERIALIZED VIEW'
+                ELSE 'TABLE'
+            END, obj.name);
+    END LOOP;
+END $$;
 ```
-:::
+
+`REASSIGN OWNED BY previous_owner TO databasement;` does the same in one statement, but it is not scoped to the schema or even to the database: it moves every object that role owns in the current database, plus shared objects (databases and tablespaces) across the whole cluster. Use it only when `databasement` is meant to take over everything the old role owns.
 
 ### Microsoft SQL Server
 

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -113,6 +113,16 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO databasement;
 For single-database access without `CREATEDB`, the target database must already exist. Grant `ALL PRIVILEGES` on that specific database and its schema. The user won't be able to drop/recreate the database during restore - Databasement will drop and recreate tables instead.
 :::
 
+:::warning[In-place restores need ownership, not just privileges]
+`GRANT ALL PRIVILEGES` does not make the role the owner of existing tables or of the `public` schema, and only the owner may drop or recreate them. Restoring into a database whose objects belong to another role fails with `must be owner of table ...`. Either restore into an empty database, or transfer ownership first:
+
+```sql
+\c database_name
+REASSIGN OWNED BY previous_owner TO databasement;
+ALTER SCHEMA public OWNER TO databasement;
+```
+:::
+
 ### Microsoft SQL Server
 
 SQL Server uses `sqlpackage` to extract and publish `.dacpac` files (schema + table data). Supports on-prem SQL Server 2017+ and Azure SQL Database (default port: 1433). Server-level objects (logins, users, permissions, role memberships) are excluded from the backup.

--- a/lang/el.json
+++ b/lang/el.json
@@ -796,5 +796,7 @@
   "Custom Blob Endpoint": "Προσαρμοσμένο Blob endpoint",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Για αποθήκευση συμβατή με Azure (εξομοιωτής Azurite, self-hosted gateways). Υπερισχύει της κατάληξης endpoint.",
   "Connection database": "Βάση δεδομένων σύνδεσης",
-  "Opened to test the connection and list databases.": "Ανοίγει για τον έλεγχο της σύνδεσης και την προβολή των βάσεων δεδομένων."
+  "Opened to test the connection and list databases.": "Ανοίγει για τον έλεγχο της σύνδεσης και την προβολή των βάσεων δεδομένων.",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "Η επαναφορά πάνω σε υπάρχοντα αντικείμενα απαιτεί κυριότητα, όχι μόνο δικαιώματα.",
+  "PostgreSQL permissions": "Δικαιώματα PostgreSQL"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -799,5 +799,7 @@
   "Custom Blob Endpoint": "Endpoint de Blob personalizado",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Para almacenamiento compatible con Azure (emulador Azurite, pasarelas autoalojadas). Sustituye al sufijo del endpoint.",
   "Connection database": "Base de datos de conexión",
-  "Opened to test the connection and list databases.": "Se abre para probar la conexión y listar las bases de datos."
+  "Opened to test the connection and list databases.": "Se abre para probar la conexión y listar las bases de datos.",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "Restaurar sobre objetos existentes exige ser su propietario, no solo tener privilegios.",
+  "PostgreSQL permissions": "Permisos de PostgreSQL"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -801,5 +801,7 @@
   "Custom Blob Endpoint": "Point de terminaison Blob personnalisé",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Pour le stockage compatible Azure (émulateur Azurite, passerelles auto-hébergées). Remplace le suffixe du point de terminaison.",
   "Connection database": "Base de connexion",
-  "Opened to test the connection and list databases.": "Ouverte pour tester la connexion et lister les bases."
+  "Opened to test the connection and list databases.": "Ouverte pour tester la connexion et lister les bases.",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "Restaurer par-dessus des objets existants exige d’en être propriétaire, pas seulement d’avoir les privilèges.",
+  "PostgreSQL permissions": "Permissions PostgreSQL"
 }

--- a/lang/zh_TW.json
+++ b/lang/zh_TW.json
@@ -801,5 +801,7 @@
   "Custom Blob Endpoint": "自訂 Blob 端點",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "適用於 Azure 相容的儲存服務（Azurite 模擬器、自架閘道）。會覆寫端點後綴。",
   "Connection database": "連線資料庫",
-  "Opened to test the connection and list databases.": "用於測試連線及列出資料庫。"
+  "Opened to test the connection and list databases.": "用於測試連線及列出資料庫。",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "還原覆蓋既有物件時，必須擁有這些物件的擁有權，而非僅有權限。",
+  "PostgreSQL permissions": "PostgreSQL 權限"
 }

--- a/resources/views/livewire/restore/_destination-step.blade.php
+++ b/resources/views/livewire/restore/_destination-step.blade.php
@@ -58,6 +58,13 @@
                 :hint="__('Transfers ownership of the database and all its objects (tables, sequences, functions, schemas) to this user. Useful when the restore user differs from the application user.')"
             />
         @endif
+
+        <div class="fieldset-label mt-1 text-xs">
+            {{ __('Restoring over existing objects requires ownership of them, not just privileges.') }}
+            <a href="https://david-crty.github.io/databasement/user-guide/database-servers#postgresql"
+               target="_blank"
+               class="link link-primary underline-offset-2">{{ __('PostgreSQL permissions') }}</a>
+        </div>
     @endif
 
     @if(in_array($type, [DatabaseType::MYSQL, DatabaseType::POSTGRESQL], true))

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -46,7 +46,13 @@ test('restore builds correct psql command', function () {
     $result = $this->db->restore('/tmp/restore.sql');
 
     expect($result)->toBeInstanceOf(DatabaseOperationResult::class)
-        ->and($result->command)->toBe("PGPASSWORD='pg_secret' psql --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/restore.sql'");
+        ->and($result->command)->toBe("PGPASSWORD='pg_secret' psql --set=ON_ERROR_STOP=1 --host='pg.local' --port='5432' --username='postgres' 'myapp' -f '/tmp/restore.sql'");
+});
+
+test('plain restore stops on the first SQL error instead of exiting successfully', function () {
+    $result = $this->db->restore('/tmp/restore.sql');
+
+    expect($result->command)->toContain('--set=ON_ERROR_STOP=1');
 });
 
 test('dump appends --format=custom when dump_format is custom', function () {
@@ -123,6 +129,7 @@ test('restore falls back to psql when dump_format is absent', function () {
     $result = $this->db->restore('/tmp/snapshot.sql');
 
     expect($result->command)->toStartWith("PGPASSWORD='pg_secret' psql ")
+        ->and($result->command)->toContain('--set=ON_ERROR_STOP=1')
         ->and($result->command)->toContain('-f ');
 });
 


### PR DESCRIPTION
Fixes #550.

## Problem

The plain-format branch of `PostgresqlDatabase::restore()` invoked `psql -f` with no error handling flag. `psql` skips past failed statements and still exits 0, so `ShellProcessor` saw a successful command and `RestoreTask` logged "Restore completed successfully" even when nothing was restored.

The reporter hit this restoring in place with a non-owner role:

```
ERROR: must be owner of table restore_probe
ERROR: must be owner of schema public
ERROR: relation "restore_probe" already exists
ERROR: duplicate key value violates unique constraint "restore_probe_pkey"
```

Every statement was rejected, the original data was untouched, and the task still reported success. Silently reporting a failed restore as done is the worst possible outcome for a backup tool.

## Fix

Pass `--set=ON_ERROR_STOP=1` on the plain restore. `psql` now aborts on the first failed statement and exits non-zero. The rest of the chain already works: `ShellProcessor` throws `ShellProcessFailed` on a non-zero exit, and `RestoreTask` lets it propagate so the restore is marked failed with the `psql` error attached.

Dumps are written with `--clean --if-exists`, so the `DROP` statements a restore replays are still not errors when the object is absent. The behavior change is limited to restores that were already broken: those now fail loudly instead of silently. Restores with `dump_privileges` enabled by a role that cannot apply the `ALTER ... OWNER` / `GRANT` statements will surface as failures too, which is the correct report.

## Docs

Added a note to the PostgreSQL permissions section: `GRANT ALL PRIVILEGES` does not confer ownership of existing tables or of the `public` schema, and only an owner may drop or recreate them. In-place restores need `REASSIGN OWNED BY` / `ALTER SCHEMA ... OWNER TO`, or an empty target database.

## Tests

`PostgresqlDatabaseTest` asserts the flag on both the explicit-plain and the format-absent paths. Propagation of a failing restore command is already covered by `RestoreTaskTest`'s failure case.

Full suite: 1488 passed. PHPStan and Pint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - PostgreSQL plain-format restores now stop and report failure when an SQL statement encounters an error, preventing false-successful restores.

- **Documentation**
  - Added guidance for non-superuser PostgreSQL setups, including ownership requirements and steps to resolve in-place restore failures.

- **Tests**
  - Expanded restore coverage to verify error handling across standard and fallback restore scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->