### PR TITLE
Match the PostgreSQL client version to the server being dumped

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For production deployments, see our [configuration guide](https://david-crty.git
 |------------|------------------------------|------------------------------|---------|
 | MySQL      | 5.6, 5.7, 8.x, 9.x           | `mariadb-dump`               | Yes     |
 | MariaDB    | 10.x, 11.x, 12.x             | `mariadb-dump`               | Yes     |
-| PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v18                | Yes     |
+| PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v16 / v18          | Yes     |
 | SQL Server | 2017, 2019, 2022, Azure SQL  | `sqlpackage` (`.dacpac`)     | Yes     |
 | MongoDB    | 4.2, 4.4, 5.0, 6.0, 7.0, 8.0 | `mongodump` / `mongorestore` | Yes     |
 | SQLite     | 3.x                          | `sqlite3 .backup`            | Yes     |

--- a/app/Services/Backup/Databases/DatabaseProvider.php
+++ b/app/Services/Backup/Databases/DatabaseProvider.php
@@ -112,8 +112,9 @@ class DatabaseProvider
         }
 
         // Marks a live server: the handler may query it for the MySQL/MariaDB
-        // flavour. Display-only configs, like the dump preview, leave it unset.
-        if ($config->databaseType === DatabaseType::MYSQL) {
+        // flavour, or for the PostgreSQL major that decides which client build
+        // to run. Display-only configs, like the dump preview, leave it unset.
+        if (in_array($config->databaseType, [DatabaseType::MYSQL, DatabaseType::POSTGRESQL], true)) {
             $dbConfig['probe_server_version'] = true;
         }
 

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -5,6 +5,7 @@ namespace App\Services\Backup\Databases;
 use App\Contracts\BackupLogger;
 use App\Enums\DatabaseType;
 use App\Exceptions\Backup\ConnectionException;
+use App\Services\Backup\DTO\DatabaseOperationLog;
 use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Support\Formatters;
 use Illuminate\Process\Exceptions\ProcessTimedOutException;
@@ -103,12 +104,15 @@ class PostgresqlDatabase implements DatabaseInterface
             $extraFlags = ' '.DatabaseOperationResult::escapeFlags($this->config['dump_flags'], DatabaseType::POSTGRESQL);
         }
 
+        $major = $this->serverMajorVersion();
+        $binary = $this->binary('pg_dump', $major);
+
         // Flags must come before the database name (last positional argument)
         $command = sprintf(
             '%sPGPASSWORD=%s %s %s --host=%s --port=%s --username=%s%s %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
-            $this->binary('pg_dump'),
+            $binary,
             implode(' ', $options),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
@@ -119,24 +123,28 @@ class PostgresqlDatabase implements DatabaseInterface
 
         $command .= ' -f '.escapeshellarg($outputPath);
 
-        return new DatabaseOperationResult(command: $command);
+        return new DatabaseOperationResult(command: $command, log: $this->legacyClientLog($binary, $major));
     }
 
     public function restore(string $inputPath): DatabaseOperationResult
     {
+        $major = $this->serverMajorVersion();
+
         if (($this->config['dump_format'] ?? 'plain') === 'custom') {
+            $binary = $this->binary('pg_restore', $major);
+
             return new DatabaseOperationResult(command: sprintf(
                 '%sPGPASSWORD=%s %s %s --host=%s --port=%s --username=%s --dbname=%s %s',
                 $this->sslEnvPrefix(),
                 escapeshellarg($this->config['pass']),
-                $this->binary('pg_restore'),
+                $binary,
                 implode(' ', $this->withPrivilegeOptions(self::RESTORE_CUSTOM_FORMAT_OPTIONS)),
                 escapeshellarg($this->config['host']),
                 escapeshellarg((string) $this->config['port']),
                 escapeshellarg($this->config['user']),
                 escapeshellarg($this->config['database']),
                 escapeshellarg($inputPath),
-            ));
+            ), log: $this->legacyClientLog($binary, $major));
         }
 
         // -v ON_ERROR_STOP=1 makes psql abort and exit non-zero on the first
