### PR TITLE
Mask the Redis password in logged commands

### DIFF
--- a/app/Services/Backup/Databases/RedisDatabase.php
+++ b/app/Services/Backup/Databases/RedisDatabase.php
@@ -151,7 +151,7 @@ class RedisDatabase implements DatabaseInterface
             if (! empty($user)) {
                 $flags[] = '--user '.escapeshellarg($user);
             }
-            $flags[] = '-a '.escapeshellarg($pass);
+            $flags[] = '--pass '.escapeshellarg($pass);
         }
 
         return $flags;

--- a/app/Services/Backup/ShellProcessor.php
+++ b/app/Services/Backup/ShellProcessor.php
@@ -147,6 +147,10 @@ class ShellProcessor
             '/SSH_ASKPASS=[^\s]+/' => 'SSH_ASKPASS=***',
             // sqlpackage: /SourcePassword:'...' or /TargetPassword:'...' (escapeshellarg single-quotes the value)
             '#/(Source|Target)Password:(?:\'[^\']*\'|"[^"]*"|[^\s]+)#' => '/$1Password:***',
+            // redis-cli --pass VALUE. The `-a` alias is deliberately not matched:
+            // `-a` is a real flag on rsync, tar and 7z, so a pattern for it would
+            // redact unrelated commands. RedisDatabase emits `--pass` for this reason.
+            '#--pass\s+(?:\'[^\']*\'|"[^"]*"|[^\s]+)#' => '--pass ***',
             // MongoDB connection URI userinfo: mongodb://user:PASS@host or mongodb+srv://user:PASS@host
             '#(mongodb(?:\+srv)?://[^:@\s/]+:)[^@\s]+@#' => '$1***@',
         ];

--- a/tests/Feature/Services/Backup/Databases/RedisDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/RedisDatabaseTest.php
@@ -38,7 +38,7 @@ test('dump includes auth flags when credentials provided', function () {
     $result = $db->dump('/tmp/dump.rdb');
 
     expect($result->command)
-        ->toBe("redis-cli -h 'redis.example.com' -p '6379' --user 'myuser' -a 'secret' --no-auth-warning --rdb '/tmp/dump.rdb'");
+        ->toBe("redis-cli -h 'redis.example.com' -p '6379' --user 'myuser' --pass 'secret' --no-auth-warning --rdb '/tmp/dump.rdb'");
 });
 
 test('dump includes password only when no username', function () {
@@ -53,7 +53,7 @@ test('dump includes password only when no username', function () {
     $result = $db->dump('/tmp/dump.rdb');
 
     expect($result->command)
-        ->toBe("redis-cli -h 'redis.example.com' -p '6379' -a 'secret' --no-auth-warning --rdb '/tmp/dump.rdb'");
+        ->toBe("redis-cli -h 'redis.example.com' -p '6379' --pass 'secret' --no-auth-warning --rdb '/tmp/dump.rdb'");
 });
 
 test('restore throws unsupported exception', function () {

--- a/tests/Unit/Services/Backup/ShellProcessorTest.php
+++ b/tests/Unit/Services/Backup/ShellProcessorTest.php
@@ -14,6 +14,7 @@ test('sanitizes sensitive patterns', function (string $input, string $expectedTo
     '--password= format' => ['mysqldump --password=secret123 dbname', '--password=***', 'secret123'],
     'quoted --password= format' => ["mysqldump --password='secret123' dbname", '--password=***', 'secret123'],
     '-p shorthand format' => ['mysqldump -psecret123 dbname', '-p***', 'secret123'],
+    'redis --pass format' => ["redis-cli -h 'redis' --pass 'secret123' PING", '--pass ***', 'secret123'],
     'firebird -password format' => ["gbak -b -user 'SYSDBA' -password 'masterkey' 'db' 'dump'", '-password ***', 'masterkey'],
     'firebird -password with spaces in value' => ["gbak -b -user 'SYSDBA' -password 'sec ret pass' 'db' 'dump'", '-password ***', 'sec ret pass'],
     'PGPASSWORD env var' => ['PGPASSWORD=secret123 pg_dump dbname', 'PGPASSWORD=***', 'secret123'],
@@ -35,6 +36,8 @@ test('preserves non-sensitive patterns', function (string $input, string $expect
     '--port option' => ['mysqldump --port=3306 dbname', '--port=3306'],
     '-p with space (port flag)' => ['pg_dump -p 5432 dbname', '-p 5432'],
     'firebird user flag not masked' => ["gbak -b -user 'sysdba' -password 'secret' 'db' 'dump'", "-user 'sysdba'"],
+    'rsync -a not treated as a password flag' => ['rsync -a /src /dst', '-a /src'],
+    '--passphrase not treated as --pass' => ['tool --passphrase-file /k', '--passphrase-file /k'],
 ]);
 
 test('sanitizes realistic mariadb-dump command', function () {


### PR DESCRIPTION
`RedisDatabase` passed the password to redis-cli through `-a`, and `ShellProcessor::sanitize()` has no pattern for that flag. The command stored in `backup_jobs.logs` therefore kept the password in cleartext, while the equivalent MySQL and PostgreSQL commands were masked. The job logs modal is readable by any member of the owning organization, a viewer included, and the demo user can both trigger a backup and read the log it produces.

## Why `--pass` rather than a pattern for `-a`

`--pass` is a documented alias of `-a`, and it is a client-side flag, so the bundled redis-cli decides whether it is understood rather than the server being backed up. `--user` pairs with it correctly despite the help text saying `--user` needs `-a`.

The switch is what makes the redaction safe. `-a` is a real flag on rsync, tar and 7z, all of which run through the same `sanitize()`, so a pattern matching `-a` would redact unrelated commands and corrupt their logs. `--pass` is distinctive enough to match without that risk. Two rows were added to the existing "does not mask" dataset to pin that down.

## Known limitation

The password stays in the process arguments. MySQL's `--password=` and PostgreSQL's `PGPASSWORD=` are inlined into their command strings today and sit in exactly the same place, so this is a property of every engine here rather than something specific to Redis. Moving all three onto `ShellProcessor`'s existing `$env` parameter is worth doing, but doing it for Redis alone would leave one engine behaving differently from the rest for no clear reason. Better as its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Redis backup commands to use the supported password option.
  * Improved command sanitization so Redis passwords are redacted in displayed or logged commands.
  * Prevented unrelated command options from being incorrectly treated as Redis passwords.

* **Tests**
  * Added coverage for Redis password redaction and command-option handling.
  * Updated backup command expectations to reflect the revised Redis authentication option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->