### PR TITLE
Let a privilege-preserving restore set the database owner (#525)

### DIFF
--- a/app/Http/Controllers/Api/V1/DatabaseServerController.php
+++ b/app/Http/Controllers/Api/V1/DatabaseServerController.php
@@ -189,6 +189,8 @@ class DatabaseServerController extends Controller
      * Trigger a restore.
      *
      * Queues a restore job to restore a snapshot to the specified database server.
+     * `options.owner_user` names the PostgreSQL role the restored database is
+     * handed to, the same option the scheduled restores accept.
      *
      * @response 202
      */
@@ -207,11 +209,14 @@ class DatabaseServerController extends Controller
         /** @var int|null $userId */
         $userId = auth()->id();
 
+        $ownerUser = trim((string) $request->validated('options.owner_user'));
+
         $restore = $backupJobFactory->createRestore(
             snapshot: $snapshot,
             targetServer: $databaseServer,
             schemaName: $request->validated('schema_name'),
-            triggeredByUserId: $userId
+            triggeredByUserId: $userId,
+            options: array_filter(['owner_user' => $ownerUser]),
         );
 
         ProcessRestoreJob::dispatch($restore->id);

--- a/app/Http/Requests/Api/V1/RestoreRequest.php
+++ b/app/Http/Requests/Api/V1/RestoreRequest.php
@@ -29,6 +29,8 @@ class RestoreRequest extends FormRequest
         return [
             'snapshot_id' => ['required', 'string', 'exists:snapshots,id'],
             'schema_name' => $server->database_type->databaseNameRules(),
+            'options' => ['nullable', 'array'],
+            'options.owner_user' => ['nullable', 'string', 'max:255'],
         ];
     }
 

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -209,29 +209,70 @@ class PostgresqlDatabase implements DatabaseInterface
         }
     }
 
