### PR TITLE
Link the PostgreSQL permissions guide from the restore modal

### DIFF
--- a/lang/el.json
+++ b/lang/el.json
@@ -796,5 +796,7 @@
   "Custom Blob Endpoint": "Προσαρμοσμένο Blob endpoint",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Για αποθήκευση συμβατή με Azure (εξομοιωτής Azurite, self-hosted gateways). Υπερισχύει της κατάληξης endpoint.",
   "Connection database": "Βάση δεδομένων σύνδεσης",
-  "Opened to test the connection and list databases.": "Ανοίγει για τον έλεγχο της σύνδεσης και την προβολή των βάσεων δεδομένων."
+  "Opened to test the connection and list databases.": "Ανοίγει για τον έλεγχο της σύνδεσης και την προβολή των βάσεων δεδομένων.",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "Η επαναφορά πάνω σε υπάρχοντα αντικείμενα απαιτεί κυριότητα, όχι μόνο δικαιώματα.",
+  "PostgreSQL permissions": "Δικαιώματα PostgreSQL"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -799,5 +799,7 @@
   "Custom Blob Endpoint": "Endpoint de Blob personalizado",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Para almacenamiento compatible con Azure (emulador Azurite, pasarelas autoalojadas). Sustituye al sufijo del endpoint.",
   "Connection database": "Base de datos de conexión",
-  "Opened to test the connection and list databases.": "Se abre para probar la conexión y listar las bases de datos."
+  "Opened to test the connection and list databases.": "Se abre para probar la conexión y listar las bases de datos.",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "Restaurar sobre objetos existentes exige ser su propietario, no solo tener privilegios.",
+  "PostgreSQL permissions": "Permisos de PostgreSQL"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -801,5 +801,7 @@
   "Custom Blob Endpoint": "Point de terminaison Blob personnalisé",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "Pour le stockage compatible Azure (émulateur Azurite, passerelles auto-hébergées). Remplace le suffixe du point de terminaison.",
   "Connection database": "Base de connexion",
-  "Opened to test the connection and list databases.": "Ouverte pour tester la connexion et lister les bases."
+  "Opened to test the connection and list databases.": "Ouverte pour tester la connexion et lister les bases.",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "Restaurer par-dessus des objets existants exige d’en être propriétaire, pas seulement d’avoir les privilèges.",
+  "PostgreSQL permissions": "Permissions PostgreSQL"
 }

--- a/lang/zh_TW.json
+++ b/lang/zh_TW.json
@@ -801,5 +801,7 @@
   "Custom Blob Endpoint": "自訂 Blob 端點",
   "For Azure-compatible storage (Azurite emulator, self-hosted gateways). Overrides the endpoint suffix.": "適用於 Azure 相容的儲存服務（Azurite 模擬器、自架閘道）。會覆寫端點後綴。",
   "Connection database": "連線資料庫",
-  "Opened to test the connection and list databases.": "用於測試連線及列出資料庫。"
+  "Opened to test the connection and list databases.": "用於測試連線及列出資料庫。",
+  "Restoring over existing objects requires ownership of them, not just privileges.": "還原覆蓋既有物件時，必須擁有這些物件的擁有權，而非僅有權限。",
+  "PostgreSQL permissions": "PostgreSQL 權限"
 }

--- a/resources/views/livewire/restore/_destination-step.blade.php
+++ b/resources/views/livewire/restore/_destination-step.blade.php
@@ -58,6 +58,13 @@
                 :hint="__('Transfers ownership of the database and all its objects (tables, sequences, functions, schemas) to this user. Useful when the restore user differs from the application user.')"
             />
         @endif
+
+        <div class="fieldset-label mt-1 text-xs">
+            {{ __('Restoring over existing objects requires ownership of them, not just privileges.') }}
+            <a href="https://david-crty.github.io/databasement/user-guide/database-servers#postgresql"
+               target="_blank"
+               class="link link-primary underline-offset-2">{{ __('PostgreSQL permissions') }}</a>
+        </div>
     @endif
 
     @if(in_array($type, [DatabaseType::MYSQL, DatabaseType::POSTGRESQL], true))


### PR DESCRIPTION
Restoring in place fails with `must be owner of table ...` when the restore user holds `GRANT ALL PRIVILEGES` but does not own the objects it has to drop and recreate (the situation behind #550). Nothing in the restore modal pointed that out, and the option sitting right there, "Transfer database ownership to user after restore", is about something else: handing ownership over once the restore has already succeeded.

Adds a hint line under the PostgreSQL options linking to the permissions section of the database servers guide.

Details:

- Uses the inline anchor style already used for docs links in the Backup configuration screen (`link link-primary underline-offset-2`, `target="_blank"`). The card-heading Documentation button does not apply here (the modal step has no card heading), and an alert with a Learn more action would put a second alert box next to the one the sibling branch already renders.
- Sits after the privileges `@if/@else` rather than inside it, so it shows whether or not the snapshot preserves privileges. The requirement applies either way.
- Uses a `fieldset-label` div rather than the input's `:hint`, because Mary renders `hint` through `{{ }}` and would escape the anchor. Same class Mary uses for hints, already used this way in `configuration/backup.blade.php`.
- Both strings added to all four locales, appended at the end of each file following the convention new keys have used.