### PR TITLE
Resolve the organization context before route-model binding

### DIFF
--- a/app/Policies/AgentPolicy.php
+++ b/app/Policies/AgentPolicy.php
@@ -5,9 +5,12 @@ namespace App\Policies;
 use App\Enums\Ability;
 use App\Models\Agent;
 use App\Models\User;
+use App\Policies\Concerns\ChecksOrganizationOwnership;
 
 class AgentPolicy
 {
+    use ChecksOrganizationOwnership;
+
     /**
      * Determine whether the user can view any models.
      * All authenticated users can view the list.
@@ -19,11 +22,11 @@ class AgentPolicy
 
     /**
      * Determine whether the user can view the model.
-     * All authenticated users can view details.
+     * All authenticated users in the owning organization can view details.
      */
     public function view(User $user, Agent $agent): bool
     {
-        return true;
+        return $this->ownedByCurrentOrganization($agent->organization_id);
     }
 
     /**
@@ -41,7 +44,8 @@ class AgentPolicy
      */
     public function update(User $user, Agent $agent): bool
     {
-        return $user->can(Ability::ManageAgents->value);
+        return $this->ownedByCurrentOrganization($agent->organization_id)
+            && $user->can(Ability::ManageAgents->value);
     }
 
     /**
@@ -50,6 +54,7 @@ class AgentPolicy
      */
     public function delete(User $user, Agent $agent): bool
     {
-        return $user->can(Ability::ManageAgents->value);
+        return $this->ownedByCurrentOrganization($agent->organization_id)
+            && $user->can(Ability::ManageAgents->value);
     }
 }

--- a/app/Policies/Concerns/ChecksOrganizationOwnership.php
+++ b/app/Policies/Concerns/ChecksOrganizationOwnership.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Policies\Concerns;
+
+use App\Services\CurrentOrganization;
+
+/**
+ * Second line of defence for tenant isolation.
+ *
+ * Records are normally kept inside the current tenant by the global scopes in
+ * {@see \App\Models\Scopes\OrganizationScope} and
+ * {@see \App\Models\Scopes\DatabaseServerOrganizationScope}. A policy that only
+ * asks "does this user hold the ability" never inspects the record it was handed,
+ * so any path that reaches a model with those scopes lifted — a raw
+ * `withoutGlobalScopes()` read, or a lookup performed before the organization
+ * context is resolved — would authorize it against the caller's own org.
+ * Policy methods that receive a model instance check ownership here as well.
+ *
+ * Applied to the models that carry `organization_id` themselves. Records that
+ * inherit their tenant from a related server (snapshots, restores) would need a
+ * per-check lookup of that server, so they rely on
+ * {@see \App\Models\Scopes\DatabaseServerOrganizationScope} alone.
+ */
+trait ChecksOrganizationOwnership
+{
+    /**
+     * Whether a record owned by $organizationId belongs to the active tenant.
+     *
+     * Passes when no organization is resolved: CLI context (artisan commands,
+     * queue workers) runs across every org by design, matching the global scopes.
+     */
+    protected function ownedByCurrentOrganization(?string $organizationId): bool
+    {
+        $currentOrganization = app(CurrentOrganization::class);
+
+        if (! $currentOrganization->isResolved()) {
+            return true;
+        }
+
+        return $organizationId !== null
+            && $organizationId === $currentOrganization->id();
+    }
+}

--- a/app/Policies/DatabaseServerPolicy.php
+++ b/app/Policies/DatabaseServerPolicy.php
@@ -6,9 +6,12 @@ use App\Enums\Ability;
 use App\Facades\AppConfig;
 use App\Models\DatabaseServer;
 use App\Models\User;