+    /**
+     * The statements that hand a restored database, and what the restore made
+     * inside it, to $owner. Also what the restore modals preview, so what the
+     * user is shown and what runs cannot drift apart.
+     *
+     * `database` always runs: pg_dump only ever describes the contents of a
+     * database, never the database itself, so after a restore it belongs to the
+     * role the restore connected as even when the dump preserved ownership.
+     * That is the one thing preserving privileges cannot cover, and the only
+     * thing left to do for such a snapshot — its objects come back under their
+     * original owners, so the restore role owns nothing to hand over, and
+     * REASSIGN OWNED BY is far too blunt to point at them anyway: it moves
+     * every object the role owns in the database plus shared objects
+     * cluster-wide. `objects` therefore only joins it for a portable dump, the
+     * one case where the restore role recreated what it is handing over.
+     *
+     * @param  string  $connectionUser  username the restore connects as
+     * @return array{database: string, objects?: string}
+     */
+    public static function ownershipStatements(string $schemaName, string $owner, string $connectionUser, bool $preservesPrivileges): array
+    {
+        $quote = static fn (string $identifier): string => '"'.str_replace('"', '""', $identifier).'"';
+
+        $statements = [
+            'database' => sprintf('ALTER DATABASE %s OWNER TO %s', $quote($schemaName), $quote($owner)),
+        ];
+
+        if (! $preservesPrivileges) {
+            $statements['objects'] = sprintf('REASSIGN OWNED BY %s TO %s', $quote($connectionUser), $quote($owner));
+        }
+
+        return $statements;
+    }
+
+    /**
+     * Hand the restored database to $username by running the statements
+     * {@see ownershipStatements()} settles on.
+     *
+     * The two run on different connections: the database is altered over the
+     * connection database, its objects reassigned from inside the restored one.
+     */
     public function transferOwnership(string $schemaName, string $username, BackupLogger $logger): void
     {
+        $statements = self::ownershipStatements(
+            $schemaName,
+            $username,
+            (string) $this->config['user'],
+            ! empty($this->config['dump_privileges']),
+        );
+
         try {
-            $safeUser = str_replace('"', '""', $username);
-            $safeDb = str_replace('"', '""', $schemaName);
-            $safeRestoreUser = str_replace('"', '""', $this->config['user']);
-
-            // Transfer database ownership
             $adminPdo = $this->createPdo();
-            $ownerCmd = "ALTER DATABASE \"{$safeDb}\" OWNER TO \"{$safeUser}\"";
-            $logger->logCommand($ownerCmd, null, 0);
-            $adminPdo->exec($ownerCmd);
+            $logger->logCommand($statements['database'], null, 0);
+            $adminPdo->exec($statements['database']);
 
-            // Reassign all objects from the restore connection user to the target user.
-            // Skip when users are the same (would be a no-op).
-            if ($this->config['user'] !== $username) {
-                $targetPdo = $this->createPdoForDatabase($schemaName);
-                $reassignCmd = "REASSIGN OWNED BY \"{$safeRestoreUser}\" TO \"{$safeUser}\"";
-                $logger->logCommand($reassignCmd, null, 0);
-                $targetPdo->exec($reassignCmd);
-            } else {
-                $logger->log('Restore user and target user are the same, skipping object reassignment');
+            if (! isset($statements['objects'])) {
+                $logger->log('Snapshot carries its own ownership information, leaving the owners of the restored objects untouched');
+
+                return;
             }
+
+            $targetPdo = $this->createPdoForDatabase($schemaName);
+            $logger->logCommand($statements['objects'], null, 0);
+            $targetPdo->exec($statements['objects']);
         } catch (\PDOException $e) {
             throw new ConnectionException("Failed to transfer ownership: {$e->getMessage()}", 0, $e);
         }

--- a/lang/el.json
+++ b/lang/el.json
@@ -798,5 +798,9 @@
   "Connection database": "Βάση δεδομένων σύνδεσης",
   "Opened to test the connection and list databases.": "Ανοίγει για τον έλεγχο της σύνδεσης και την προβολή των βάσεων δεδομένων.",
   "Restoring over existing objects requires ownership of them, not just privileges.": "Η επαναφορά πάνω σε υπάρχοντα αντικείμενα απαιτεί κυριότητα, όχι μόνο δικαιώματα.",
-  "PostgreSQL permissions": "Δικαιώματα PostgreSQL"
+  "PostgreSQL permissions": "Δικαιώματα PostgreSQL",
+  "Transfer database ownership to user after restore": "Μεταβίβαση της ιδιοκτησίας της Βάσης Δεδομένων σε αυτόν τον χρήστη μετά το restore",
+  "Set database owner after restore": "Ορισμός του ιδιοκτήτη της Βάσης Δεδομένων μετά το restore",
+  "PostgreSQL username (leave empty to skip)": "Όνομα χρήστη PostgreSQL (αφήστε κενό για παράλειψη)",
+  "This SQL will be run after the restore:": "Αυτό το SQL θα εκτελεστεί μετά το restore:"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -801,5 +801,9 @@
   "Connection database": "Base de datos de conexión",
   "Opened to test the connection and list databases.": "Se abre para probar la conexión y listar las bases de datos.",
   "Restoring over existing objects requires ownership of them, not just privileges.": "Restaurar sobre objetos existentes exige ser su propietario, no solo tener privilegios.",
-  "PostgreSQL permissions": "Permisos de PostgreSQL"
+  "PostgreSQL permissions": "Permisos de PostgreSQL",
+  "Transfer database ownership to user after restore": "Transferir la propiedad de la base de datos a este usuario tras el restore",
+  "Set database owner after restore": "Definir el propietario de la base de datos tras el restore",
+  "PostgreSQL username (leave empty to skip)": "Nombre de usuario de PostgreSQL (dejar vacío para omitir)",
+  "This SQL will be run after the restore:": "Este SQL se ejecutará tras el restore:"
 }

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -803,5 +803,9 @@
   "Connection database": "Base de connexion",
   "Opened to test the connection and list databases.": "Ouverte pour tester la connexion et lister les bases.",
   "Restoring over existing objects requires ownership of them, not just privileges.": "Restaurer par-dessus des objets existants exige d’en être propriétaire, pas seulement d’avoir les privilèges.",
-  "PostgreSQL permissions": "Permissions PostgreSQL"
+  "PostgreSQL permissions": "Permissions PostgreSQL",
+  "Transfer database ownership to user after restore": "Transférer la propriété de la base à cet utilisateur après le restore",
+  "Set database owner after restore": "Définir le propriétaire de la base après le restore",
+  "PostgreSQL username (leave empty to skip)": "Nom d’utilisateur PostgreSQL (laisser vide pour ignorer)",
+  "This SQL will be run after the restore:": "Ce SQL sera exécuté après le restore :"
 }

