### PR TITLE
Apply the job view policy where the logs modal reads the job

### DIFF
--- a/app/Livewire/Concerns/HandlesJobLogsModal.php
+++ b/app/Livewire/Concerns/HandlesJobLogsModal.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Concerns;
 
 use App\Models\BackupJob;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Attributes\Url;
 
 /**
@@ -11,8 +12,9 @@ use Livewire\Attributes\Url;
  *
  * - extend {@see \Livewire\Component}
  * - use {@see \Illuminate\Foundation\Auth\Access\AuthorizesRequests}
- * - define a `getSelectedJobProperty()` returning the eager-loaded BackupJob
- *   (each consumer chooses which relations to load).
+ * - define a `getSelectedJobProperty()` that loads the job it wants (each
+ *   consumer chooses which relations) and returns it through
+ *   {@see self::guardSelectedJob()}
  *
  * When the `?job=ID` URL parameter resolves to an unknown job, the trait
  * exposes the message via `$errorMessage` (the host's blade is expected to
@@ -58,5 +60,21 @@ trait HandlesJobLogsModal
     {
         $this->showLogsModal = false;
         $this->selectedJobId = null;
+    }
+
+    /**
+     * Drop the job unless the viewer passes the view policy.
+     *
+     * `selectedJobId` is a public property, so the client can set it directly
+     * without going through mount() or viewLogs(). The check therefore belongs
+     * where the job is read, not only where the id is assigned.
+     */
+    protected function guardSelectedJob(?BackupJob $job): ?BackupJob
+    {
+        if ($job === null || Gate::denies('view', $job)) {
+            return null;
+        }
+
+        return $job;
     }
 }

--- a/app/Livewire/Restore/Index.php
+++ b/app/Livewire/Restore/Index.php
@@ -78,15 +78,14 @@ class Index extends Component
         // Bypass the organization scopes so cross-org deeplinks (e.g. a
         // notification opened while the user is in another org) can still
         // render source/target server context in the logs modal. Read-only:
-        // BackupJobPolicy@view has already confirmed membership of the owning
-        // org in mountHandlesJobLogsModal(), and a non-member gets a 403 there.
-        return BackupJob::with([
+        // guardSelectedJob() applies BackupJobPolicy@view to what comes back.
+        return $this->guardSelectedJob(BackupJob::with([
             'restore' => fn ($q) => $q->withoutGlobalScopes(),
             'restore.snapshot.databaseServer' => fn ($q) => $q->withoutGlobalScopes(),
             'restore.snapshot.files.volume' => fn ($q) => $q->withoutGlobalScopes(),
             'restore.targetServer' => fn ($q) => $q->withoutGlobalScopes(),
             'restore.triggeredBy',
-        ])->find($this->selectedJobId);
+        ])->find($this->selectedJobId));
     }
 
     public function openNewRestore(): void

--- a/app/Livewire/Snapshot/Index.php
+++ b/app/Livewire/Snapshot/Index.php
@@ -78,12 +78,12 @@ class Index extends Component
         // Bypass the OrganizationScope on DatabaseServer/Volume so cross-org
         // deeplinks (e.g. a notification opened while the user is in another
         // org) can still render the snapshot/server context in the logs modal.
-        // The job-view policy already gates access to this data.
-        return BackupJob::with([
+        // guardSelectedJob() applies the view policy to what comes back.
+        return $this->guardSelectedJob(BackupJob::with([
             'snapshot.databaseServer' => fn ($q) => $q->withoutGlobalScopes(),
             'snapshot.files.volume' => fn ($q) => $q->withoutGlobalScopes(),
             'snapshot.triggeredBy',
-        ])->find($this->selectedJobId);
+        ])->find($this->selectedJobId));
     }
 
     public function triggerRestore(string $snapshotId): void