+use App\Policies\Concerns\ChecksOrganizationOwnership;
 
 class DatabaseServerPolicy
 {
+    use ChecksOrganizationOwnership;
+
     /**
      * Determine whether the user can view any models.
      * All authenticated users can view the list.
@@ -20,11 +23,11 @@ class DatabaseServerPolicy
 
     /**
      * Determine whether the user can view the model.
-     * All authenticated users can view details.
+     * All authenticated users in the owning organization can view details.
      */
     public function view(User $user, DatabaseServer $databaseServer): bool
     {
-        return true;
+        return $this->ownedByCurrentOrganization($databaseServer->organization_id);
     }
 
     /**
@@ -33,6 +36,10 @@ class DatabaseServerPolicy
      */
     public function viewForm(User $user, ?DatabaseServer $databaseServer = null): bool
     {
+        if ($databaseServer && ! $this->ownedByCurrentOrganization($databaseServer->organization_id)) {
+            return false;
+        }
+
         return $user->isDemo() || $user->can(Ability::ManageDatabaseServers->value);
     }
 
@@ -49,7 +56,8 @@ class DatabaseServerPolicy
      */
     public function update(User $user, DatabaseServer $databaseServer): bool
     {
-        return $user->can(Ability::ManageDatabaseServers->value);
+        return $this->ownedByCurrentOrganization($databaseServer->organization_id)
+            && $user->can(Ability::ManageDatabaseServers->value);
     }
 
     /**
@@ -57,7 +65,8 @@ class DatabaseServerPolicy
      */
     public function delete(User $user, DatabaseServer $databaseServer): bool
     {
-        return $user->can(Ability::ManageDatabaseServers->value);
+        return $this->ownedByCurrentOrganization($databaseServer->organization_id)
+            && $user->can(Ability::ManageDatabaseServers->value);
     }
 
     /**
@@ -93,6 +102,10 @@ class DatabaseServerPolicy
      */
     public function backup(User $user, DatabaseServer $databaseServer): bool
     {
+        if (! $this->ownedByCurrentOrganization($databaseServer->organization_id)) {
+            return false;
+        }
+
         if ($databaseServer->backups_enabled === false || $databaseServer->backups->isEmpty()) {
             return false;
         }
@@ -105,6 +118,7 @@ class DatabaseServerPolicy
      */
     public function restore(User $user, DatabaseServer $databaseServer): bool
     {
-        return $user->isDemo() || $user->can(Ability::OperateRestores->value);
+        return $this->ownedByCurrentOrganization($databaseServer->organization_id)
+            && ($user->isDemo() || $user->can(Ability::OperateRestores->value));
     }
 }

--- a/app/Policies/DatabaseServerSshConfigPolicy.php
+++ b/app/Policies/DatabaseServerSshConfigPolicy.php
@@ -5,9 +5,12 @@ namespace App\Policies;
 use App\Enums\Ability;
 use App\Models\DatabaseServerSshConfig;
 use App\Models\User;
+use App\Policies\Concerns\ChecksOrganizationOwnership;
 
 class DatabaseServerSshConfigPolicy
 {
+    use ChecksOrganizationOwnership;
+
     /**
      * Determine whether the user can view any models.
      * All authenticated users can view the list.
@@ -19,11 +22,11 @@ class DatabaseServerSshConfigPolicy
 
     /**
      * Determine whether the user can view the model.
-     * All authenticated users can view details.
+     * All authenticated users in the owning organization can view details.
      */
     public function view(User $user, DatabaseServerSshConfig $sshConfig): bool
     {
-        return true;
+        return $this->ownedByCurrentOrganization($sshConfig->organization_id);
     }
 
     /**
@@ -40,7 +43,8 @@ class DatabaseServerSshConfigPolicy
      */
     public function update(User $user, DatabaseServerSshConfig $sshConfig): bool
     {
-        return $user->can(Ability::ManageDatabaseServers->value);
+        return $this->ownedByCurrentOrganization($sshConfig->organization_id)
+            && $user->can(Ability::ManageDatabaseServers->value);
     }
 
     /**
@@ -48,6 +52,7 @@ class DatabaseServerSshConfigPolicy
      */
     public function delete(User $user, DatabaseServerSshConfig $sshConfig): bool
     {
-        return $user->can(Ability::ManageDatabaseServers->value);
+        return $this->ownedByCurrentOrganization($sshConfig->organization_id)
+            && $user->can(Ability::ManageDatabaseServers->value);
     }
 }

--- a/app/Policies/VolumePolicy.php
+++ b/app/Policies/VolumePolicy.php
@@ -5,9 +5,12 @@ namespace App\Policies;
 use App\Enums\Ability;
 use App\Models\User;
 use App\Models\Volume;
+use App\Policies\Concerns\ChecksOrganizationOwnership;
 
 class VolumePolicy
 {
+    use ChecksOrganizationOwnership;
+
     /**
      * Determine whether the user can view any models.
      * All authenticated users can view the list.
@@ -19,11 +22,11 @@ class VolumePolicy
 
     /**
      * Determine whether the user can view the model.
-     * All authenticated users can view details.
+     * All authenticated users in the owning organization can view details.
      */
     public function view(User $user, Volume $volume): bool
     {
-        return true;
+        return $this->ownedByCurrentOrganization($volume->organization_id);
     }
 
     /**
@@ -32,6 +35,10 @@ class VolumePolicy
      */
     public function viewForm(User $user, ?Volume $volume = null): bool
     {
+        if ($volume && ! $this->ownedByCurrentOrganization($volume->organization_id)) {
+            return false;
+        }
+
         return $user->isDemo() || $user->can(Ability::ManageVolumes->value);
     }
 
@@ -50,7 +57,8 @@ class VolumePolicy
      */
     public function update(User $user, Volume $volume): bool
     {
-        return $user->can(Ability::ManageVolumes->value);
+        return $this->ownedByCurrentOrganization($volume->organization_id)
+            && $user->can(Ability::ManageVolumes->value);
     }
 
     /**
@@ -59,6 +67,7 @@ class VolumePolicy
      */
     public function delete(User $user, Volume $volume): bool
     {
-        return $user->can(Ability::ManageVolumes->value);
+        return $this->ownedByCurrentOrganization($volume->organization_id)
+            && $user->can(Ability::ManageVolumes->value);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -55,6 +55,25 @@ return Application::configure(basePath: dirname(__DIR__))
             \App\Http\Middleware\SetCurrentOrganization::class,
             \App\Http\Middleware\ScopeBouncer::class,
         ]);
+        // Tenant context must be resolved before SubstituteBindings: route-model
+        // binding that runs first resolves {model} parameters with no organization
+        // in scope, which turns OrganizationScope into a no-op and hands back
+        // records from any organization. Pinning the order here covers every
+        // group, so appending to `web`/`api` cannot silently undo it.
+        // EnsureUserIsActive is pinned alongside them to keep rejecting pending
+        // accounts before the organization lookup they would fail anyway.
+        $middleware->prependToPriorityList(
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\EnsureUserIsActive::class,
+        );
+        $middleware->prependToPriorityList(
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\SetCurrentOrganization::class,
+        );
+        $middleware->prependToPriorityList(
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+            \App\Http\Middleware\ScopeBouncer::class,
+        );
         $middleware->preventRequestForgery(except: [
             'adminer',
         ]);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -55,24 +55,12 @@ return Application::configure(basePath: dirname(__DIR__))
             \App\Http\Middleware\SetCurrentOrganization::class,
             \App\Http\Middleware\ScopeBouncer::class,
         ]);