@@ -148,7 +156,7 @@ class PostgresqlDatabase implements DatabaseInterface
             '%sPGPASSWORD=%s %s --set=ON_ERROR_STOP=1 --host=%s --port=%s --username=%s %s -f %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
-            $this->binary('psql'),
+            $this->binary('psql', $major),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
             escapeshellarg($this->config['user']),
@@ -163,10 +171,8 @@ class PostgresqlDatabase implements DatabaseInterface
      * Servers below {@see LEGACY_CLIENT_MAJOR} get the matching older build
      * when the image carries one; everything else keeps the client on PATH.
      */
-    private function binary(string $name): string
+    private function binary(string $name, ?int $major): string
     {
-        $major = $this->serverMajorVersion();
-
         if ($major === null || $major > self::LEGACY_CLIENT_MAJOR) {
             return $name;
         }
@@ -181,8 +187,34 @@ class PostgresqlDatabase implements DatabaseInterface
 
         // No versioned build on this host, as on a native install without the
         // package. The client on PATH still dumps; its output just carries the
-        // forward-incompatible SET this method exists to steer around.
+        // forward-incompatible SET this method exists to steer around, which
+        // {@see legacyClientLog()} warns about rather than failing the backup.
         return $name;
+    }
+
+    /**
+     * Warn when an older server had to be handled by the client on PATH.
+     *
+     * A backup that runs and warns beats one that refuses: the snapshot still
+     * holds the data and still restores into a server as new as the client
+     * that wrote it. What it may not do is go back into the server it came
+     * from, and that is worth saying at the time rather than at recovery.
+     */
+    private function legacyClientLog(string $binary, ?int $major): ?DatabaseOperationLog
+    {
+        if ($major === null || $major > self::LEGACY_CLIENT_MAJOR || str_contains($binary, '/')) {
+            return null;
+        }
+
+        return new DatabaseOperationLog(
+            sprintf(
+                'No PostgreSQL %d client is installed, so the client on PATH was used against this PostgreSQL %d server. '
+                .'If it is newer, the snapshot will not restore into a server this old.',
+                self::LEGACY_CLIENT_MAJOR,
+                $major,
+            ),
+            'warning',
+        );
     }
 
     /**

--- a/app/Services/Backup/Databases/PostgresqlDatabase.php
+++ b/app/Services/Backup/Databases/PostgresqlDatabase.php
@@ -18,6 +18,17 @@ class PostgresqlDatabase implements DatabaseInterface
      */
     public const string DEFAULT_CONNECTION_DATABASE = 'postgres';
 
+    /**
+     * Newest client major whose output an older server still accepts.
+     *
+     * pg_dump 17 and 18 write `SET transaction_timeout = 0` into every dump,
+     * a GUC that only exists from PostgreSQL 17 on, and they do it whatever
+     * the version of the server they read. A dump is only guaranteed to load
+     * into a server at least as new as the client that wrote it, so servers
+     * below 17 are dumped and restored with a client of this major instead.
+     */
+    private const int LEGACY_CLIENT_MAJOR = 16;
+
     /** @var array<string, mixed> */
     private array $config;
 