--- a/lang/zh_TW.json
+++ b/lang/zh_TW.json
@@ -803,5 +803,9 @@
   "Connection database": "連線資料庫",
   "Opened to test the connection and list databases.": "用於測試連線及列出資料庫。",
   "Restoring over existing objects requires ownership of them, not just privileges.": "還原覆蓋既有物件時，必須擁有這些物件的擁有權，而非僅有權限。",
-  "PostgreSQL permissions": "PostgreSQL 權限"
+  "PostgreSQL permissions": "PostgreSQL 權限",
+  "Transfer database ownership to user after restore": "Restore 後將資料庫擁有權轉移給此使用者",
+  "Set database owner after restore": "Restore 後設定資料庫擁有者",
+  "PostgreSQL username (leave empty to skip)": "PostgreSQL 使用者名稱（留空則略過）",
+  "This SQL will be run after the restore:": "Restore 後將執行以下 SQL："
 }

--- a/resources/views/livewire/restore/_destination-step.blade.php
+++ b/resources/views/livewire/restore/_destination-step.blade.php
@@ -1,4 +1,7 @@
-@php use App\Enums\DatabaseType; @endphp
+@php
+    use App\Enums\DatabaseType;
+    use App\Services\Backup\Databases\PostgresqlDatabase;
+@endphp
 {{--
     Shared "destination" step for the restore modals: choose the target server
     (unless it is locked), the destination database name (type-ahead), and the
@@ -12,12 +15,14 @@
     Params:
       $targetLocked (bool) - when true the target is fixed; hide the select
       $snapshotPreservesPrivileges (bool, optional) - when true the snapshot was
-          dumped with ownership/privilege information, so the post-restore
-          ownership transfer option is hidden (the dump itself sets owners)
+          dumped with ownership/privilege information, so the restore sets the
+          owners of the objects itself and the post-restore option narrows to
+          the database's own owner (which no dump carries)
 --}}
 @php
     $type = $this->targetServer?->database_type;
     $isSqlite = $type === DatabaseType::SQLITE;
+    $preservesPrivileges = $snapshotPreservesPrivileges ?? false;
 @endphp
 
 @unless($targetLocked)
@@ -46,17 +51,30 @@
     @endif
 
     @if($type === DatabaseType::POSTGRESQL)