-        // Tenant context must be resolved before SubstituteBindings: route-model
-        // binding that runs first resolves {model} parameters with no organization
-        // in scope, which turns OrganizationScope into a no-op and hands back
-        // records from any organization. Pinning the order here covers every
-        // group, so appending to `web`/`api` cannot silently undo it.
-        // EnsureUserIsActive is pinned alongside them to keep rejecting pending
-        // accounts before the organization lookup they would fail anyway.
-        $middleware->prependToPriorityList(
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \App\Http\Middleware\EnsureUserIsActive::class,
-        );
+        // OrganizationScope is a no-op while no organization is resolved, so
+        // SetCurrentOrganization has to run ahead of SubstituteBindings: a route
+        // {model} parameter bound before it resolves across every tenant.
         $middleware->prependToPriorityList(
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\SetCurrentOrganization::class,
-        );
-        $middleware->prependToPriorityList(
-            \Illuminate\Routing\Middleware\SubstituteBindings::class,
-            \App\Http\Middleware\ScopeBouncer::class,
         );
         $middleware->preventRequestForgery(except: [
             'adminer',

--- a/tests/Feature/Security/CrossOrganizationIsolationTest.php
+++ b/tests/Feature/Security/CrossOrganizationIsolationTest.php
@@ -126,4 +126,12 @@ describe('policy ownership guard', function () {
                 ->and($this->eve->can('delete', $model))->toBeTrue();
         }
     });
+
+    // Artisan commands and queue workers resolve no organization, and the
+    // global scopes do not filter there either.
+    test('the guard passes when no organization is resolved', function () {
+        asUnresolvedRequest();
+
+        expect($this->eve->can('view', $this->foreignServer))->toBeTrue();
+    });
 });

