### PR TITLE
Ship the PostgreSQL 16 client in the base image

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 # Add tools
 RUN apk add --no-cache git \
         mariadb-client mariadb-connector-c \
-        postgresql18-client \
+        postgresql16-client postgresql18-client \
         supervisor \
         gzip zstd 7zip \
         tzdata \


### PR DESCRIPTION
The base image carries only the PostgreSQL 18 client. `pg_dump` writes a dump that is only guaranteed to load into a server at least as new as the client that wrote it, so v18 produces snapshots that no server below 17 can restore, including the one they came from. That is the cause of #588 and #590.

Fixing that means running a v16 client against older servers, which needs the package present in the image first.

This PR adds only the package, and it is inert on its own: the default client on PATH stays v18 (the `/usr/libexec/postgresql` symlink still points at `postgresql18`, verified on a local build) and nothing selects the older build yet. The ~3 MB it costs buys back both plain and custom format for pre-17 targets.

It is split out from the fix so the base image is published before the follow-up PR runs. That PR needs the v16 client at test time, and CI runs its jobs inside `davidcrty/databasement-php:latest`, which is only rebuilt on push to main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added PostgreSQL 16 client tooling to the application environment while retaining PostgreSQL 18 client support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->