### PR TITLE
Fix wire:navigate dying on the version modal tabs

### DIFF
--- a/app/Livewire/VersionStatus.php
+++ b/app/Livewire/VersionStatus.php
@@ -17,8 +17,6 @@ class VersionStatus extends Component
 
     public bool $showModal = false;
 
-    public string $updateInstructionsTab = 'docker-compose-tab';
-
     public string $dockerComposeCommand = "docker compose pull\ndocker compose up -d";
 
     public string $helmCommand = "helm repo update\nhelm upgrade databasement databasement/databasement";

--- a/resources/views/livewire/version-status.blade.php
+++ b/resources/views/livewire/version-status.blade.php
@@ -89,10 +89,15 @@
             </x-alert>
         @endif
 
-        <x-tabs wire:model="updateInstructionsTab" label-class="tabs-sm">
+        <div class="tabs tabs-border tabs-sm">
 
             {{-- Docker Compose tab --}}
-            <x-tab name="docker-compose-tab" :label="__('Docker Compose')" icon="devicon.docker">
+            <label class="tab gap-2">
+                <input type="radio" name="update-instructions" checked/>
+                <x-icon name="devicon.docker"/>
+                {{ __('Docker Compose') }}
+            </label>
+            <div class="tab-content px-3 py-5">
                 <div class="flex items-center justify-between mb-1.5">
                     <p class="text-sm opacity-70">
                         {{ __('Run from the folder where your docker-compose.yml is located') }}
@@ -106,10 +111,15 @@
                     />
                 </div>
                 <pre class="bg-neutral text-neutral-content rounded-box p-5 text-sm overflow-x-auto"><code class="break-all select-all whitespace-pre-wrap">{{ $dockerComposeCommand }}</code></pre>
-            </x-tab>
+            </div>
 
             {{-- Helm / Kubernetes tab --}}
-            <x-tab name="helm-tab" :label="__('Helm / Kubernetes')" icon="devicon.kubernetes">
+            <label class="tab gap-2">
+                <input type="radio" name="update-instructions"/>
+                <x-icon name="devicon.kubernetes"/>
+                {{ __('Helm / Kubernetes') }}
+            </label>
+            <div class="tab-content px-3 py-5">
                 <div class="flex items-center justify-between mb-1.5">
                     <p class="text-sm opacity-70">
                         {{ __('Update the Helm repository and upgrade the release') }}
@@ -123,10 +133,15 @@
                     />
                 </div>
                 <pre class="bg-neutral text-neutral-content rounded-box p-5 text-sm overflow-x-auto"><code class="break-all select-all whitespace-pre-wrap">{{ $helmCommand }}</code></pre>
-            </x-tab>
+            </div>
 
             {{-- Docker tab --}}
-            <x-tab name="docker-tab" :label="__('Docker')" icon="devicon.docker">
+            <label class="tab gap-2">
+                <input type="radio" name="update-instructions"/>
+                <x-icon name="devicon.docker"/>
+                {{ __('Docker') }}
+            </label>
+            <div class="tab-content px-3 py-5">
                 <div class="flex items-center justify-between mb-1.5">
                     <p class="text-sm opacity-70">
                         {{ __('Run from the folder where your .env file is located') }}
@@ -140,9 +155,9 @@
                     />
                 </div>
                 <pre class="bg-neutral text-neutral-content rounded-box p-5 text-sm overflow-x-auto"><code class="break-all select-all whitespace-pre-wrap">{{ $dockerCommand }}</code></pre>
-            </x-tab>
+            </div>
 
-        </x-tabs>
+        </div>
 
         <x-slot:actions>
             <x-button :label="__('Done')" class="btn-primary" @click="$wire.showModal = false" />


### PR DESCRIPTION
Since v1.7.4, navigating between pages randomly kills the SPA: nothing responds until a manual refresh, with this in the console.

```
Alpine Warning: Cannot find x-teleport element for selector: "#mary...updateInstructionsTab-labels"
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'appendChild')
    at placeInDom
    at el._x_teleportPutBack
    at unPackPersistedTeleports
    at putPersistantElementsBack
    at swapCurrentPageWithNewHtml
```

v1.7.4 bumped Mary 2.9.3 to 2.9.9, and that range rewrote `x-tabs` to teleport its labels into a container rendered by `x-tabs` itself. Before, the labels were moved with a plain `appendChild`, so there was no teleport in play.

`<livewire:version-status />` sits inside the layout's `@persist` block, and Livewire's persist puts teleports back before it re-attaches the persisted element:

```js
callback(old, i);                            // unPackPersistedTeleports(old)
Alpine.mutateDom(() => { i.replaceWith(old) });
```

`_x_teleportPutBack` resolves the target with `document.querySelector`, which cannot see inside the still-detached element. The component is `#[Lazy]`, so the incoming page only carries its placeholder and no matching container either. Target null, `appendChild` throws, and the exception aborts the swap before Alpine is initialised on the new page.

The fix keeps the same UI with plain daisyUI radio tabs: no teleport, no Alpine, no round trip when switching tab. The selected tab was never read server side, so `$updateInstructionsTab` goes with it.

`agent/_token-modal.blade.php` also uses `x-tabs`, but it is not inside a persisted element, so it stays on Mary.

Reported upstream: livewire/livewire#10652


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the update-instructions tab controls for more reliable switching.
  * Tab selection now works directly in the browser without requiring additional application state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->