### PR TITLE
Scope single-job lookups to the current organization

### DIFF
--- a/app/Http/Controllers/Api/V1/BackupJobController.php
+++ b/app/Http/Controllers/Api/V1/BackupJobController.php
@@ -28,17 +28,24 @@ class BackupJobController extends Controller
 
     /**
      * Get a job.
+     *
+     * Resolved here rather than by route-model binding: BackupJob has no
+     * organization_id and so no global scope, and binding would hand back any
+     * organization's job.
      */
-    public function show(BackupJob $backupJob): BackupJobResource
+    public function show(string $backupJob): BackupJobResource
     {
-        $backupJob->load([
-            'snapshot.databaseServer',
-            'snapshot.triggeredBy',
-            'restore.snapshot.databaseServer',
-            'restore.targetServer',
-            'restore.triggeredBy',
-        ]);
+        $job = BackupJob::query()
+            ->forCurrentOrg()
+            ->with([
+                'snapshot.databaseServer',
+                'snapshot.triggeredBy',
+                'restore.snapshot.databaseServer',
+                'restore.targetServer',
+                'restore.triggeredBy',
+            ])
+            ->findOrFail($backupJob);
 
-        return new BackupJobResource($backupJob);
+        return new BackupJobResource($job);
     }
 }

--- a/app/Mcp/Tools/GetJobStatusTool.php
+++ b/app/Mcp/Tools/GetJobStatusTool.php
@@ -17,11 +17,20 @@ class GetJobStatusTool extends Tool
     public function handle(Request $request): Response
     {
         $validated = $request->validate([
-            'job_id' => 'required|string|exists:backup_jobs,id',
+            'job_id' => 'required|string',
         ]);
 
-        /** @var BackupJob $job */
-        $job = BackupJob::with(['snapshot.databaseServer', 'restore.targetServer', 'restore.snapshot'])->findOrFail($validated['job_id']);
+        // Scoped rather than validated with `exists`, which would query the
+        // table directly and answer for every organization's jobs.
+        $job = BackupJob::query()
+            ->forCurrentOrg()
+            ->with(['snapshot.databaseServer', 'restore.targetServer', 'restore.snapshot'])
+            ->whereKey($validated['job_id'])
+            ->first();
+
+        if ($job === null) {
+            return Response::error('Job not found.');
+        }
 
         $lines = [
             "Job ID: {$job->id}",

--- a/tests/Feature/Api/BackupJobApiTest.php
+++ b/tests/Feature/Api/BackupJobApiTest.php
@@ -106,3 +106,12 @@ test('authenticated users can get a specific job', function () {
         ->assertJsonPath('data.id', $job->id)
         ->assertJsonPath('data.type', 'backup');
 });
+
+test('a job from another organization is not readable via api', function () {
+    $user = User::factory()->withAbilities([])->create();
+    $foreign = foreignSnapshot();
+
+    $this->actingAs($user, 'sanctum')
+        ->getJson("/api/v1/jobs/{$foreign->backup_job_id}")
+        ->assertNotFound();
+});

--- a/tests/Feature/Mcp/McpServerTest.php
+++ b/tests/Feature/Mcp/McpServerTest.php
@@ -172,6 +172,17 @@ test('get job status returns status info', function () {
         ->assertSee('status_db');
 });
 
+test('get job status does not reach another organization\'s job', function () {
+    $user = User::factory()->create();
+    $foreign = foreignSnapshot();
+
+    $response = DatabasementServer::actingAs($user)->tool(GetJobStatusTool::class, [
+        'job_id' => $foreign->backup_job_id,
+    ]);
+
+    $response->assertHasErrors();
+});
+
 test('list database servers includes backup configuration', function () {
     $user = User::factory()->create();
     $server = createDatabaseServer(['name' => 'Configured Server', 'backups_enabled' => true]);


### PR DESCRIPTION
`BackupJob` has no `organization_id` column and so no global scope, only the opt-in `forCurrentOrg()` that the listing query applies. Neither by-ID lookup applied it: the REST `show()` used the route-bound model as given, and the MCP `get-job-status` tool validated with `exists:backup_jobs,id` before calling `findOrFail()`. Both could return a job from outside the caller's organization.

This resolves both through `forCurrentOrg()`, matching the listing. The REST action takes the raw route value rather than a bound model, because route-model binding runs before the middleware that establishes the organization context.

The MCP `exists` rule is dropped rather than scoped: it queries the table directly, and its validation error would still tell a caller whether an ID exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backup job details are now restricted to the current organization.
  - Requests for jobs belonging to another organization return a 404 response.
  - Job status lookups now report “Job not found” when the job is unavailable or inaccessible.

- **Tests**
  - Added coverage confirming cross-organization backup jobs cannot be accessed through the API or job status tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->