@@ -94,9 +105,10 @@ class PostgresqlDatabase implements DatabaseInterface
 
         // Flags must come before the database name (last positional argument)
         $command = sprintf(
-            '%sPGPASSWORD=%s pg_dump %s --host=%s --port=%s --username=%s%s %s',
+            '%sPGPASSWORD=%s %s %s --host=%s --port=%s --username=%s%s %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
+            $this->binary('pg_dump'),
             implode(' ', $options),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
@@ -114,9 +126,10 @@ class PostgresqlDatabase implements DatabaseInterface
     {
         if (($this->config['dump_format'] ?? 'plain') === 'custom') {
             return new DatabaseOperationResult(command: sprintf(
-                '%sPGPASSWORD=%s pg_restore %s --host=%s --port=%s --username=%s --dbname=%s %s',
+                '%sPGPASSWORD=%s %s %s --host=%s --port=%s --username=%s --dbname=%s %s',
                 $this->sslEnvPrefix(),
                 escapeshellarg($this->config['pass']),
+                $this->binary('pg_restore'),
                 implode(' ', $this->withPrivilegeOptions(self::RESTORE_CUSTOM_FORMAT_OPTIONS)),
                 escapeshellarg($this->config['host']),
                 escapeshellarg((string) $this->config['port']),
@@ -132,15 +145,79 @@ class PostgresqlDatabase implements DatabaseInterface
         // dump is written with --clean --if-exists, so the DROP statements it
         // replays are not an error when the object is absent.
         return new DatabaseOperationResult(command: sprintf(
-            '%sPGPASSWORD=%s psql --set=ON_ERROR_STOP=1 --host=%s --port=%s --username=%s %s -f %s',
+            '%sPGPASSWORD=%s %s --set=ON_ERROR_STOP=1 --host=%s --port=%s --username=%s %s -f %s',
             $this->sslEnvPrefix(),
             escapeshellarg($this->config['pass']),
+            $this->binary('psql'),
             escapeshellarg($this->config['host']),
             escapeshellarg((string) $this->config['port']),
             escapeshellarg($this->config['user']),
             escapeshellarg($this->config['database']),
             escapeshellarg($inputPath)
         ));
+    }
+
+    /**
+     * Path to the libpq client binary to run for this server.
+     *
+     * Servers below {@see LEGACY_CLIENT_MAJOR} get the matching older build
+     * when the image carries one; everything else keeps the client on PATH.
+     */
+    private function binary(string $name): string
+    {
+        $major = $this->serverMajorVersion();
+
+        if ($major === null || $major > self::LEGACY_CLIENT_MAJOR) {
+            return $name;
+        }
+
+        foreach ($this->clientBinDirs() as $directory) {
+            $path = sprintf($directory, self::LEGACY_CLIENT_MAJOR).'/'.$name;
+
+            if (is_executable($path)) {
+                return $path;
+            }
+        }
+
+        // No versioned build on this host, as on a native install without the
+        // package. The client on PATH still dumps; its output just carries the
+        // forward-incompatible SET this method exists to steer around.
+        return $name;
+    }
+
+    /**
+     * Where a versioned client build lands, on Alpine and on Debian/Ubuntu.
+     *
+     * @return list<string>
+     */
+    protected function clientBinDirs(): array
+    {
+        return [
+            '/usr/libexec/postgresql%d',
+            '/usr/lib/postgresql/%d/bin',
+        ];
+    }
+
+    /**
+     * Major version the server reports, or null when it cannot be read.
+     */
+    private function serverMajorVersion(): ?int
+    {
+        // Unset for configs that never reach a server, such as the UI preview.
+        if (empty($this->config['probe_server_version'])) {
+            return null;
+        }
+
+        try {
+            $version = $this->createPdo()->getAttribute(\PDO::ATTR_SERVER_VERSION);
+        } catch (\PDOException) {
+            return null;
+        }
+
+        // Reported as "16.15 (Debian 16.15-1.pgdg13+2)", so the leading integer is the major.
+        $major = is_string($version) ? (int) $version : 0;
+
+        return $major > 0 ? $major : null;
     }
 
     /**

--- a/docs/docs/user-guide/database-servers.md
+++ b/docs/docs/user-guide/database-servers.md
@@ -14,7 +14,7 @@ Databasement uses standard CLI tools to perform backup and restore operations. T
 |------------|------------------------------|------------------------------|---------|
 | MySQL      | 5.6, 5.7, 8.x, 9.x, 26.x     | `mariadb-dump`               | Yes     |
 | MariaDB    | 10.x, 11.x, 12.x             | `mariadb-dump`               | Yes     |
-| PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v18                | Yes     |
+| PostgreSQL | 12, 13, 14, 15, 16, 17, 18   | `pg_dump` v16 / v18          | Yes     |
 | SQL Server | 2017, 2019, 2022, Azure SQL  | `sqlpackage` (`.dacpac`)     | Yes     |
 | MongoDB    | 4.2, 4.4, 5.0, 6.0, 7.0, 8.0 | `mongodump` / `mongorestore` | Yes     |
 | SQLite     | 3.x                          | File copy                    | Yes     |
@@ -24,7 +24,7 @@ Databasement uses standard CLI tools to perform backup and restore operations. T
 
 :::info How this works
 - **MySQL / MariaDB**: Databasement ships the MariaDB 11.4 client (`mariadb-dump`), which is wire-protocol compatible with MySQL servers. On MySQL 26.0 and later, stored procedures and functions are left out of the dump: the client reads MySQL's new YY.M version number (9.7 → 26.7) as a MariaDB one and asks for stored packages, which MySQL rejects. Tables, data, views and triggers are unaffected, and the job logs a warning.
-- **PostgreSQL**: The `pg_dump` v18 client can dump from any server version back to 9.2. Versions below 12 have reached end-of-life and are not recommended.
+- **PostgreSQL**: Databasement ships both the v16 and the v18 client and runs whichever one matches the server: v16 for servers up to 16, v18 for 17 and later. A dump only replays into a server at least as new as the client that wrote it, so a single v18 client would produce snapshots that no server below 17 could restore, not even the one they came from. Each client dumps from any server back to 9.2. Versions below 12 have reached end-of-life and are not recommended.
 - **SQL Server**: Backups are extracted as `.dacpac` files (schema + table data) using Microsoft's `sqlpackage` CLI (`/Action:Extract`) and re-applied with `/Action:Publish`. Server-bound objects (logins, users, permissions, role memberships) are excluded so backups stay portable across instances and don't fail on Windows-auth principals like `[NT AUTHORITY\SYSTEM]`. Works against on-prem SQL Server 2017+ and Azure SQL Database. Connections use the `pdo_sqlsrv` PHP extension.
 - **MongoDB**: The MongoDB Database Tools (`mongodump` / `mongorestore`) officially support server versions 4.2 through 8.0.
 - **SQLite**: Backups are performed by copying the database file over SFTP. The SQLite 3.x file format has been backwards-compatible since 3.0.0 (2004).

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -134,7 +134,7 @@ use App\Enums\DatabaseType;
 
                                     @if($form->dump_format === 'custom')
                                         <x-alert class="alert-warning" icon="o-exclamation-triangle">
-                                            {{ __('Custom format archives are version-sensitive: the target restore server must be PostgreSQL 17 or newer. Restores run with 4 parallel pg_restore workers.') }}
+                                            {{ __('Custom format archives are version-sensitive: the target restore server must be no older than this one. Restores run with 4 parallel pg_restore workers.') }}
                                         </x-alert>
                                     @endif
 

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -6,15 +6,30 @@ use App\Services\Backup\DTO\DatabaseOperationResult;
 use App\Services\Backup\InMemoryBackupLogger;
 use Illuminate\Support\Facades\Process;
 
-beforeEach(function () {
-    $this->db = new PostgresqlDatabase;
-    $this->db->setConfig([
+/** The connection every handler in this file is built on, with $overrides applied. */
+function postgresConfig(array $overrides = []): array
+{
+    return [
         'host' => 'pg.local',
         'port' => 5432,
         'user' => 'postgres',
         'pass' => 'pg_secret',
         'database' => 'myapp',
-    ]);
+        ...$overrides,
+    ];
+}
+
+/** A handler wired to {@see postgresConfig()}. */
+function postgresHandler(array $overrides = []): PostgresqlDatabase
+{
+    $db = new PostgresqlDatabase;
+    $db->setConfig(postgresConfig($overrides));
+
+    return $db;
+}
+
+beforeEach(function () {
+    $this->db = postgresHandler();
 });
 
 test('dump builds correct pg_dump command', function () {
@@ -25,15 +40,7 @@ test('dump builds correct pg_dump command', function () {
 });
 
 test('dump includes extra dump flags', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'dump_flags' => '--exclude-table=large_logs',
-    ]);
+    $db = postgresHandler(['dump_flags' => '--exclude-table=large_logs']);
 
     $result = $db->dump('/tmp/dump.sql');
 
@@ -56,15 +63,7 @@ test('plain restore stops on the first SQL error instead of exiting successfully
 });
 
 test('dump appends --format=custom when dump_format is custom', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'dump_format' => 'custom',
-    ]);
+    $db = postgresHandler(['dump_format' => 'custom']);
 
     $result = $db->dump('/tmp/dump.sql');
 
@@ -73,15 +72,7 @@ test('dump appends --format=custom when dump_format is custom', function () {
 });
 
 test('restore uses pg_restore when dump_format config is custom', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'dump_format' => 'custom',
-    ]);
+    $db = postgresHandler(['dump_format' => 'custom']);
 
     $result = $db->restore('/tmp/snapshot.sql');
 