-        @if($snapshotPreservesPrivileges ?? false)
-            <x-alert class="alert-info" icon="o-information-circle">
-                {{ __('This snapshot includes ownership and privilege information; original owners and grants will be applied by the restore itself.') }}
-            </x-alert>
-        @else
-            <x-input
-                wire:model="ownerUser"
-                :label="__('Transfer database ownership to user after restore')"
-                :placeholder="__('PostgreSQL username (leave empty to skip)')"
-                :hint="__('Transfers ownership of the database and all its objects (tables, sequences, functions, schemas) to this user. Useful when the restore user differs from the application user.')"
-            />
+        <x-input
+            wire:model.live.debounce.300ms="ownerUser"
+            :label="$preservesPrivileges
+                ? __('Set database owner after restore')
+                : __('Transfer database ownership to user after restore')"
+            :placeholder="__('PostgreSQL username (leave empty to skip)')"
+        />
+
+        {{-- Named owner only: an empty field skips the transfer altogether. --}}
+        @php
+            $owner = trim($ownerUser);
+            $ownershipStatements = $owner === '' ? [] : PostgresqlDatabase::ownershipStatements(
+                $schemaName,
+                $owner,
+                (string) $this->targetServer?->username,
+                $preservesPrivileges,
+            );
+        @endphp
+
+        @if($ownershipStatements)
+            <div class="fieldset-label mt-1 block text-xs">
+                {{ __('This SQL will be run after the restore:') }}
+                <pre class="bg-base-200 rounded-box mt-1 overflow-x-auto p-3"><code class="select-all">{{ implode(PHP_EOL, $ownershipStatements) }}</code></pre>
+            </div>
         @endif
 
         <div class="fieldset-label mt-1 text-xs">

--- a/tests/Feature/Api/RestoreApiTest.php
+++ b/tests/Feature/Api/RestoreApiTest.php
@@ -3,6 +3,7 @@
 use App\Enums\Ability;
 use App\Jobs\ProcessRestoreJob;
 use App\Models\DatabaseServer;
+use App\Models\Restore;
 use App\Models\Snapshot;
 use App\Models\User;
 use Illuminate\Support\Facades\Queue;
@@ -120,4 +121,39 @@ test('restore rejects nonexistent snapshot', function () {
 
     $response->assertUnprocessable()
         ->assertJsonValidationErrors(['snapshot_id']);
+});
+
+test('restore hands the restored database to the owner_user option', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::OperateRestores->value])->create();
+    $server = DatabaseServer::factory()->create(['database_type' => 'postgres']);
+    $snapshot = Snapshot::factory()->forServer($server)->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->postJson("/api/v1/database-servers/{$server->id}/restore", [
+            'snapshot_id' => $snapshot->id,
+            'schema_name' => 'target_db',
+            'options' => ['owner_user' => 'webapp'],
+        ]);
+
+    $response->assertStatus(202);
+
+    expect(Restore::firstOrFail()->getOption('owner_user'))->toBe('webapp');
+});
+
+test('restore leaves ownership alone when no owner_user is given', function () {
+    Queue::fake();
+
+    $user = User::factory()->withAbilities([Ability::OperateRestores->value])->create();
+    $server = DatabaseServer::factory()->create(['database_type' => 'postgres']);
+    $snapshot = Snapshot::factory()->forServer($server)->create();
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson("/api/v1/database-servers/{$server->id}/restore", [
+            'snapshot_id' => $snapshot->id,
+            'schema_name' => 'target_db',
+        ])->assertStatus(202);
+
+    expect(Restore::firstOrFail()->getOption('owner_user'))->toBeNull();
 });

--- a/tests/Feature/Livewire/Restore/ModalTest.php
+++ b/tests/Feature/Livewire/Restore/ModalTest.php
@@ -461,3 +461,55 @@ test('rejects a source copy that does not belong to the selected snapshot', func
 
     Queue::assertNothingPushed();
 });
