### PR TITLE
Validate volume host and endpoint fields

### DIFF
--- a/app/Http/Requests/Api/V1/Volume/StoreFtpVolumeRequest.php
+++ b/app/Http/Requests/Api/V1/Volume/StoreFtpVolumeRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Volume;
 
 use App\Enums\VolumeType;
+use App\Rules\SafeHost;
 use App\Rules\SafePath;
 
 class StoreFtpVolumeRequest extends StoreVolumeRequest
@@ -18,7 +19,7 @@ class StoreFtpVolumeRequest extends StoreVolumeRequest
     protected function configRules(): array
     {
         return [
-            'config.host' => ['required', 'string', 'max:255'],
+            'config.host' => ['required', 'string', 'max:255', new SafeHost],
             'config.port' => ['nullable', 'integer', 'min:1', 'max:65535'],
             'config.username' => ['required', 'string', 'max:255'],
             'config.password' => ['required', 'string', 'max:1000'],

--- a/app/Http/Requests/Api/V1/Volume/StoreSftpVolumeRequest.php
+++ b/app/Http/Requests/Api/V1/Volume/StoreSftpVolumeRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Api\V1\Volume;
 
 use App\Enums\VolumeType;
+use App\Rules\SafeHost;
 use App\Rules\SafePath;
 
 class StoreSftpVolumeRequest extends StoreVolumeRequest
@@ -18,7 +19,7 @@ class StoreSftpVolumeRequest extends StoreVolumeRequest
     protected function configRules(): array
     {
         return [
-            'config.host' => ['required', 'string', 'max:255'],
+            'config.host' => ['required', 'string', 'max:255', new SafeHost],
             'config.port' => ['nullable', 'integer', 'min:1', 'max:65535'],
             'config.username' => ['required', 'string', 'max:255'],
             'config.password' => ['required', 'string', 'max:1000'],

--- a/app/Livewire/Volume/Connectors/AzureConfig.php
+++ b/app/Livewire/Volume/Connectors/AzureConfig.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Volume\Connectors;
 
+use App\Rules\SafeEndpointUrl;
 use App\Rules\SafePath;
 
 class AzureConfig extends BaseConfig
@@ -32,7 +33,7 @@ class AzureConfig extends BaseConfig
             "{$prefix}.container" => ['required_if:type,azure', 'string', 'max:255'],
             "{$prefix}.prefix" => ['nullable', 'string', 'max:255', new SafePath],
             "{$prefix}.endpoint_suffix" => ['nullable', 'string', 'max:255'],
-            "{$prefix}.endpoint" => ['nullable', 'string', 'max:255'],
+            "{$prefix}.endpoint" => ['nullable', 'string', 'max:255', new SafeEndpointUrl],
         ];
     }
 }

--- a/app/Livewire/Volume/Connectors/FtpConfig.php
+++ b/app/Livewire/Volume/Connectors/FtpConfig.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Volume\Connectors;
 
+use App\Rules\SafeHost;
 use App\Rules\SafePath;
 
 class FtpConfig extends BaseConfig
@@ -29,7 +30,7 @@ class FtpConfig extends BaseConfig
     public static function rules(string $prefix): array
     {
         return [
-            "{$prefix}.host" => ['required_if:type,ftp', 'string', 'max:255'],
+            "{$prefix}.host" => ['required_if:type,ftp', 'string', 'max:255', new SafeHost],
             "{$prefix}.port" => ['nullable', 'integer', 'min:1', 'max:65535'],
             "{$prefix}.username" => ['required_if:type,ftp', 'string', 'max:255'],
             "{$prefix}.password" => ['required_if:type,ftp', 'string', 'max:1000'],

--- a/app/Livewire/Volume/Connectors/SftpConfig.php
+++ b/app/Livewire/Volume/Connectors/SftpConfig.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Volume\Connectors;
 
+use App\Rules\SafeHost;
 use App\Rules\SafePath;
 
 class SftpConfig extends BaseConfig
@@ -27,7 +28,7 @@ class SftpConfig extends BaseConfig
     public static function rules(string $prefix): array
     {
         return [
-            "{$prefix}.host" => ['required_if:type,sftp', 'string', 'max:255'],
+            "{$prefix}.host" => ['required_if:type,sftp', 'string', 'max:255', new SafeHost],
             "{$prefix}.port" => ['nullable', 'integer', 'min:1', 'max:65535'],
             "{$prefix}.username" => ['required_if:type,sftp', 'string', 'max:255'],
             "{$prefix}.password" => ['required_if:type,sftp', 'string', 'max:1000'],

--- a/app/Livewire/Volume/Connectors/SmbConfig.php
+++ b/app/Livewire/Volume/Connectors/SmbConfig.php
@@ -2,6 +2,7 @@
 
 namespace App\Livewire\Volume\Connectors;
 
+use App\Rules\SafeHost;
 use App\Rules\SafePath;
 
 class SmbConfig extends BaseConfig
@@ -27,7 +28,7 @@ class SmbConfig extends BaseConfig
     public static function rules(string $prefix): array
     {
         return [
-            "{$prefix}.host" => ['required_if:type,smb', 'string', 'max:255'],
+            "{$prefix}.host" => ['required_if:type,smb', 'string', 'max:255', new SafeHost],
             "{$prefix}.share" => ['required_if:type,smb', 'string', 'max:255'],
             "{$prefix}.username" => ['required_if:type,smb', 'string', 'max:255'],
             "{$prefix}.password" => ['required_if:type,smb', 'string', 'max:1000'],


### PR DESCRIPTION
Two gaps reported together, different in kind.

The Azure custom blob endpoint is a URL handed to an SDK that fetches it server-side, the same shape as the S3 endpoints commit 1b43a067 already covered, so it takes the same `SafeEndpointUrl` rule. Pointing it at instance metadata was a straightforward request forgery, and the only genuinely exploitable part.

The SFTP, FTP and SMB host fields take `SafeHost`, as hygiene rather than as a fix. SMB is the only one with a sink at all, `icewind/smb` interpolating the host into an `smb://host/share` URL, and even there a slash only appends a path segment that the adjacent `share` field already lets you set. SFTP and FTP hand the host to the client as a discrete argument (`ftp_connect($host, $port)`), so there is nothing to inject into.

## Two things worth flagging on the report

It suggested `SafeEndpointUrl` on those three host fields. That would reject every valid one: the rule requires an http or https URL, and these are bare hostnames. `sftp.example.com` and `192.168.1.50` both fail it, and `169.254.169.254` fails for the wrong reason ("must be a valid URL"), so a test written against it would pass while proving nothing.

A link-local check would not have helped either. SFTP, FTP and SMB clients speak their own protocols, and a metadata service answers HTTP, so those connections simply fail rather than leaking anything.

## Scope

Reaching any of these fields requires the `manage-volumes` ability. That is a trusted configuration role: whoever holds it chooses where backups are written and supplies the credentials used to get there. These rules constrain malformed input, they are not a boundary against someone who legitimately holds that ability.
