### PR TITLE
Serve PHP only through the front controller

### DIFF
--- a/docker/php/Caddyfile
+++ b/docker/php/Caddyfile
@@ -1,0 +1,49 @@
+# FrankenPHP configuration for Databasement.
+#
+# Derived from the Caddyfile shipped in dunglas/frankenphp, keeping its
+# environment hooks, with the front-controller restriction below added.
+#
+# https://frankenphp.dev/docs/config
+{
+	skip_install_trust
+
+	{$CADDY_GLOBAL_OPTIONS}
+
+	frankenphp {
+		{$FRANKENPHP_CONFIG}
+	}
+}
+
+{$CADDY_EXTRA_CONFIG}
+
+{$SERVER_NAME:localhost} {
+	root {$SERVER_ROOT:public/}
+	encode zstd br gzip
+
+	{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+	# Only the front controller runs. Laravel is served entirely through
+	# public/index.php, which try_files reaches internally, so no .php file
+	# needs to be addressable by URL and none is.
+	#
+	# Two spellings have to be refused, and each is handled by a different line
+	# below.
+	#
+	# The matcher ends in *.php* rather than *.php because php_server splits on
+	# .php: a request for /x.php/y does not end in .php, yet it would still run
+	# x.php with /y as PATH_INFO.
+	#
+	# try_files omits the {path}/index.php entry that php_server includes by
+	# default. That entry runs a directory's index.php when the directory itself
+	# is requested, and such a request carries no .php for the matcher to catch.
+	@phpFile path *.php*
+	error @phpFile "Not found" 404
+
+	php_server {
+		try_files {path} index.php
+	}
+}
+
+# Site blocks dropped in this directory are included, provided they use the
+# .caddyfile extension.
+import Caddyfile.d/*.caddyfile

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -120,6 +120,7 @@ RUN chmod 755 /usr/local/bin/gbak /usr/local/bin/isql
 COPY supervisord.conf /config/supervisord.conf
 COPY php-custom-production.ini /usr/local/etc/php/php-custom-production.ini
 COPY php-custom.ini /usr/local/etc/php/conf.d/zz-php-custom.ini
+COPY Caddyfile /etc/frankenphp/Caddyfile
 
 # Default PUID/PGID for the application user (can be overridden at runtime)
 ENV PUID=1000


### PR DESCRIPTION
FrankenPHP's stock Caddyfile ships `php_server` with its default `try_files`, so any `.php` file under `public/` is executable by URL. Only `public/index.php` should be, and it does not need to be addressable at all: `try_files` reaches it internally.

This ships a Caddyfile rather than inheriting the image's. It keeps the upstream environment hooks (`CADDY_GLOBAL_OPTIONS`, `FRANKENPHP_CONFIG`, `CADDY_EXTRA_CONFIG`, `CADDY_SERVER_EXTRA_DIRECTIVES`, `SERVER_NAME`, `SERVER_ROOT`) and the `Caddyfile.d` import, and adds two lines that only work together:

```caddy
@phpFile path *.php*
error @phpFile "Not found" 404

php_server {
    try_files {path} index.php
}
```

## Why each line

The matcher ends in `*.php*` rather than `*.php` because `php_server` splits on `.php`. A request for `/x.php/y` does not end in `.php`, so a `*.php` matcher misses it, yet it still runs `x.php` with `/y` as `PATH_INFO`.

`try_files` omits the `{path}/index.php` entry that `php_server` includes by default. That entry runs a directory's `index.php` when the directory itself is requested, and such a request carries no `.php` in the URL for any matcher to catch. Dropping it is what FrankenPHP's own Laravel guide shows, though it is presented there as setup rather than as a restriction.

Neither line is sufficient alone. The matcher alone leaves the directory route open; the `try_files` alone leaves direct access open.

## Verification

Run against the container, with probe files placed in `public/`:

| Request | Stock | This PR |
|---|---|---|
| `/x.php` | 200, executed | 404 |
| `/x.php/y` | 200, executed | 404 |
| `/dir/` (holding `dir/index.php`) | 200, executed | 404 |
| `/dir/index.php` | 200, executed | 404 |
| `/index.php` | 200 | 404 |

Every application route answers identically on both configs, compared by diffing the status codes for `/`, `/login`, `/register`, `/adminer`, `/api/v1/jobs`, `/favicon.ico`, `/favicon.svg`, `/robots.txt`, `/build/manifest.json` and `/apple-touch-icon.png`. `POST /login` returns 419 (CSRF), confirming requests still reach Laravel. `frankenphp adapt` shows the error route ordered ahead of the rewrite and php handlers, and `frankenphp fmt` reports no changes.

`public/` contains exactly one `.php` file, and Adminer is a route rather than a file, so nothing legitimate is affected.

## Note

Returning 404 for `/index.php` is intended. Symfony's web server documentation recommends the same restriction for nginx (`location ~ \.php$ { return 404; }`) and explicitly warns to confirm `index.php` is not reachable in production.

This is hardening, not a fix for any single issue: it removes the webroot as a target, but a file-write primitive elsewhere on the host is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved PHP application serving to prevent direct access to PHP files.
* **Configuration**
  * Added FrankenPHP/Caddy server configuration with compression support and environment-driven options.
  * Configured application routing through the Laravel front controller.
  * Included additional site configuration files automatically.
* **Infrastructure**
  * Packaged the new server configuration in the FrankenPHP container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->