--- a/tests/Feature/Livewire/Restore/IndexTest.php
+++ b/tests/Feature/Livewire/Restore/IndexTest.php
@@ -239,3 +239,21 @@ test('another organization restore record cannot be re-run', function () {
     expect(fn () => Livewire::test(Index::class)->call('rerunRestore', $foreign->id))
         ->toThrow(ModelNotFoundException::class);
 });
+
+test('viewLogs does not render a job from an org the user is not a member of', function () {
+    $otherOrg = \App\Models\Organization::factory()->create(['name' => 'OtherOrg']);
+
+    $current = app(\App\Services\CurrentOrganization::class);
+    $current->set($otherOrg);
+    $otherOrgServer = DatabaseServer::factory()->create(['organization_id' => $otherOrg->id]);
+    $snapshot = Snapshot::factory()->forServer($otherOrgServer)->withFile()->create();
+    $restore = makeRestore(['snapshot' => $snapshot, 'target' => $otherOrgServer]);
+    $restore->job->log('pg_restore --host=other-org-host', 'info');
+
+    // Return to the default org. The user is NOT a member of OtherOrg.
+    $current->set(\App\Models\Organization::default());
+
+    Livewire::test(Index::class)
+        ->call('viewLogs', $restore->job->id)
+        ->assertDontSee('other-org-host');
+});

--- a/tests/Feature/Livewire/Snapshot/IndexTest.php
+++ b/tests/Feature/Livewire/Snapshot/IndexTest.php
@@ -309,3 +309,17 @@ test('?job= from another org is forbidden when the user is not a member', functi
         ->test(Index::class)
         ->assertForbidden();
 });
+
+test('viewLogs does not render a job from another organization', function () {
+    $otherOrg = \App\Models\Organization::factory()->create();
+    $server = DatabaseServer::factory()->create(['organization_id' => $otherOrg->id]);
+    $job = Snapshot::factory()->forServer($server)->create()->job;
+    $job->log('mariadb-dump --host=other-org-host', 'info');
+
+    // Acting as the default-org user (beforeEach), who is not a member of
+    // $otherOrg. selectedJobId is client-writable, so the modal must resolve
+    // the job through the view policy rather than trusting the id.
+    Livewire::test(Index::class)
+        ->call('viewLogs', $job->id)
+        ->assertDontSee('other-org-host');
+});


### PR DESCRIPTION
The job logs modal resolves its job from `selectedJobId` and renders whatever comes back. `mountHandlesJobLogsModal()` checks `BackupJobPolicy@view` for the `?job=` deeplink, but that is only one of the three ways the id gets set:

- `mount()` via `?job=`, checked
- `viewLogs($id)`, a Livewire action callable with any id, not checked
- a direct write to `selectedJobId`, which is a plain public property and so settable from the client without calling either method

So the check sat at one of the assignment sites rather than at the read.

## Change

`guardSelectedJob()` in `HandlesJobLogsModal` runs the view policy on the resolved job and returns null when it fails. Both consumers (`Snapshot\Index` and `Restore\Index`) now pass their eager-loaded query through it:

```php
return $this->guardSelectedJob(BackupJob::with([...])->find($this->selectedJobId));
```

Putting it at the read covers all three entry points at once, including any future one, which assignment-site checks would not.

The relations are still loaded with `withoutGlobalScopes()`, so a user who is a member of another organization and follows a notification deeplink still gets the source/target server context the modal is meant to show, along with the existing warning banner. Only the policy decides now, not the scope.

## Tests

One per consumer, asserting that a job belonging to an organization the actor is not a member of does not render through `viewLogs()`. Both fail without the guard and pass with it. The existing deeplink tests (member renders, non-member gets 403) are unchanged and still pass.

Full suite: 1558 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job log access controls by verifying viewing permissions whenever a job is selected.
  * Prevented users from viewing logs for jobs belonging to organizations where they lack membership.
* **Tests**
  * Added coverage confirming unauthorized restore and snapshot job logs are not displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->