@@ -91,15 +82,7 @@ test('restore uses pg_restore when dump_format config is custom', function () {
 });
 
 test('dump keeps ownership and privileges when dump_privileges is enabled', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'dump_privileges' => true,
-    ]);
+    $db = postgresHandler(['dump_privileges' => true]);
 
     $result = $db->dump('/tmp/dump.sql');
 
@@ -107,16 +90,7 @@ test('dump keeps ownership and privileges when dump_privileges is enabled', func
 });
 
 test('custom format restore keeps ownership and privileges when dump_privileges is enabled', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'dump_format' => 'custom',
-        'dump_privileges' => true,
-    ]);
+    $db = postgresHandler(['dump_format' => 'custom', 'dump_privileges' => true]);
 
     $result = $db->restore('/tmp/snapshot.sql');
 
@@ -125,62 +99,15 @@ test('custom format restore keeps ownership and privileges when dump_privileges 
     );
 });
 
-test('restore falls back to psql when dump_format is absent', function () {
-    $result = $this->db->restore('/tmp/snapshot.sql');
+test('every client is prefixed with PGSSLMODE=require when ssl_enabled is true', function (array $overrides, string $method, string $binary) {
+    $result = postgresHandler([...$overrides, 'ssl_enabled' => true])->{$method}('/tmp/snapshot.sql');
 
-    expect($result->command)->toStartWith("PGPASSWORD='pg_secret' psql ")
-        ->and($result->command)->toContain('--set=ON_ERROR_STOP=1')
-        ->and($result->command)->toContain('-f ');
-});
-
-test('dump prefixes PGSSLMODE=require when ssl_enabled is true', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'ssl_enabled' => true,
-    ]);
-
-    $result = $db->dump('/tmp/dump.sql');
-
-    expect($result->command)->toStartWith("PGSSLMODE=require PGPASSWORD='pg_secret' pg_dump ");
-});
-
-test('plain restore prefixes PGSSLMODE=require when ssl_enabled is true', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'ssl_enabled' => true,
-    ]);
-
-    $result = $db->restore('/tmp/restore.sql');
-
-    expect($result->command)->toStartWith("PGSSLMODE=require PGPASSWORD='pg_secret' psql ");
-});
-
-test('custom-format restore prefixes PGSSLMODE=require when ssl_enabled is true', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'dump_format' => 'custom',
-        'ssl_enabled' => true,
-    ]);
-
-    $result = $db->restore('/tmp/snapshot.sql');
-
-    expect($result->command)->toStartWith("PGSSLMODE=require PGPASSWORD='pg_secret' pg_restore ");
-});
+    expect($result->command)->toStartWith("PGSSLMODE=require PGPASSWORD='pg_secret' {$binary} ");
+})->with([
+    'dump' => [[], 'dump', 'pg_dump'],
+    'plain restore' => [[], 'restore', 'psql'],
+    'custom-format restore' => [['dump_format' => 'custom'], 'restore', 'pg_restore'],
+]);
 
 test('dump and restore omit PGSSLMODE when ssl_enabled is absent', function () {
     expect($this->db->dump('/tmp/dump.sql')->command)->not->toContain('PGSSLMODE')
@@ -194,15 +121,7 @@ test('testConnection query command carries PGSSLMODE=require when ssl_enabled is
         'PGSSLMODE=require*ssl*' => Process::result(output: 'yes'),
     ]);
 
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
-        'user' => 'postgres',
-        'pass' => 'pg_secret',
-        'database' => 'myapp',
-        'ssl_enabled' => true,
-    ]);
+    $db = postgresHandler(['ssl_enabled' => true]);
 
     $result = $db->testConnection();
 