+
+// The ownership option used to be swapped for a bare notice on snapshots dumped
+// with ownership and privilege information, which left the reporter of #525 —
+// who runs exactly that setup — with no way to say who owns the restored
+// database. No dump carries that, so the field stays; only its reach narrows.
+test('destination step offers a database owner field whatever the snapshot preserves', function (bool $preservesPrivileges, string $label) {
+    $target = DatabaseServer::factory()->create(['database_type' => 'postgres', 'username' => 'databasement']);
+    $source = DatabaseServer::factory()->create(['database_type' => 'postgres']);
+    $snapshot = Snapshot::factory()->forServer($source)->withFile()->create([
+        'metadata' => $preservesPrivileges ? ['dump_privileges' => true] : [],
+    ]);
+
+    $component = Livewire::test(Modal::class)
+        ->dispatch('open-restore-modal', mode: 'from-server', targetServerId: $target->id)
+        ->call('selectSnapshot', $snapshot->id)
+        ->assertSee($label)
+        // Nothing runs until an owner is named, so nothing is previewed either.
+        ->assertDontSee('ALTER DATABASE')
+        ->set('schemaName', 'restored_db')
+        ->set('ownerUser', 'webapp')
+        ->assertSee('ALTER DATABASE "restored_db" OWNER TO "webapp"');
+
+    // The reassignment is announced only where it runs: a snapshot that carries
+    // its own owners restores its objects under them, leaving nothing to move.
+    if ($preservesPrivileges) {
+        $component->assertDontSee('REASSIGN OWNED BY');
+    } else {
+        $component->assertSee('REASSIGN OWNED BY "databasement" TO "webapp"');
+    }
+})->with([
+    'snapshot preserving ownership' => [true, 'Set database owner after restore'],
+    'portable snapshot' => [false, 'Transfer database ownership to user after restore'],
+]);
+
+test('the owner of a privilege-preserving restore reaches the queued job', function () {
+    Queue::fake();
+
+    $target = DatabaseServer::factory()->create(['database_type' => 'postgres']);
+    $source = DatabaseServer::factory()->create(['database_type' => 'postgres']);
+    $snapshot = Snapshot::factory()->forServer($source)->withFile()->create([
+        'metadata' => ['dump_privileges' => true],
+    ]);
+
+    Livewire::test(Modal::class)
+        ->dispatch('open-restore-modal', mode: 'from-server', targetServerId: $target->id)
+        ->call('selectSnapshot', $snapshot->id)
+        ->set('schemaName', 'restored_db')
+        ->set('ownerUser', 'webapp')
+        ->call('restore');
+
+    expect(Restore::firstOrFail()->getOption('owner_user'))->toBe('webapp');
+});

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -320,3 +320,46 @@ test('prepareForRestore allows recreating a database other than the connection o
     expect(fn () => $db->prepareForRestore('other_db', new InMemoryBackupLogger, forceDatabase: true))
         ->toThrow(ConnectionException::class, 'Failed to prepare database');
 });
