### PR TITLE
Scope ssh_config_id validation to the current organization

### DIFF
--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -56,7 +56,7 @@ class SaveDatabaseServerRequest extends FormRequest
             'database_type' => ['required', 'string', Rule::in(array_map(fn (DatabaseType $t) => $t->value, DatabaseType::cases()))],
             'description' => 'nullable|string|max:1000',
             'backups_enabled' => 'boolean',
-            'ssh_config_id' => 'nullable|exists:database_server_ssh_configs,id',
+            'ssh_config_id' => ['nullable', Rule::exists('database_server_ssh_configs', 'id')->where('organization_id', app(CurrentOrganization::class)->id())],
             'agent_id' => ['nullable', Rule::exists('agents', 'id')->where('organization_id', app(CurrentOrganization::class)->id())],
             'managed_by' => 'nullable|string|max:255',
         ];

--- a/tests/Feature/Api/DatabaseServerCrudApiTest.php
+++ b/tests/Feature/Api/DatabaseServerCrudApiTest.php
@@ -4,6 +4,7 @@ use App\Enums\Ability;
 use App\Models\BackupSchedule;
 use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
+use App\Models\Organization;
 use App\Models\User;
 use App\Models\Volume;
 use App\Services\Backup\Databases\DatabaseProvider;
@@ -349,6 +350,35 @@ test('update attaches an ssh config to a server that has none', function () {
         ->assertJsonPath('data.ssh_config_id', $sshConfig->id);
 
     expect($server->fresh()->sshConfig->host)->toBe('bastion.example.com');
+});
+
+test('an ssh config from another organization is rejected', function () {
+    $user = User::factory()->withAbilities([Ability::ManageDatabaseServers->value])->create();
+    $foreignOrg = Organization::factory()->create();
+    $foreignConfig = DatabaseServerSshConfig::factory()->create(['organization_id' => $foreignOrg->id]);
+    $volume = Volume::factory()->local()->create();
+    $schedule = BackupSchedule::firstOrCreate(['name' => 'Daily'], ['expression' => '0 2 * * *']);
+
+    $this->actingAs($user, 'sanctum')
+        ->postJson('/api/v1/database-servers', [
+            'name' => 'Tunnelled',
+            'database_type' => 'mysql',
+            'host' => 'localhost',
+            'port' => 3306,
+            'username' => 'root',
+            'ssh_config_id' => $foreignConfig->id,
+            'backups' => [[
+                'database_selection_mode' => 'all',
+                'volume_id' => $volume->id,
+                'backup_schedule_id' => $schedule->id,
+                'retention_policy' => 'days',
+                'retention_days' => 14,
+            ]],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('ssh_config_id');
+
+    expect(DatabaseServer::withoutGlobalScopes()->where('name', 'Tunnelled')->exists())->toBeFalse();
 });
 
 test('blank password keeps existing password on update', function () {


### PR DESCRIPTION
The database-server API validated `ssh_config_id` with a bare `exists:database_server_ssh_configs,id`. That queries the table directly, so the model's organization scope does not apply and a config belonging to another organization is accepted.

The sibling `agent_id` rule already constrains its lookup to the caller's organization. This applies the same constraint to `ssh_config_id` so the two behave consistently.

The Livewire form is unaffected: it resolves the config through `DatabaseServerSshConfig::find()`, which is scoped.

Adds API tests covering create and update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database server SSH configuration validation now ensures the selected configuration belongs to the current organization.
  * Invalid cross-organization SSH configuration selections are rejected with a validation error.
  * Database servers are not created when an unauthorized SSH configuration is submitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->