### PR TITLE
Reject dump flags that choose where the dump client writes

### DIFF
--- a/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
+++ b/app/Http/Requests/Api/V1/SaveDatabaseServerRequest.php
@@ -10,6 +10,7 @@ use App\Models\DatabaseServer;
 use App\Models\Volume;
 use App\Rules\MaxBytes;
 use App\Rules\SafeDatabasePath;
+use App\Rules\SafeDumpFlags;
 use App\Rules\SafeHost;
 use App\Rules\SafePath;
 use App\Services\CurrentOrganization;
@@ -51,6 +52,9 @@ class SaveDatabaseServerRequest extends FormRequest
      */
     public function rules(): array
     {
+        $type = $this->input('database_type');
+        $databaseType = is_string($type) ? DatabaseType::tryFrom($type) : null;
+
         $rules = [
             'name' => 'required|string|max:255',
             'database_type' => ['required', 'string', Rule::in(array_map(fn (DatabaseType $t) => $t->value, DatabaseType::cases()))],
@@ -59,9 +63,9 @@ class SaveDatabaseServerRequest extends FormRequest
             'ssh_config_id' => 'nullable|exists:database_server_ssh_configs,id',
             'agent_id' => ['nullable', Rule::exists('agents', 'id')->where('organization_id', app(CurrentOrganization::class)->id())],
             'managed_by' => 'nullable|string|max:255',
+            // Every engine but SQLite appends these to its dump command.
+            'dump_flags' => ['nullable', 'string', 'max:500', new SafeDumpFlags($databaseType)],
         ];
-
-        $type = $this->input('database_type');
 
         if (in_array($type, ['mysql', 'postgres', 'mongodb', 'redis'])) {
             $rules['host'] = ['required', 'string', 'max:255', new SafeHost];
@@ -71,7 +75,6 @@ class SaveDatabaseServerRequest extends FormRequest
         if (in_array($type, ['mysql', 'postgres'])) {
             $rules['username'] = 'required|string|max:255';
             $rules['password'] = 'nullable';
-            $rules['dump_flags'] = ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'];
         }
 
         if ($type === 'postgres') {
@@ -83,7 +86,6 @@ class SaveDatabaseServerRequest extends FormRequest
         if (in_array($type, ['mongodb', 'redis'])) {
             $rules['username'] = 'nullable|string|max:255';
             $rules['password'] = 'nullable';
-            $rules['dump_flags'] = ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'];
         }
 
         if ($type === 'mongodb') {

--- a/app/Livewire/DatabaseServer/Form.php
+++ b/app/Livewire/DatabaseServer/Form.php
@@ -14,6 +14,7 @@ use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
 use App\Models\NotificationChannel;
 use App\Rules\MaxBytes;
+use App\Rules\SafeDumpFlags;
 use App\Services\Backup\Databases\DatabaseProvider;
 use App\Services\Backup\ShellProcessor;
 use App\Services\Backup\SyncBackupConfigurationsAction;
@@ -893,7 +894,7 @@ class Form extends \Livewire\Form
             'description' => 'nullable|string|max:1000',
             'agent_id' => ['nullable', Rule::exists('agents', 'id')->where('organization_id', app(CurrentOrganization::class)->id())],
             'backups_enabled' => 'boolean',
-            'dump_flags' => ['nullable', 'string', 'max:500', 'regex:/^[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+$/'],
+            'dump_flags' => ['nullable', 'string', 'max:500', new SafeDumpFlags(DatabaseType::tryFrom($this->database_type))],
             'dump_format' => ['nullable', 'string', Rule::in(['plain', 'custom'])],
             'dump_privileges' => 'boolean',
             'ssl_enabled' => 'boolean',

--- a/app/Rules/SafeDumpFlags.php
+++ b/app/Rules/SafeDumpFlags.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Rules;
+
+use App\Enums\DatabaseType;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Validates the extra options appended to a dump command: the characters a
+ * flag may contain, and the options it may not name.
+ *
+ * Some options name the file the dump client writes, so a dump carrying one
+ * lands at a path of the caller's choosing rather than the destination
+ * Databasement selected. Shell-quoting the tokens does not help: the option is
+ * read by the dump client, not by the shell.
+ *
+ * Denied options are per engine because each client reads its own: `-r` is
+ * `--result-file` to mariadb-dump but a repeat count to redis-cli, and `-f` is
+ * `--file` to pg_dump but `--force` to mariadb-dump.
+ *
+ * `violation()` and `tokenize()` are shared with
+ * {@see \App\Services\Backup\DTO\DatabaseOperationResult::escapeFlags()}, which
+ * treats them as its last line of defence for configurations stored before a
+ * flag was denied.
+ */
+readonly class SafeDumpFlags implements ValidationRule
+{
+    public const string PATTERN = '/\A[a-zA-Z0-9\s\-\_\=\.\/\,\:\*\?\%\+\@]+\z/';
+
+    /**
+     * Options that let the caller choose a path the dump client writes, or one
+     * it loads further options or code from. Short forms are listed alongside
+     * the long ones they abbreviate. Every spelling here was checked against
+     * the client shipped in the runtime image.
+     *
+     * @var array<string, list<string>>
+     */
+    private const DENIED = [
+        // mariadb-dump
+        DatabaseType::MYSQL->value => [
+            '--result-file', '-r',   // the dump itself
+            '--tab', '-T',           // one .sql file per table, into a directory
+            '--dir', '-D',           // directory-format backup (MariaDB 11+)
+            '--log-error',           // warnings and errors
+            '--defaults-file', '--defaults-extra-file', // options, --result-file among them
+            '--plugin-dir',          // client-side plugins, loaded as code
+        ],
+        // pg_dump
+        DatabaseType::POSTGRESQL->value => [
+            '--file', '-f',          // output file or directory
+        ],
+        // mongodump
+        DatabaseType::MONGODB->value => [
+            '--out', '-o',           // output directory
+            '--archive',             // archive path; the dump sets its own
+            '--config',              // options, read from a YAML file
+        ],
+        // redis-cli
+        DatabaseType::REDIS->value => [
+            '--rdb', '--functions-rdb', // the dump itself; the dump sets its own
+            '--eval',                // runs a local Lua file on the server
+            '--pipe', '-x', '-X',    // feeds stdin to the server
+        ],
+        // sqlpackage
+        DatabaseType::MSSQL->value => [
+            '/targetfile', '/tf',    // the dump itself; the dump sets its own
+            '/diagnosticsfile', '/df', // diagnostic log
+            '/profile', '/pr',       // publish profile, TargetFile among its settings
+        ],
+    ];
+
+    public function __construct(private ?DatabaseType $type) {}
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        if (preg_match(self::PATTERN, $value) !== 1) {
+            $fail(__('The :attribute contains characters that are not allowed in a dump flag.'));
+
+            return;
+        }
+
+        $violation = self::violation($value, $this->type);
+
+        if ($violation !== null) {
+            $fail(__('The :attribute may not contain :option, which redirects where the dump is written.', [
+                'option' => $violation,
+            ]));
+        }
+    }
+
+    /**
+     * The first option in $flags denied for $type, or null when there is none.
+     *
+     * Both `--result-file=path` and `--result-file path` reduce to the same
+     * name here, since the name is always its own whitespace-delimited token.
+     *
+     * Long names are compared case-insensitively, which only ever refuses more
+     * than the client would accept. Short ones are compared as written, because
+     * their case is what distinguishes them: to mariadb-dump `-R` is
+     * `--routines`, `-d` is `--no-data` and `-t` is `--no-create-info`, none of
+     * which have anything to do with `-r`, `-D` or `-T`.
+     */
+    public static function violation(?string $flags, ?DatabaseType $type): ?string
+    {
+        $denied = self::DENIED[$type?->value] ?? [];
+
+        if ($denied === []) {
+            return null;
+        }
+
+        foreach (self::tokenize($flags) as $token) {
+            if (array_intersect(self::optionNames($token, $type), $denied) !== []) {
+                return $token;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * The option names a token carries.
+     *
+     * sqlpackage spells its options `/Name:Value`, case-insensitively, so the
+     * name ends at the first colon. Everywhere else a long name ends at the
+     * first `=`.
+     *
+     * A short token is a cluster rather than a single option: pg_dump and
+     * mariadb-dump both read `-vf/tmp/x` as `-v` followed by `-f` carrying
+     * `/tmp/x`, so every character in the cluster counts as an option. Telling
+     * an option apart from the value attached to an earlier one would take each
+     * client's full option table, so a value whose text happens to contain a
+     * denied letter is refused as well.
+     *
+     * The MySQL clients read `_` and `-` as the same character in a long name,
+     * so `--result_file` reaches the same code as `--result-file` (the dump
+     * command relies on this itself, passing `--skip_ssl`). No other client
+     * here does: pg_dump, mongodump and redis-cli all refuse the underscored
+     * spelling outright.
+     *
+     * @return list<string>
+     */
+    private static function optionNames(string $token, ?DatabaseType $type): array
+    {
+        if ($type === DatabaseType::MSSQL) {
+            return [strtolower(strstr($token, ':', true) ?: $token)];
+        }
+
+        if (str_starts_with($token, '--')) {
+            $name = strtolower(strstr($token, '=', true) ?: $token);
+
+            return [$type === DatabaseType::MYSQL ? str_replace('_', '-', $name) : $name];
+        }
+
+        if (! str_starts_with($token, '-')) {
+            return [$token];
+        }
+
+        return array_map(
+            static fn (string $character): string => '-'.$character,
+            str_split(substr($token, 1)),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function tokenize(?string $flags): array
+    {
+        if ($flags === null || trim($flags) === '') {
+            return [];
+        }
+
+        /** @var list<string> $tokens */
+        $tokens = preg_split('/\s+/', trim($flags), -1, PREG_SPLIT_NO_EMPTY);
+
+        return $tokens;
+    }
+}

--- a/app/Services/Backup/DTO/DatabaseOperationResult.php
+++ b/app/Services/Backup/DTO/DatabaseOperationResult.php
@@ -2,6 +2,10 @@
 
 namespace App\Services\Backup\DTO;
 
+use App\Enums\DatabaseType;
+use App\Exceptions\Backup\DatabaseDumpException;
+use App\Rules\SafeDumpFlags;
+
 readonly class DatabaseOperationResult
 {
     public function __construct(
@@ -11,12 +15,24 @@ readonly class DatabaseOperationResult
 
     /**
      * Escape user-provided dump flags by individually quoting each token.
+     *
+     * Quoting stops the shell from reading the tokens, not the dump client, so
+     * an output-redirecting option is refused here as well as at validation.
+     * Stored configurations are not revalidated, so this is the only check that
+     * sees them.
+     *
+     * @throws DatabaseDumpException
      */
-    public static function escapeFlags(string $flags): string
+    public static function escapeFlags(string $flags, DatabaseType $type): string
     {
-        /** @var list<string> $tokens */
-        $tokens = preg_split('/\s+/', trim($flags), -1, PREG_SPLIT_NO_EMPTY);
+        $violation = SafeDumpFlags::violation($flags, $type);
 
-        return implode(' ', array_map('escapeshellarg', $tokens));
+        if ($violation !== null) {
+            throw new DatabaseDumpException(
+                "Dump flag '{$violation}' is not allowed: it redirects where the dump is written."
+            );
+        }
+
+        return implode(' ', array_map('escapeshellarg', SafeDumpFlags::tokenize($flags)));
     }
 }

--- a/app/Services/Backup/Databases/MongodbDatabase.php
+++ b/app/Services/Backup/Databases/MongodbDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Databases;
 
 use App\Contracts\BackupLogger;
+use App\Enums\DatabaseType;
 use App\Rules\SafeHost;
 use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
@@ -40,7 +41,7 @@ class MongodbDatabase implements DatabaseInterface
         ];
 
         if (! empty($this->config['dump_flags'])) {
-            $parts[] = DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+            $parts[] = DatabaseOperationResult::escapeFlags($this->config['dump_flags'], DatabaseType::MONGODB);
         }
 
         $parts[] = '--archive='.escapeshellarg($outputPath);

--- a/app/Services/Backup/Databases/MssqlDatabase.php
+++ b/app/Services/Backup/Databases/MssqlDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Databases;
 
 use App\Contracts\BackupLogger;
+use App\Enums\DatabaseType;
 use App\Exceptions\Backup\ConnectionException;
 use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
@@ -60,7 +61,7 @@ class MssqlDatabase implements DatabaseInterface
         ];
 
         if (! empty($this->config['dump_flags'])) {
-            $parts[] = DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+            $parts[] = DatabaseOperationResult::escapeFlags($this->config['dump_flags'], DatabaseType::MSSQL);
         }
 
         return new DatabaseOperationResult(command: implode(' ', $parts));

--- a/app/Services/Backup/Databases/MysqlDatabase.php
+++ b/app/Services/Backup/Databases/MysqlDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Databases;
 
 use App\Contracts\BackupLogger;
+use App\Enums\DatabaseType;
 use App\Exceptions\Backup\ConnectionException;
 use App\Services\Backup\DTO\DatabaseOperationLog;
 use App\Services\Backup\DTO\DatabaseOperationResult;
@@ -80,7 +81,7 @@ class MysqlDatabase implements DatabaseInterface
 
         $extraFlags = '';
         if (! empty($this->config['dump_flags'])) {
-            $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+            $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags'], DatabaseType::MYSQL);
         }
 
         // Flags must come before the database name; mariadb-dump treats anything after it as table names

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Databases;
 
 use App\Contracts\BackupLogger;
+use App\Enums\DatabaseType;
 use App\Exceptions\Backup\ConnectionException;
 use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
@@ -88,7 +89,7 @@ class PostgresqlDatabase implements DatabaseInterface
 
         $extraFlags = '';
         if (! empty($this->config['dump_flags'])) {
-            $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+            $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags'], DatabaseType::POSTGRESQL);
         }
 
         // Flags must come before the database name (last positional argument)

--- a/app/Services/Backup/Databases/RedisDatabase.php
+++ b/app/Services/Backup/Databases/RedisDatabase.php
@@ -3,6 +3,7 @@
 namespace App\Services\Backup\Databases;
 
 use App\Contracts\BackupLogger;
+use App\Enums\DatabaseType;
 use App\Exceptions\Backup\UnsupportedDatabaseTypeException;
 use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
@@ -32,7 +33,7 @@ class RedisDatabase implements DatabaseInterface
         $parts = $this->buildBaseCommand();
 
         if (! empty($this->config['dump_flags'])) {
-            $parts[] = DatabaseOperationResult::escapeFlags($this->config['dump_flags']);
+            $parts[] = DatabaseOperationResult::escapeFlags($this->config['dump_flags'], DatabaseType::REDIS);
         }
 
         $parts[] = '--rdb '.escapeshellarg($outputPath);

--- a/tests/Feature/Rules/SafeDumpFlagsTest.php
+++ b/tests/Feature/Rules/SafeDumpFlagsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Enums\DatabaseType;
+use App\Rules\SafeDumpFlags;
+use Illuminate\Support\Facades\Validator;
+
+test('SafeDumpFlags accepts or rejects dump flags', function (DatabaseType $type, string $flags, bool $valid) {
+    $passes = Validator::make(
+        ['dump_flags' => $flags],
+        ['dump_flags' => [new SafeDumpFlags($type)]],
+    )->passes();
+
+    expect($passes)->toBe($valid);
+})->with([
+    'ordinary flags' => [DatabaseType::MYSQL, '--single-transaction --no-tablespaces', true],
+    'empty' => [DatabaseType::MYSQL, '', true],
+    'characters a flag cannot contain' => [DatabaseType::MYSQL, '--where=`id`', false],
+
+    // The option name is its own token, however its value is attached.
+    'long name, attached value' => [DatabaseType::MYSQL, '--result-file=/app/public/shell.php', false],
+    'short name, separated value' => [DatabaseType::MYSQL, '-r /app/public/shell.php', false],
+    'short name, attached value' => [DatabaseType::MYSQL, '-D/app/public', false],
+
+    // Long names fold case, short names do not: -R is --routines and -d is
+    // --no-data, neither of which has anything to do with -r or -D.
+    'long name in caps' => [DatabaseType::MYSQL, '--RESULT-FILE=/app/public/shell.php', false],
+
+    // The MySQL clients read _ and - as the same character in a long name.
+    'underscored alias' => [DatabaseType::MYSQL, '--result_file=/app/public/shell.php', false],
+    'underscored alias of another denied option' => [DatabaseType::MYSQL, '--log_error=/app/public/x.php', false],
+    'underscore in a name that is not denied' => [DatabaseType::MYSQL, '--skip_ssl', true],
+    'short names in the other case' => [DatabaseType::MYSQL, '-R -d', true],
+
+    // pg_dump and mariadb-dump read a short token as a cluster, so a denied
+    // option reaches them even when another option opens the token.
+    'clustered short names, postgres' => [DatabaseType::POSTGRESQL, '-vf/app/public/dump.sql', false],
+    'clustered short names, mysql' => [DatabaseType::MYSQL, '-vr/app/public/shell.php', false],
+    'cluster of short names that are all allowed' => [DatabaseType::MYSQL, '-Rd', true],
+
+    // A denied name must match whole, not as a prefix.
+    'longer option starting the same way' => [DatabaseType::MYSQL, '--result-file-suffix=x', true],
+    'longer sqlpackage option starting the same way' => [DatabaseType::MSSQL, '/tfoo:x', true],
+
+    // One per engine, so a mis-keyed list does not go unnoticed.
+    'mysql config file, an indirect route to the same write' => [DatabaseType::MYSQL, '--defaults-extra-file=/tmp/evil.cnf', false],
+    'postgres output file' => [DatabaseType::POSTGRESQL, '--file=/app/public/shell.php', false],
+    'mongo output directory' => [DatabaseType::MONGODB, '--out=/app/public', false],
+    'redis lua script' => [DatabaseType::REDIS, '--eval /tmp/x.lua', false],
+    'sqlpackage target file' => [DatabaseType::MSSQL, '/tf:/app/public/shell.php', false],
+
+    // The same spelling is a legitimate option on another engine.
+    'mysql --force is not the postgres --file' => [DatabaseType::MYSQL, '-f', true],
+    'redis repeat count is not the mysql --result-file' => [DatabaseType::REDIS, '-r 5', true],
+]);
+
+test('SafeDumpFlags names the offending option', function () {
+    $errors = Validator::make(
+        ['dump_flags' => '--result-file=/app/public/shell.php'],
+        ['dump_flags' => [new SafeDumpFlags(DatabaseType::MYSQL)]],
+    )->errors();
+
+    expect($errors->first('dump_flags'))->toContain('--result-file=/app/public/shell.php');
+});

--- a/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/MysqlDatabaseTest.php
@@ -186,3 +186,18 @@ test('testConnection returns failure when process fails', function () {
     expect($result['success'])->toBeFalse()
         ->and($result['message'])->toContain('Access denied');
 });
+
+test('dump refuses a flag that redirects where the client writes', function () {
+    $db = new MysqlDatabase;
+    $db->setConfig([
+        'host' => 'db.local',
+        'port' => 3306,
+        'user' => 'root',
+        'pass' => 'secret',
+        'database' => 'myapp',
+        'dump_flags' => '--result-file=/app/public/shell.php',
+    ]);
+
+    expect(fn () => $db->dump('/tmp/dump.sql'))
+        ->toThrow(App\Exceptions\Backup\DatabaseDumpException::class, '--result-file=/app/public/shell.php');
+});


### PR DESCRIPTION
`dump_flags` is shell-quoted token by token, which keeps the shell from interpreting it. The dump client still reads every option it is handed, and several of them name a path it writes, or one it loads further options or code from, so the dump lands wherever the caller asks rather than at the destination Databasement selected.

## Denied options

Every spelling was checked against the client shipped in the runtime image, not from memory.

| Client | Denied |
|---|---|
| `mariadb-dump` | `--result-file`/`-r`, `--tab`/`-T`, `--dir`/`-D`, `--log-error`, `--defaults-file`, `--defaults-extra-file`, `--plugin-dir` |
| `pg_dump` | `--file`/`-f` |
| `mongodump` | `--out`/`-o`, `--archive`, `--config` |
| `redis-cli` | `--rdb`, `--functions-rdb`, `--eval`, `--pipe`, `-x`, `-X` |
| `sqlpackage` | `/targetfile`, `/tf`, `/diagnosticsfile`, `/df`, `/profile`, `/pr` |

Two classes are covered: options naming an output path, and options loading configuration or code from a path, which are an indirect route back to the first.

## Matching

The lists are per engine because each client reads its own options: `-r` is `--result-file` to mariadb-dump but a repeat count to redis-cli, and `-f` is `--file` to pg_dump but `--force` to mariadb-dump.

The MySQL clients also read `_` and `-` as the same character in a long name, so `--result_file` reaches the same code as `--result-file` (the dump command relies on this itself, passing `--skip_ssl`). Those are folded together for that engine only: `pg_dump`, `mongodump` and `redis-cli` each refuse the underscored spelling outright, verified by running them.

Long names match case-insensitively, which only refuses more than the client would accept. Short names match as written, because their case is what tells them apart: `-R`, `-d` and `-t` are `--routines`, `--no-data` and `--no-create-info`, and folding case would refuse all three. sqlpackage names end at the first colon, so `/tf` is caught without also catching `/tfoo`.

## Also in here

The MSSQL dump command already consumed `dump_flags`, but the API never validated it: the rule sat inside the mysql/postgres and mongodb/redis branches. It is declared once now, so every engine is covered and the duplication goes.

`SafeDumpFlags` also owns the character-set check that was a separate `regex:` rule at each entry point, so `dump_flags` validation lives in one place.

`escapeFlags()` checks again at dump time, since a server configured before this change still holds whatever was accepted then. This follows the arrangement `SafeHost` already has with the MongoDB connection-string builder.