--- a/tests/Feature/Security/CrossOrganizationIsolationTest.php
+++ b/tests/Feature/Security/CrossOrganizationIsolationTest.php
@@ -9,6 +9,7 @@ use App\Models\Snapshot;
 use App\Models\User;
 use App\Models\Volume;
 use App\Services\CurrentOrganization;
+use App\Support\BouncerScope;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use Illuminate\Routing\Router;
@@ -18,7 +19,7 @@ use Illuminate\Routing\SortedMiddleware;
  * A real request reaches the framework with no organization resolved; the
  * suite's setupOrgContext() resolves one up front, which hides anything that
  * reads the tenant before SetCurrentOrganization has run. Clearing it here
- * makes these tests exercise the same starting state as production.
+ * makes these tests start where a request does.
  */
 function asUnresolvedRequest(): void
 {
@@ -35,7 +36,6 @@ beforeEach(function () {
     attachUserToOrg($this->eve, $this->orgB, 'admin');
 
     $this->foreignServer = DatabaseServer::factory()->create([
-        'name' => 'org-a-db',
         'organization_id' => $this->orgA->id,
     ]);
 });
@@ -51,129 +51,79 @@ test('tenant context is resolved before route-model binding', function (string $
         ->toBeLessThan(array_search(SubstituteBindings::class, $pipeline, true));
 })->with(['api.database-servers.show', 'dashboard']);
 
-describe('database servers', function () {
-    test('a non-member cannot read another organization\'s server', function () {
-        asUnresolvedRequest();
+// Reading is guarded by the organization scope alone: show performs no
+// authorize() call of its own.
+test('a non-member cannot read another organization\'s record', function () {
+    asUnresolvedRequest();
 
-        $this->actingAs($this->eve, 'sanctum')
-            ->getJson("/api/v1/database-servers/{$this->foreignServer->id}")
-            ->assertNotFound();
-    });
-
-    test('a non-member cannot update another organization\'s server', function () {
-        asUnresolvedRequest();
-
-        $this->actingAs($this->eve, 'sanctum')
-            ->putJson("/api/v1/database-servers/{$this->foreignServer->id}", [
-                'name' => 'PWNED',
-                'database_type' => 'sqlite',
-                'backups_enabled' => false,
-                'backups' => [],
-            ])
-            ->assertNotFound();
-
-        expect($this->foreignServer->fresh()->name)->toBe('org-a-db');
-    });
-
-    test('a non-member cannot delete another organization\'s server', function () {
-        asUnresolvedRequest();
-
-        $this->actingAs($this->eve, 'sanctum')
-            ->deleteJson("/api/v1/database-servers/{$this->foreignServer->id}")
-            ->assertNotFound();
-
-        expect(DatabaseServer::withoutGlobalScopes()->find($this->foreignServer->id))->not->toBeNull();
-    });
-
-    test('a non-member cannot trigger a backup on another organization\'s server', function () {
-        asUnresolvedRequest();
-
-        $this->actingAs($this->eve, 'sanctum')
-            ->postJson("/api/v1/database-servers/{$this->foreignServer->id}/backup")
-            ->assertNotFound();
-    });
+    $this->actingAs($this->eve, 'sanctum')
+        ->getJson("/api/v1/database-servers/{$this->foreignServer->id}")
+        ->assertNotFound();
 });
 
-describe('volumes', function () {
-    test('a non-member cannot read another organization\'s volume', function () {
-        $volume = Volume::factory()->create(['organization_id' => $this->orgA->id]);
+// Writing goes through authorize(), so this covers the scope and the policy
+// together on the path where a bypass destroys data.
+test('a non-member cannot delete another organization\'s record', function () {
+    $volume = Volume::factory()->create(['organization_id' => $this->orgA->id]);
 
-        asUnresolvedRequest();
+    asUnresolvedRequest();
 
-        $this->actingAs($this->eve, 'sanctum')
-            ->getJson("/api/v1/volumes/{$volume->id}")
-            ->assertNotFound();
-    });
+    $this->actingAs($this->eve, 'sanctum')
+        ->deleteJson("/api/v1/volumes/{$volume->id}")
+        ->assertNotFound();
 
-    test('a non-member cannot delete another organization\'s volume', function () {
-        $volume = Volume::factory()->create(['organization_id' => $this->orgA->id]);
-
-        asUnresolvedRequest();
-
-        $this->actingAs($this->eve, 'sanctum')
-            ->deleteJson("/api/v1/volumes/{$volume->id}")
-            ->assertNotFound();
-
-        expect(Volume::withoutGlobalScopes()->find($volume->id))->not->toBeNull();
-    });
+    expect(Volume::withoutGlobalScopes()->find($volume->id))->not->toBeNull();
 });
 
-describe('records inheriting their tenant from a server', function () {
-    test('a non-member cannot read another organization\'s snapshot', function () {
-        $snapshot = Snapshot::factory()
-            ->forServer($this->foreignServer)
-            ->onVolumes(Volume::factory()->create(['organization_id' => $this->orgA->id]))
-            ->create();
+// Snapshots own no organization_id and are scoped through their server by
+// DatabaseServerOrganizationScope, a separate implementation.
+test('a non-member cannot read a record scoped through its server', function () {
+    $snapshot = Snapshot::factory()
+        ->forServer($this->foreignServer)
+        ->onVolumes(Volume::factory()->create(['organization_id' => $this->orgA->id]))
+        ->create();
 
-        asUnresolvedRequest();
+    asUnresolvedRequest();
 
-        $this->actingAs($this->eve, 'sanctum')
-            ->getJson("/api/v1/snapshots/{$snapshot->id}")
-            ->assertNotFound();
-    });
-
-    test('a non-member cannot read another organization\'s ssh config', function () {
-        $sshConfig = DatabaseServerSshConfig::factory()->create([
-            'organization_id' => $this->orgA->id,
-        ]);
-
-        asUnresolvedRequest();
-
-        $this->actingAs($this->eve, 'sanctum')
-            ->getJson("/api/v1/database-server-ssh-configs/{$sshConfig->id}")
-            ->assertNotFound();
-    });
+    $this->actingAs($this->eve, 'sanctum')
+        ->getJson("/api/v1/snapshots/{$snapshot->id}")
+        ->assertNotFound();
 });
 
 describe('policy ownership guard', function () {
-    test('abilities do not authorize a model from another organization', function () {
-        $volume = Volume::factory()->create(['organization_id' => $this->orgA->id]);
-        $agent = Agent::factory()->create(['organization_id' => $this->orgA->id]);
-
-        // Eve is scoped to her own org, but holds every ability there.
+    beforeEach(function () {
+        // Eve is scoped to her own org, where she holds every ability.
         app(CurrentOrganization::class)->set($this->orgB);
-        App\Support\BouncerScope::apply($this->orgB->id);
-
-        expect($this->eve->can('view', $this->foreignServer))->toBeFalse()
-            ->and($this->eve->can('update', $this->foreignServer))->toBeFalse()
-            ->and($this->eve->can('delete', $this->foreignServer))->toBeFalse()
-            ->and($this->eve->can('view', $volume))->toBeFalse()
-            ->and($this->eve->can('delete', $volume))->toBeFalse()
-            ->and($this->eve->can('view', $agent))->toBeFalse()
-            ->and($this->eve->can('delete', $agent))->toBeFalse();
+        BouncerScope::apply($this->orgB->id);
     });
 
-    test('the same abilities still authorize a model in the current organization', function () {
-        $ownServer = DatabaseServer::factory()->create(['organization_id' => $this->orgB->id]);
-        $ownVolume = Volume::factory()->create(['organization_id' => $this->orgB->id]);
+    test('an ability does not authorize a model from another organization', function () {
+        $foreign = [
+            $this->foreignServer,
+            Volume::factory()->create(['organization_id' => $this->orgA->id]),
+            Agent::factory()->create(['organization_id' => $this->orgA->id]),
+            DatabaseServerSshConfig::factory()->create(['organization_id' => $this->orgA->id]),
+        ];
 
-        app(CurrentOrganization::class)->set($this->orgB);
-        App\Support\BouncerScope::apply($this->orgB->id);
+        foreach ($foreign as $model) {
+            expect($this->eve->can('view', $model))->toBeFalse()
+                ->and($this->eve->can('update', $model))->toBeFalse()
+                ->and($this->eve->can('delete', $model))->toBeFalse();
+        }
+    });
 
-        expect($this->eve->can('view', $ownServer))->toBeTrue()
-            ->and($this->eve->can('update', $ownServer))->toBeTrue()
-            ->and($this->eve->can('delete', $ownServer))->toBeTrue()
-            ->and($this->eve->can('view', $ownVolume))->toBeTrue()
-            ->and($this->eve->can('delete', $ownVolume))->toBeTrue();
+    test('the same ability still authorizes a model in the current organization', function () {
+        $own = [
+            DatabaseServer::factory()->create(['organization_id' => $this->orgB->id]),
+            Volume::factory()->create(['organization_id' => $this->orgB->id]),
+            Agent::factory()->create(['organization_id' => $this->orgB->id]),
+            DatabaseServerSshConfig::factory()->create(['organization_id' => $this->orgB->id]),
+        ];
+
+        foreach ($own as $model) {
+            expect($this->eve->can('view', $model))->toBeTrue()
+                ->and($this->eve->can('update', $model))->toBeTrue()
+                ->and($this->eve->can('delete', $model))->toBeTrue();
+        }
     });
 });

--- a/tests/Feature/Security/CrossOrganizationIsolationTest.php
+++ b/tests/Feature/Security/CrossOrganizationIsolationTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use App\Models\Agent;
+use App\Models\DatabaseServer;
+use App\Models\DatabaseServerSshConfig;
+use App\Models\Organization;
+use App\Models\Snapshot;
+use App\Models\User;
+use App\Models\Volume;
+use App\Services\CurrentOrganization;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+
+/**
+ * A real request reaches the framework with no organization resolved; the
+ * suite's setupOrgContext() resolves one up front, which hides anything that
+ * reads the tenant before SetCurrentOrganization has run. Clearing it here
+ * makes these tests exercise the same starting state as production.
+ */
+function asUnresolvedRequest(): void
+{
+    app(CurrentOrganization::class)->reset();
+}
+
+beforeEach(function () {
+    $this->orgA = Organization::factory()->create(['name' => 'Org A']);
+    $this->orgB = Organization::factory()->create(['name' => 'Org B']);
+
+    // Eve holds every ability, but only inside Org B.
+    $this->eve = User::factory()->create();
+    $this->eve->organizations()->detach();
+    attachUserToOrg($this->eve, $this->orgB, 'admin');
+
+    $this->foreignServer = DatabaseServer::factory()->create([
+        'name' => 'org-a-db',
+        'organization_id' => $this->orgA->id,
+    ]);
+});
+
+test('tenant context is resolved before route-model binding', function () {
+    $priority = app(Illuminate\Contracts\Http\Kernel::class)->getMiddlewarePriority();
+
+    expect(array_search(App\Http\Middleware\SetCurrentOrganization::class, $priority, true))
+        ->toBeLessThan(array_search(SubstituteBindings::class, $priority, true));
+
+    expect(array_search(App\Http\Middleware\ScopeBouncer::class, $priority, true))
+        ->toBeLessThan(array_search(SubstituteBindings::class, $priority, true));
+});
+
+describe('database servers', function () {
+    test('a non-member cannot read another organization\'s server', function () {
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->getJson("/api/v1/database-servers/{$this->foreignServer->id}")
+            ->assertNotFound();
+    });
+
+    test('a non-member cannot update another organization\'s server', function () {
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->putJson("/api/v1/database-servers/{$this->foreignServer->id}", [
+                'name' => 'PWNED',
+                'database_type' => 'sqlite',
+                'backups_enabled' => false,
+                'backups' => [],
+            ])
+            ->assertNotFound();
+
+        expect($this->foreignServer->fresh()->name)->toBe('org-a-db');
+    });
+
+    test('a non-member cannot delete another organization\'s server', function () {
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->deleteJson("/api/v1/database-servers/{$this->foreignServer->id}")
+            ->assertNotFound();
+
+        expect(DatabaseServer::withoutGlobalScopes()->find($this->foreignServer->id))->not->toBeNull();
+    });
+
+    test('a non-member cannot trigger a backup on another organization\'s server', function () {
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->postJson("/api/v1/database-servers/{$this->foreignServer->id}/backup")
+            ->assertNotFound();
+    });
+});
+
+describe('volumes', function () {
+    test('a non-member cannot read another organization\'s volume', function () {
+        $volume = Volume::factory()->create(['organization_id' => $this->orgA->id]);
+
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->getJson("/api/v1/volumes/{$volume->id}")
+            ->assertNotFound();
+    });
+
+    test('a non-member cannot delete another organization\'s volume', function () {
+        $volume = Volume::factory()->create(['organization_id' => $this->orgA->id]);
+
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->deleteJson("/api/v1/volumes/{$volume->id}")
+            ->assertNotFound();
+
+        expect(Volume::withoutGlobalScopes()->find($volume->id))->not->toBeNull();
+    });
+});
+
+describe('records inheriting their tenant from a server', function () {
+    test('a non-member cannot read another organization\'s snapshot', function () {
+        $snapshot = Snapshot::factory()
+            ->forServer($this->foreignServer)
+            ->onVolumes(Volume::factory()->create(['organization_id' => $this->orgA->id]))
+            ->create();
+
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->getJson("/api/v1/snapshots/{$snapshot->id}")
+            ->assertNotFound();
+    });
+
+    test('a non-member cannot read another organization\'s ssh config', function () {
+        $sshConfig = DatabaseServerSshConfig::factory()->create([
+            'organization_id' => $this->orgA->id,
+        ]);
+
+        asUnresolvedRequest();
+
+        $this->actingAs($this->eve, 'sanctum')
+            ->getJson("/api/v1/database-server-ssh-configs/{$sshConfig->id}")
+            ->assertNotFound();
+    });
+});
+
+describe('policy ownership guard', function () {
+    test('abilities do not authorize a model from another organization', function () {
+        $volume = Volume::factory()->create(['organization_id' => $this->orgA->id]);
+        $agent = Agent::factory()->create(['organization_id' => $this->orgA->id]);
+
+        // Eve is scoped to her own org, but holds every ability there.
+        app(CurrentOrganization::class)->set($this->orgB);
+        App\Support\BouncerScope::apply($this->orgB->id);
+
+        expect($this->eve->can('view', $this->foreignServer))->toBeFalse()
+            ->and($this->eve->can('update', $this->foreignServer))->toBeFalse()
+            ->and($this->eve->can('delete', $this->foreignServer))->toBeFalse()
+            ->and($this->eve->can('view', $volume))->toBeFalse()
+            ->and($this->eve->can('delete', $volume))->toBeFalse()
+            ->and($this->eve->can('view', $agent))->toBeFalse()
+            ->and($this->eve->can('delete', $agent))->toBeFalse();
+    });
+
+    test('the same abilities still authorize a model in the current organization', function () {
+        $ownServer = DatabaseServer::factory()->create(['organization_id' => $this->orgB->id]);
+        $ownVolume = Volume::factory()->create(['organization_id' => $this->orgB->id]);
+
+        app(CurrentOrganization::class)->set($this->orgB);
+        App\Support\BouncerScope::apply($this->orgB->id);
+
+        expect($this->eve->can('view', $ownServer))->toBeTrue()
+            ->and($this->eve->can('update', $ownServer))->toBeTrue()
+            ->and($this->eve->can('delete', $ownServer))->toBeTrue()
+            ->and($this->eve->can('view', $ownVolume))->toBeTrue()
+            ->and($this->eve->can('delete', $ownVolume))->toBeTrue();
+    });
+});

--- a/tests/Feature/Security/CrossOrganizationIsolationTest.php
+++ b/tests/Feature/Security/CrossOrganizationIsolationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SetCurrentOrganization;
 use App\Models\Agent;
 use App\Models\DatabaseServer;
 use App\Models\DatabaseServerSshConfig;
@@ -8,7 +9,10 @@ use App\Models\Snapshot;
 use App\Models\User;
 use App\Models\Volume;
 use App\Services\CurrentOrganization;
+use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Routing\Router;
+use Illuminate\Routing\SortedMiddleware;
 
 /**
  * A real request reaches the framework with no organization resolved; the
@@ -36,15 +40,16 @@ beforeEach(function () {
     ]);
 });
 
-test('tenant context is resolved before route-model binding', function () {
-    $priority = app(Illuminate\Contracts\Http\Kernel::class)->getMiddlewarePriority();
+test('tenant context is resolved before route-model binding', function (string $routeName) {
+    $router = app(Router::class);
+    $pipeline = iterator_to_array(new SortedMiddleware(
+        app(Kernel::class)->getMiddlewarePriority(),
+        $router->gatherRouteMiddleware($router->getRoutes()->getByName($routeName)),
+    ));
 
-    expect(array_search(App\Http\Middleware\SetCurrentOrganization::class, $priority, true))
-        ->toBeLessThan(array_search(SubstituteBindings::class, $priority, true));
-
-    expect(array_search(App\Http\Middleware\ScopeBouncer::class, $priority, true))
-        ->toBeLessThan(array_search(SubstituteBindings::class, $priority, true));
-});
+    expect(array_search(SetCurrentOrganization::class, $pipeline, true))
+        ->toBeLessThan(array_search(SubstituteBindings::class, $pipeline, true));
+})->with(['api.database-servers.show', 'dashboard']);
 
 describe('database servers', function () {
     test('a non-member cannot read another organization\'s server', function () {


### PR DESCRIPTION
`SetCurrentOrganization` and `ScopeBouncer` were only appended to the `web` and `api` middleware groups, so `SubstituteBindings` ran ahead of them. Route parameters were resolved before any organization context existed, and `OrganizationScope` skips its `where()` clause while `CurrentOrganization` is unresolved, so a lookup by id returned the record regardless of which organization owned it. List endpoints were never affected: they query after the context is set.

## Changes

**`bootstrap/app.php`** pins `SetCurrentOrganization` ahead of `SubstituteBindings` on the middleware priority list rather than reordering the group definitions. That covers both affected groups at once and a later `append` to `web` or `api` cannot silently undo it. The `/mcp` route needs nothing here: it wires its middleware by hand and pulls in no `SubstituteBindings`, so it has no route-model binding to protect. The resolved pipeline is now:

```
Authenticate -> SetCurrentOrganization -> SubstituteBindings -> ScopeBouncer -> ...
```

`ScopeBouncer` is deliberately left unpinned. It only has to precede whatever calls `$user->can()`, which is the controller or the `Authorize` middleware, and `Authorize` sorts to the end of the pipeline either way. Leaving it alone also keeps it exactly where it already sat, and a middleware outside the priority list can never be hoisted above one inside it, so it still cannot overtake `SetCurrentOrganization`.

**`ChecksOrganizationOwnership`** is a new policy concern. Policy methods that receive a model instance only asked whether the user held an ability, never which organization the record belonged to, so they granted nothing on their own once the scope had been bypassed. Applied to `DatabaseServerPolicy`, `VolumePolicy`, `AgentPolicy` and `DatabaseServerSshConfigPolicy`, the four models carrying `organization_id` directly. It passes when no organization is resolved, matching how the global scopes behave in CLI context.

Records that inherit their tenant from a related server (snapshots, restores) keep relying on `DatabaseServerOrganizationScope`. Resolving the server per check would cost a query per row on the listings, and the generated relation type is non-nullable because the FK is, so the nullable read PHPStan needs is not available there.

## Testing

`setupOrgContext()` resolves an organization before every test, so binding always ran with a tenant in scope and none of this was observable. `OrganizationContextApiTest`'s existing single-record test passed for that reason alone.

`tests/Feature/Security/CrossOrganizationIsolationTest.php` clears the context first so each test starts where a real request does. It covers one case per mechanism that can break on its own: a read, where the scope is the only guard because `show` performs no `authorize()` call; a delete, which additionally runs the policy on the path that destroys data; and a snapshot read, which is scoped through its server by a separate implementation. Two further cases assert the policy guard in both directions across all four policies the trait was added to, and one asserts the middleware ordering on the resolved pipeline of a real route so a future reorder breaks CI instead of production.

Removing the middleware pin fails 5 of the 7. Removing the ownership check from a single policy fails 1.

`make test` 1565 passed, PHPStan 0 errors, Pint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened organization-level access controls for agents, database servers, SSH configurations, and volumes.
  * Prevented users from viewing, modifying, or deleting resources belonging to another organization.
  * Ensured organization context is established before resource access checks, improving cross-organization isolation.
  * Preserved authorized access for resources within the user’s current organization and for approved administrative contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->