@@ -225,7 +144,7 @@ test('listDatabases returns databases excluding managed-service internals but ke
 
     $db = Mockery::mock(PostgresqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $db->shouldReceive('createPdo')->once()->andReturn($pdo);
-    $db->setConfig(['host' => 'pg.local', 'port' => 5432, 'user' => 'postgres', 'pass' => 'pg_secret', 'database' => 'postgres']);
+    $db->setConfig(postgresConfig(['database' => 'postgres']));
 
     $databases = $db->listDatabases();
 
@@ -270,16 +189,12 @@ test('admin connections use the configured connection database', function (?stri
         }
     };
 
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
+    // The target database stays 'myapp', deliberately different from the
+    // connection one: listDatabases() must not connect there.
+    $db->setConfig(postgresConfig([
         'user' => 'app',
-        'pass' => 'pg_secret',
-        // The target database, deliberately different from the connection one:
-        // listDatabases() must not connect here.
-        'database' => 'myapp',
         'connection_database' => $configured,
-    ]);
+    ]));
 
     expect(fn () => $db->listDatabases())->toThrow(PDOException::class)
         ->and($db->connectedTo)->toBe($expected);
@@ -290,12 +205,8 @@ test('admin connections use the configured connection database', function (?stri
 ]);
 
 test('prepareForRestore refuses to recreate the connection database', function () {
-    $db = new PostgresqlDatabase;
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
+    $db = postgresHandler([
         'user' => 'app',
-        'pass' => 'pg_secret',
         'database' => 'app_db',
         'connection_database' => 'app_db',
     ]);
@@ -326,14 +237,11 @@ function postgresHandlerConnectingWith(PDO $adminPdo, bool $dumpPrivileges): Pos
 {
     $db = Mockery::mock(PostgresqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
     $db->shouldReceive('createPdo')->once()->andReturn($adminPdo);
-    $db->setConfig([
-        'host' => 'pg.local',
-        'port' => 5432,
+    $db->setConfig(postgresConfig([
         'user' => 'databasement',
-        'pass' => 'pg_secret',
         'database' => 'restored_db',
         'dump_privileges' => $dumpPrivileges,
-    ]);
+    ]));
 
     return $db;
 }
@@ -362,4 +270,103 @@ test('ownership transfer leaves the restored objects alone for a snapshot that c
     $db->shouldNotReceive('createPdoForDatabase');
 
     $db->transferOwnership('restored_db', 'webapp', new InMemoryBackupLogger);
+});
+
+/**
+ * A handler on a live server reporting $serverVersion, exactly as PDO hands it
+ * back from ATTR_SERVER_VERSION. Null stands for a server that cannot be read.
+ */
+function postgresHandlerReportingVersion(?string $serverVersion, array $config = []): PostgresqlDatabase
+{
+    $pdo = Mockery::mock(PDO::class);
+
+    if ($serverVersion === null) {
+        $pdo->shouldReceive('getAttribute')->andThrow(new PDOException('server closed the connection unexpectedly'));
+    } else {
+        $pdo->shouldReceive('getAttribute')->with(PDO::ATTR_SERVER_VERSION)->andReturn($serverVersion);
+    }
+
+    $db = Mockery::mock(PostgresqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldReceive('createPdo')->andReturn($pdo);
+    $db->setConfig(postgresConfig(['probe_server_version' => true, ...$config]));
+
+    return $db;
+}
+
+// pg_dump 17 and 18 emit `SET transaction_timeout = 0`, a PG17+ GUC, whatever
+// the version of the server they read, so their output cannot be replayed into
+// an older server — not even the one it came from (#588, #590).
+test('a server below 17 is dumped and restored with the matching older client', function (string $method, string $binary) {
+    $result = postgresHandlerReportingVersion('16.15 (Debian 16.15-1.pgdg13+2)')->{$method}('/tmp/snapshot.sql');
+
+    expect($result->command)->toContain("/postgresql16/{$binary} ")
+        ->and($result->command)->not->toContain("PGPASSWORD='pg_secret' {$binary} ");
+})->with([
+    'dump' => ['dump', 'pg_dump'],
+    'restore' => ['restore', 'psql'],
+])->skip(
+    ! is_executable('/usr/libexec/postgresql16/pg_dump'),
+    'no PostgreSQL 16 client build in this image',
+);
+
+test('a custom-format snapshot restores into a server below 17 with the matching older client', function () {
+    $result = postgresHandlerReportingVersion('16.15', ['dump_format' => 'custom'])->restore('/tmp/snapshot.dump');
+
+    expect($result->command)->toContain('/postgresql16/pg_restore ');
+})->skip(
+    ! is_executable('/usr/libexec/postgresql16/pg_restore'),
+    'no PostgreSQL 16 client build in this image',
+);
+
+// A native install without the versioned package still has to dump, so an
+// older server with no matching build anywhere falls back to the client on
+// PATH rather than to a path that does not exist.
+test('a server below 17 falls back to the client on PATH when no matching build is installed', function () {
+    $db = postgresHandlerReportingVersion('16.15');
+    $db->shouldReceive('clientBinDirs')->andReturn(['/nonexistent/postgresql%d']);
+
+    expect($db->dump('/tmp/dump.sql')->command)->toContain("PGPASSWORD='pg_secret' pg_dump ")
+        ->and($db->restore('/tmp/restore.sql')->command)->toContain("PGPASSWORD='pg_secret' psql ");
+});
+
+test('servers the default client can write for keep it', function (?string $serverVersion) {
+    $db = postgresHandlerReportingVersion($serverVersion);
+
+    expect($db->dump('/tmp/dump.sql')->command)->toContain("PGPASSWORD='pg_secret' pg_dump ")
+        ->and($db->restore('/tmp/restore.sql')->command)->toContain("PGPASSWORD='pg_secret' psql ");
+})->with([
+    'PostgreSQL 17' => ['17.11 (Debian 17.11-1.pgdg13+2)'],
+    'PostgreSQL 18' => ['18.6 (Debian 18.6-1.pgdg13+2)'],
+    'unreadable version' => [null],
+]);
+
+// The major has to survive every shape a server states its version in: managed
+// services report a bare `major.minor`, distro packages append their own build
+// string, and a pre-release has no minor at all. Anything unreadable must fall
+// back to the default client rather than to major 0, which would read as
+// ancient and wrongly pick the legacy one.
+test('the client follows the major whatever shape the reported version comes in', function (string $reported, string $expected) {
+    expect(postgresHandlerReportingVersion($reported)->dump('/tmp/dump.sql')->command)->toContain($expected);
+})->with([
+    'Debian and Ubuntu pgdg build, 16' => ['16.15 (Debian 16.15-1.pgdg13+2)', '/postgresql16/pg_dump '],
+    'Alpine build, 16' => ['16.15', '/postgresql16/pg_dump '],
+    'Homebrew build, 16' => ['16.15 (Homebrew)', '/postgresql16/pg_dump '],
+    'Amazon RDS and Aurora, 12' => ['12.7', '/postgresql16/pg_dump '],
+    'legacy 9.x numbering' => ['9.6.24', '/postgresql16/pg_dump '],
+    'managed service, 17' => ['17.11', "PGPASSWORD='pg_secret' pg_dump "],
+    'Debian pgdg build, 18' => ['18.6 (Debian 18.6-1.pgdg13+2)', "PGPASSWORD='pg_secret' pg_dump "],
+    'pre-release, 18' => ['18beta1', "PGPASSWORD='pg_secret' pg_dump "],
+    'empty' => ['', "PGPASSWORD='pg_secret' pg_dump "],
+    'unparseable' => ['not a version', "PGPASSWORD='pg_secret' pg_dump "],
+])->skip(
+    ! is_executable('/usr/libexec/postgresql16/pg_dump'),
+    'no PostgreSQL 16 client build in this image',
+);
+
+test('a display-only config is never probed for its version', function () {
+    $db = Mockery::mock(PostgresqlDatabase::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $db->shouldNotReceive('createPdo');
+    $db->setConfig(postgresConfig());
+
+    expect($db->dump('/tmp/dump.sql')->command)->toContain("PGPASSWORD='pg_secret' pg_dump ");
 });

--- a/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
+++ b/tests/Feature/Services/Backup/Databases/PostgresqlDatabaseTest.php
@@ -329,6 +329,30 @@ test('a server below 17 falls back to the client on PATH when no matching build 
         ->and($db->restore('/tmp/restore.sql')->command)->toContain("PGPASSWORD='pg_secret' psql ");
 });
 
+// Falling back is survivable, but it produces a snapshot the source server
+// cannot take back, so the job log has to say so while the backup is running.
+test('falling back to the client on PATH warns that the snapshot may not restore', function (string $method, array $config) {
+    $db = postgresHandlerReportingVersion('16.15', $config);
+    $db->shouldReceive('clientBinDirs')->andReturn(['/nonexistent/postgresql%d']);
+
+    $log = $db->{$method}('/tmp/snapshot.sql')->log;
+
+    expect($log?->level)->toBe('warning')
+        ->and($log?->message)->toContain('No PostgreSQL 16 client is installed')
+        ->and($log?->message)->toContain('PostgreSQL 16 server');
+})->with([
+    'dump' => ['dump', []],
+    'custom-format restore' => ['restore', ['dump_format' => 'custom']],
+]);
+
+test('a server handled by the matching client is not warned about', function () {
+    expect(postgresHandlerReportingVersion('16.15')->dump('/tmp/dump.sql')->log)->toBeNull()
+        ->and(postgresHandlerReportingVersion('17.11')->dump('/tmp/dump.sql')->log)->toBeNull();
+})->skip(
+    ! is_executable('/usr/libexec/postgresql16/pg_dump'),
+    'no PostgreSQL 16 client build in this image',
+);
+
 test('servers the default client can write for keep it', function (?string $serverVersion) {
     $db = postgresHandlerReportingVersion($serverVersion);
 


### PR DESCRIPTION
`pg_dump` reading an older server is supported, but the reverse is not: its output is only guaranteed to load into a server at least as new as the client that wrote it. The image shipped only the v18 client, and v18 writes `SET transaction_timeout = 0` into every dump it produces, a GUC that only exists from PostgreSQL 17 on. Every snapshot taken from a server below 17 was therefore unrestorable, including back onto the server it came from. That is #588 and #590.

The handler now probes the server and runs the v16 client for majors up to 16, keeping the default v18 for 17 and later. #595 put that client in the image.

## Why a second client rather than stripping the line

`pg_dump` has no flag that suppresses the SET preamble, so the options were a version-matched client or rewriting the dump ourselves. Rewriting only covers plain SQL: custom format is a binary archive and `pg_restore` 18 emits the same statement, which is what the "target must be PostgreSQL 17 or newer" warning on the dump format selector was working around. Matching the client fixes both formats and lets that warning go.

Diffing the two clients against one PostgreSQL 16 server showed the output differs by exactly that single line, and against a 17 server the v18 and v17 output are identical. That is why only the v16 package was added rather than v16 and v17.

## Known limitation

Only backups taken after this ships are restorable. Existing snapshots already carry the line, and no restore-side client can remove it because psql just forwards it to the server, so affected users need a fresh backup. The failure is at least safe: `ON_ERROR_STOP=1` aborts on the SET, which precedes every DROP in the dump, so a failed restore leaves the target untouched unless database recreation was requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PostgreSQL backups now select a compatible client version based on the server, improving restore compatibility across supported PostgreSQL versions.
  - The system falls back to the default client when a matching versioned client is unavailable or server version detection is inconclusive, with a warning recorded in the operation log.
  - Custom dump restore guidance now reflects source and target server version compatibility.

- **Documentation**
  - Updated supported PostgreSQL client versions and compatibility guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->