+
+/** A handler whose connections are the given mocks, configured to restore as `databasement`. */
+function postgresHandlerConnectingWith(PDO $adminPdo, bool $dumpPrivileges): PostgresqlDatabase
+{
+    $db = Mockery::mock(PostgresqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldReceive('createPdo')->once()->andReturn($adminPdo);
+    $db->setConfig([
+        'host' => 'pg.local',
+        'port' => 5432,
+        'user' => 'databasement',
+        'pass' => 'pg_secret',
+        'database' => 'restored_db',
+        'dump_privileges' => $dumpPrivileges,
+    ]);
+
+    return $db;
+}
+
+test('ownership transfer hands the database over and reassigns what a portable restore created', function () {
+    $adminPdo = Mockery::mock(PDO::class);
+    $adminPdo->shouldReceive('exec')->once()->with('ALTER DATABASE "restored_db" OWNER TO "webapp"');
+
+    $targetPdo = Mockery::mock(PDO::class);
+    $targetPdo->shouldReceive('exec')->once()->with('REASSIGN OWNED BY "databasement" TO "webapp"');
+
+    $db = postgresHandlerConnectingWith($adminPdo, dumpPrivileges: false);
+    $db->shouldReceive('createPdoForDatabase')->once()->with('restored_db')->andReturn($targetPdo);
+
+    $db->transferOwnership('restored_db', 'webapp', new InMemoryBackupLogger);
+});
+
+// A privilege-preserving snapshot restores its objects under their original
+// owners, so only the database itself is left to hand over: pg_dump never
+// describes the database, whatever the snapshot preserved (#525).
+test('ownership transfer leaves the restored objects alone for a snapshot that carries its own owners', function () {
+    $adminPdo = Mockery::mock(PDO::class);
+    $adminPdo->shouldReceive('exec')->once()->with('ALTER DATABASE "restored_db" OWNER TO "webapp"');
+
+    $db = postgresHandlerConnectingWith($adminPdo, dumpPrivileges: true);
+    $db->shouldNotReceive('createPdoForDatabase');
+
+    $db->transferOwnership('restored_db', 'webapp', new InMemoryBackupLogger);
+});


### PR DESCRIPTION
Closes the second half of #525.

## The problem

A snapshot dumped with **Backup ownership and privilege information** hid the post-restore ownership field entirely, on the grounds that the dump sets the owners itself. That holds for the objects, not for the database.

`pg_dump` describes the *contents* of a database, never the database itself (we pass no `--create`), so after a restore the database belongs to whichever role the restore connected as, whatever the snapshot preserved. Users of that option, which is exactly the reporter's setup, had no way to say who owns the restored database.

## What changed

**The field renders for both kinds of snapshot**, labelled for what it can reach in each:

| Snapshot | Label | Runs |
|---|---|---|
| preserves ownership | Set database owner after restore | `ALTER DATABASE ... OWNER TO ...` |
| portable | Transfer database ownership to user after restore | the above, then `REASSIGN OWNED BY ... TO ...` |

The reassignment stops at privilege-preserving snapshots because their objects come back under their original owners, leaving the restore role nothing to hand over, and because `REASSIGN OWNED BY` moves every object the role owns in the database plus shared objects cluster-wide. That is why it was dropped from the docs recipe in #562.

**One source of truth.** `PostgresqlDatabase::ownershipStatements()` decides which statements a transfer consists of and renders their SQL. `transferOwnership()` executes them and the destination step previews them, so what the user is shown and what runs cannot drift apart. The preview appears under the field as soon as an owner is named:

```
This SQL will be run after the restore:
  ALTER DATABASE "staging" OWNER TO "webapp"
  REASSIGN OWNED BY "databasement" TO "webapp"
```

The old same-user check went with the refactor: `REASSIGN OWNED BY x TO x` is accepted as a no-op (verified on PostgreSQL 17), so skipping it bought nothing.

**API.** The one-off restore endpoint now accepts `options.owner_user`, the option scheduled restores already take, since the reporter drives Databasement declaratively rather than through the UI:

```
POST /api/v1/database-servers/{id}/restore
{"snapshot_id": "...", "schema_name": "staging", "options": {"owner_user": "webapp"}}
```

`options.force_database` is still not accepted there. Happy to add it if you want the two endpoints fully aligned.

## Tests

- `PostgresqlDatabaseTest`: a portable transfer issues both statements on their respective connections; a privilege-preserving one issues only `ALTER DATABASE` and never opens the second connection.
- `ModalTest`: the field and the correct preview render for both snapshot kinds, nothing is previewed until an owner is named, and the owner reaches the queued restore.
- `RestoreApiTest`: `options.owner_user` lands on the restore, and stays null when omitted.

`1528 passed`, Pint and PHPStan clean. Translations added to all four locales.

## Note on part 1 of the issue

Configuring `dump_privileges` from Helm values is not part of this PR. That setting already ships as a first-class field on the database-server API, which is the supported path for declarative setup and covers the whole server definition rather than one checkbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - PostgreSQL restores now let you specify a database owner or ownership-transfer user.
  - The restore screen previews the SQL statements that will run after restoration.
  - Ownership handling now adapts to whether the backup preserves privileges.

- **Bug Fixes**
  - PostgreSQL object ownership is reassigned correctly for backups that do not preserve privileges.
  - Selected ownership settings are retained when restoring through the API or interface.

- **Localization**
  - Added translated PostgreSQL restore ownership labels and guidance in Greek, Spanish, French, and Traditional Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->