### PR TITLE
Normalize button loading states across the app

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,7 @@ Authorization is built on [silber/bouncer](https://github.com/JosephSilber/bounc
 - Alert pattern: Use `class="alert-success"`, `class="alert-error"`, etc.
 - Form components: `<x-input>`, `<x-password>`, `<x-select>`, `<x-checkbox>`, etc.
 - Translated attributes: always use `:attr` bindings (`:label="__('Host')"`), never `label="{{ __('Host') }}"` — interpolation double-encodes special characters (see "Avoiding HTML Encoding Artifacts" below)
+- Loading states: every `<x-button>` / `<x-menu-item>` with `wire:click` takes the bare `spinner` prop (it targets the click expression, parameters included, so per-row buttons spin individually); `type="submit"` buttons of `wire:submit` forms take `spinner="method"`; `$set`/`$toggle` clicks take `spinner="property"`; classic POST forms (auth pages, logout) use `<x-submit-button>`.
 - Documentation: https://mary-ui.com/docs/components/button
 
 ### Resource Index Pages

--- a/app/Livewire/DatabaseServer/Form.php
+++ b/app/Livewire/DatabaseServer/Form.php
@@ -142,8 +142,6 @@ class Form extends \Livewire\Form
 
     public bool $connectionTestSuccess = false;
 
-    public bool $testingConnection = false;
-
     /** @var array<string, mixed> Connection test details (dbms, ping, ssl, etc.) */
     public array $connectionTestDetails = [];
 
@@ -1100,7 +1098,6 @@ class Form extends \Livewire\Form
 
     public function testConnection(): void
     {
-        $this->testingConnection = true;
         $this->connectionTestMessage = null;
         $this->connectionTestDetails = [];
         $this->availableDatabases = [];
@@ -1122,7 +1119,6 @@ class Form extends \Livewire\Form
                 $this->validate($rules);
             }
         } catch (ValidationException $e) {
-            $this->testingConnection = false;
             $this->connectionTestSuccess = false;
             /** @var string $message */
             $message = collect($e->errors())->flatten()->first()
@@ -1136,7 +1132,6 @@ class Form extends \Livewire\Form
         try {
             $password = $this->password ?: $this->server?->getDecryptedPassword();
         } catch (EncryptionException $e) {
-            $this->testingConnection = false;
             $this->connectionTestSuccess = false;
             $this->connectionTestMessage = $e->getMessage();
 
@@ -1165,7 +1160,6 @@ class Form extends \Livewire\Form
         $this->connectionTestSuccess = $result['success'];
         $this->connectionTestMessage = $result['message'];
         $this->connectionTestDetails = $result['details'];
-        $this->testingConnection = false;
 
         // If connection successful and supports per-database backups, load available databases
         if ($this->connectionTestSuccess && ! $this->identifiesDatabasesByPath() && ! $this->isRedis()) {

--- a/app/Livewire/Volume/Form.php
+++ b/app/Livewire/Volume/Form.php
@@ -50,8 +50,6 @@ class Form extends \Livewire\Form
 
     public bool $connectionTestSuccess = false;
 
-    public bool $testingConnection = false;
-
     public function __construct(
         Component $component,
         mixed $propertyName,
@@ -216,7 +214,6 @@ class Form extends \Livewire\Form
 
     public function testConnection(): void
     {
-        $this->testingConnection = true;
         $this->connectionTestMessage = null;
 
         $volumeType = VolumeType::from($this->type);
@@ -232,7 +229,6 @@ class Form extends \Livewire\Form
         try {
             $this->validate($filteredRules);
         } catch (ValidationException) {
-            $this->testingConnection = false;
             $this->connectionTestSuccess = false;
             $this->connectionTestMessage = 'Please fill in all required configuration fields.';
 
@@ -257,6 +253,5 @@ class Form extends \Livewire\Form
 
         $this->connectionTestSuccess = $result['success'];
         $this->connectionTestMessage = $result['message'];
-        $this->testingConnection = false;
     }
 }

--- a/lang/el.json
+++ b/lang/el.json
@@ -617,8 +617,6 @@
   "Test SSH": "Δοκιμή SSH",
   "Test notification sent to: :channel": "Η δοκιμαστική ειδοποίηση στάλθηκε στο: :channel",
   "Test notification sent to: :channels": "Η δοκιμαστική ειδοποίηση στάλθηκε στα: :channels",
-  "Testing Connection...": "Δοκιμή σύνδεσης...",
-  "Testing...": "Δοκιμή...",
   "The AWS region where your S3 bucket is located.": "Η AWS region όπου βρίσκεται το S3 bucket σας.",
   "The Discord channel where failure notifications are sent.": "Το Discord channel όπου αποστέλλονται ειδοποιήσεις αποτυχίας.",
   "The chat or group ID where failure notifications are sent.": "Το ID chat ή group όπου αποστέλλονται ειδοποιήσεις αποτυχίας.",

--- a/lang/es.json
+++ b/lang/es.json
@@ -620,8 +620,6 @@
   "Test SSH": "Probar SSH",
   "Test notification sent to: :channel": "Notificación de prueba enviada a: :channel",
   "Test notification sent to: :channels": "Notificación de prueba enviada a: :channels",
-  "Testing Connection...": "Probando la conexión...",
-  "Testing...": "Probando...",
   "The AWS region where your S3 bucket is located.": "La región de AWS donde se encuentra su bucket S3.",
   "The Discord channel where failure notifications are sent.": "El canal de Discord donde se envían las notificaciones de error.",
   "The chat or group ID where failure notifications are sent.": "El ID de chat o grupo al que se envían las notificaciones de error.",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -622,8 +622,6 @@
   "Test SSH": "Tester SSH",
   "Test notification sent to: :channel": "Notification de test envoyée à : :channel",
   "Test notification sent to: :channels": "Notification de test envoyée à : :channels",
-  "Testing Connection...": "Test de la connexion...",
-  "Testing...": "Test en cours...",
   "The AWS region where your S3 bucket is located.": "La région AWS où se trouve votre bucket S3.",
   "The Discord channel where failure notifications are sent.": "Le canal Discord où les notifications d’échec sont envoyées.",
   "The chat or group ID where failure notifications are sent.": "L’ID du chat ou groupe où les notifications d’échec sont envoyées.",

--- a/lang/zh_TW.json
+++ b/lang/zh_TW.json
@@ -622,8 +622,6 @@
   "Test SSH": "測試 SSH",
   "Test notification sent to: :channel": "測試通知已傳送至：:channel",
   "Test notification sent to: :channels": "測試通知已傳送至：:channels",
-  "Testing Connection...": "正在測試連線…",
-  "Testing...": "測試中…",
   "The AWS region where your S3 bucket is located.": "您的 S3 bucket 所在的 AWS 區域。",
   "The Discord channel where failure notifications are sent.": "傳送失敗通知的 Discord 頻道。",
   "The chat or group ID where failure notifications are sent.": "傳送失敗通知的聊天或群組 ID。",

--- a/resources/views/components/delete-confirmation-modal.blade.php
+++ b/resources/views/components/delete-confirmation-modal.blade.php
@@ -22,6 +22,6 @@
 
     <x-slot:actions>
         <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
-        <x-button :label="__('Delete')" class="btn-error" wire:click="{{ $onConfirm }}" spinner="{{ $onConfirm }}" />
+        <x-button :label="__('Delete')" class="btn-error" wire:click="{{ $onConfirm }}" spinner />
     </x-slot:actions>
 </x-modal>

--- a/resources/views/components/invitation-link-modal.blade.php
+++ b/resources/views/components/invitation-link-modal.blade.php
@@ -22,7 +22,7 @@
 
     <x-slot:actions>
         @if($doneAction)
-            <x-button label="{{ $doneLabel }}" wire:click="{{ $doneAction }}" class="btn-primary" />
+            <x-button label="{{ $doneLabel }}" wire:click="{{ $doneAction }}" spinner class="btn-primary" />
         @else
             <x-button label="{{ $doneLabel }}" @click="$wire.showCopyModal = false" class="btn-primary" />
         @endif

--- a/resources/views/components/submit-button.blade.php
+++ b/resources/views/components/submit-button.blade.php
@@ -1,0 +1,25 @@
+{{--
+    Submit button for a classic (non-Livewire) form. Mary's `spinner` relies on
+    wire:loading, so here the loading state is driven by the form's submit event.
+--}}
+@props([
+    'label' => null,
+    'icon' => null,
+])
+
+<x-button
+    type="submit"
+    x-data="{ submitting: false }"
+    x-init="$el.form?.addEventListener('submit', () => submitting = true)"
+    x-on:pageshow.window="submitting = false"
+    x-bind:disabled="submitting"
+    {{ $attributes }}
+>
+    <x-loading x-show="submitting" x-cloak class="loading-spinner w-5 h-5" />
+    @if($icon)
+        <span class="block" x-show="! submitting">
+            <x-icon :name="$icon" />
+        </span>
+    @endif
+    {{ $label ?? $slot }}
+</x-button>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -78,9 +78,9 @@
                         @endunless
                         <form method="POST" action="{{ route('logout') }}" class="w-full">
                             @csrf
-                            <x-button type="submit" class="w-full" icon="o-power">
+                            <x-submit-button class="w-full" icon="o-power">
                                 {{ __('Logout') }}
-                            </x-button>
+                            </x-submit-button>
                         </form>
                     </x-menu-sub>
                 </x-menu>

--- a/resources/views/livewire/agent/_token-modal.blade.php
+++ b/resources/views/livewire/agent/_token-modal.blade.php
@@ -41,7 +41,7 @@
     </x-tabs>
 
     <x-slot:actions>
-        <x-button :label="__('Done')" class="btn-primary" wire:click="closeTokenModal" />
+        <x-button :label="__('Done')" class="btn-primary" wire:click="closeTokenModal" spinner />
     </x-slot:actions>
 
 </x-modal>

--- a/resources/views/livewire/agent/edit.blade.php
+++ b/resources/views/livewire/agent/edit.blade.php
@@ -25,6 +25,7 @@
                 icon="o-arrow-path"
                 class="btn-warning btn-sm"
                 wire:click="confirmRegenerate"
+                spinner
             />
         </div>
     </x-card>
@@ -35,7 +36,7 @@
 
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showRegenerateModal = false" />
-            <x-button :label="__('Regenerate')" class="btn-warning" wire:click="regenerateToken" spinner="regenerateToken" />
+            <x-button :label="__('Regenerate')" class="btn-warning" wire:click="regenerateToken" spinner />
         </x-slot:actions>
     </x-modal>
 

--- a/resources/views/livewire/agent/index.blade.php
+++ b/resources/views/livewire/agent/index.blade.php
@@ -108,6 +108,7 @@
                         <x-button
                             icon="o-trash"
                             wire:click="confirmDelete('{{ $agent->id }}')"
+                            spinner
                             :tooltip="__('Delete')"
                             class="btn-ghost btn-sm text-error"
                         />

--- a/resources/views/livewire/api-token/index.blade.php
+++ b/resources/views/livewire/api-token/index.blade.php
@@ -1,7 +1,7 @@
 <div>
     <x-header title="{{ __('API Tokens') }}" subtitle="{{ __('Manage your personal access tokens for API authentication') }}" size="text-2xl" separator class="mb-6">
         <x-slot:actions>
-            <x-button label="{{ __('Create Token') }}" icon="o-plus" class="btn-primary" wire:click="openCreateModal" />
+            <x-button label="{{ __('Create Token') }}" icon="o-plus" class="btn-primary" wire:click="openCreateModal" spinner />
         </x-slot:actions>
     </x-header>
 
@@ -42,6 +42,7 @@
                             <x-button
                                 icon="o-trash"
                                 wire:click="confirmDelete('{{ $token->id }}')"
+                                spinner
                                 tooltip="{{ __('Revoke') }}"
                                 class="btn-ghost btn-sm text-error"
                             />
@@ -62,8 +63,8 @@
         />
 
         <x-slot:actions>
-            <x-button label="{{ __('Cancel') }}" wire:click="closeCreateModal" />
-            <x-button label="{{ __('Create') }}" wire:click="createToken" class="btn-primary" spinner="createToken" />
+            <x-button label="{{ __('Cancel') }}" wire:click="closeCreateModal" spinner />
+            <x-button label="{{ __('Create') }}" wire:click="createToken" class="btn-primary" spinner />
         </x-slot:actions>
     </x-modal>
 
@@ -91,7 +92,7 @@
         </div>
 
         <x-slot:actions>
-            <x-button label="{{ __('Done') }}" class="btn-primary" wire:click="closeTokenModal" />
+            <x-button label="{{ __('Done') }}" class="btn-primary" wire:click="closeTokenModal" spinner />
         </x-slot:actions>
     </x-modal>
 
@@ -100,8 +101,8 @@
         <p>{{ __('Are you sure you want to revoke this token? Any applications using this token will no longer be able to access the API.') }}</p>
 
         <x-slot:actions>
-            <x-button label="{{ __('Cancel') }}" wire:click="closeDeleteModal" />
-            <x-button label="{{ __('Revoke Token') }}" class="btn-error" wire:click="deleteToken" spinner="deleteToken" />
+            <x-button label="{{ __('Cancel') }}" wire:click="closeDeleteModal" spinner />
+            <x-button label="{{ __('Revoke Token') }}" class="btn-error" wire:click="deleteToken" spinner />
         </x-slot:actions>
     </x-modal>
 </div>

--- a/resources/views/livewire/auth/confirm-password.blade.php
+++ b/resources/views/livewire/auth/confirm-password.blade.php
@@ -21,7 +21,7 @@
                 placeholder="{{ __('Password') }}"
             />
 
-            <x-button type="submit" class="btn-primary w-full" label="{{ __('Confirm') }}" data-test="confirm-password-button" />
+            <x-submit-button class="btn-primary w-full" :label="__('Confirm')" data-test="confirm-password-button" />
         </form>
     </div>
 </x-layouts::auth>

--- a/resources/views/livewire/auth/forgot-password.blade.php
+++ b/resources/views/livewire/auth/forgot-password.blade.php
@@ -24,7 +24,7 @@
                 placeholder="email@example.com"
             />
 
-            <x-button type="submit" class="btn-primary w-full" label="{{ __('Email password reset link') }}" data-test="email-password-reset-link-button" />
+            <x-submit-button class="btn-primary w-full" :label="__('Email password reset link')" data-test="email-password-reset-link-button" />
         </form>
 
         <div class="space-x-1 rtl:space-x-reverse text-center text-sm">

--- a/resources/views/livewire/auth/login.blade.php
+++ b/resources/views/livewire/auth/login.blade.php
@@ -72,7 +72,7 @@
                 <x-checkbox name="remember" label="{{ __('Remember me') }}" :checked="old('remember')" />
 
                 <div class="flex items-center justify-end">
-                    <x-button type="submit" class="btn-primary w-full" label="{{ __('Log in') }}" data-test="login-button" />
+                    <x-submit-button class="btn-primary w-full" :label="__('Log in')" data-test="login-button" />
                 </div>
             </x-form>
         @endunless

--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -66,7 +66,7 @@
             @endif
 
             <div class="flex items-center justify-end">
-                <x-button type="submit" class="btn-primary w-full" label="{{ __('Create account') }}" data-test="register-user-button" />
+                <x-submit-button class="btn-primary w-full" :label="__('Create account')" data-test="register-user-button" />
             </div>
         </form>
     </div>

--- a/resources/views/livewire/auth/reset-password.blade.php
+++ b/resources/views/livewire/auth/reset-password.blade.php
@@ -45,7 +45,7 @@
             />
 
             <div class="flex items-center justify-end">
-                <x-button type="submit" class="btn-primary w-full" label="{{ __('Reset password') }}" data-test="reset-password-button" />
+                <x-submit-button class="btn-primary w-full" :label="__('Reset password')" data-test="reset-password-button" />
             </div>
         </form>
     </div>

--- a/resources/views/livewire/auth/two-factor-challenge.blade.php
+++ b/resources/views/livewire/auth/two-factor-challenge.blade.php
@@ -73,10 +73,9 @@
                         @enderror
                     </div>
 
-                    <x-button
-                        type="submit"
+                    <x-submit-button
                         class="btn-primary w-full"
-                        label="{{ __('Continue') }}"
+                        :label="__('Continue')"
                     />
                 </div>
 

--- a/resources/views/livewire/auth/verify-email.blade.php
+++ b/resources/views/livewire/auth/verify-email.blade.php
@@ -13,12 +13,12 @@
         <div class="flex flex-col items-center justify-between space-y-3">
             <form method="POST" action="{{ route('verification.send') }}">
                 @csrf
-                <x-button type="submit" class="btn-primary w-full" label="{{ __('Resend verification email') }}" />
+                <x-submit-button class="btn-primary w-full" :label="__('Resend verification email')" />
             </form>
 
             <form method="POST" action="{{ route('logout') }}">
                 @csrf
-                <x-button type="submit" class="btn-ghost text-sm" label="{{ __('Log out') }}" data-test="logout-button" />
+                <x-submit-button class="btn-ghost text-sm" :label="__('Log out')" data-test="logout-button" />
             </form>
         </div>
     </div>

--- a/resources/views/livewire/configuration/backup.blade.php
+++ b/resources/views/livewire/configuration/backup.blade.php
@@ -23,6 +23,7 @@
                         icon="o-plus"
                         class="btn-primary btn-sm"
                         wire:click="openScheduleModal"
+                        spinner
                     />
                 @endif
             </x-card-heading>
@@ -76,7 +77,7 @@
                 @scope('cell_actions', $schedule)
                     @if ($this->canManage)
                         <div class="flex justify-end flex-nowrap gap-1">
-                            <x-button icon="o-pencil-square" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openScheduleModal('{{ $schedule->id }}')" :tooltip-left="__('Edit')" />
+                            <x-button icon="o-pencil-square" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openScheduleModal('{{ $schedule->id }}')" spinner :tooltip-left="__('Edit')" />
                             @if ($schedule->total_backups_count > 0 || $schedule->scheduled_restores_count > 0)
                                 <x-popover>
                                     <x-slot:trigger>
@@ -93,7 +94,7 @@
                                     </x-slot:content>
                                 </x-popover>
                             @else
-                                <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDeleteSchedule('{{ $schedule->id }}')" :tooltip-left="__('Delete')" />
+                                <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDeleteSchedule('{{ $schedule->id }}')" spinner :tooltip-left="__('Delete')" />
                             @endif
                         </div>
                     @endif
@@ -175,7 +176,7 @@
                                 <div class="fieldset-label mt-1 text-xs">{{ \App\Support\Formatters::cronTranslation($form->cleanup_cron) }}</div>
                             </div>
                             @if ($this->canManage)
-                                <x-button icon="o-play" class="btn-ghost btn-sm mt-1" wire:click="runCleanup" spinner="runCleanup" :tooltip-left="__('Run now')" />
+                                <x-button icon="o-play" class="btn-ghost btn-sm mt-1" wire:click="runCleanup" spinner :tooltip-left="__('Run now')" />
                             @endif
                         </div>
                     </x-config-row>
@@ -192,7 +193,7 @@
                                     <div class="fieldset-label mt-1 text-xs">{{ \App\Support\Formatters::cronTranslation($form->verify_files_cron) }}</div>
                                 </div>
                                 @if ($this->canManage)
-                                    <x-button icon="o-play" class="btn-ghost btn-sm mt-1" wire:click="runVerifyFiles" spinner="runVerifyFiles" :tooltip-left="__('Run now')" />
+                                    <x-button icon="o-play" class="btn-ghost btn-sm mt-1" wire:click="runVerifyFiles" spinner :tooltip-left="__('Run now')" />
                                 @endif
                             </div>
                         </x-config-row>
@@ -371,7 +372,7 @@
                 class="btn-primary"
                 :label="__('Save')"
                 wire:click="saveSchedule"
-                spinner="saveSchedule"
+                spinner
             />
         </x-slot:actions>
     </x-modal>
@@ -386,7 +387,7 @@
                 class="btn-error"
                 :label="__('Delete')"
                 wire:click="deleteSchedule"
-                spinner="deleteSchedule"
+                spinner
             />
         </x-slot:actions>
     </x-modal>

--- a/resources/views/livewire/configuration/notification.blade.php
+++ b/resources/views/livewire/configuration/notification.blade.php
@@ -22,6 +22,7 @@
                     icon="o-plus"
                     class="btn-primary btn-sm"
                     wire:click="openChannelModal"
+                    spinner
                 />
             @endif
         </x-card-heading>
@@ -50,8 +51,8 @@
                 @if ($this->canManage)
                     <div class="flex justify-end flex-nowrap gap-1">
                         <x-button icon="o-paper-airplane" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="sendTestNotification('{{ $channel->id }}')" spinner="sendTestNotification('{{ $channel->id }}')" :tooltip-left="__('Test')" />
-                        <x-button icon="o-pencil-square" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openChannelModal('{{ $channel->id }}')" :tooltip-left="__('Edit')" />
-                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDeleteChannel('{{ $channel->id }}')" :tooltip-left="__('Delete')" />
+                        <x-button icon="o-pencil-square" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openChannelModal('{{ $channel->id }}')" spinner :tooltip-left="__('Edit')" />
+                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDeleteChannel('{{ $channel->id }}')" spinner :tooltip-left="__('Delete')" />
                     </div>
                 @endif
             @endscope
@@ -118,7 +119,7 @@
                 class="btn-primary"
                 :label="__('Save')"
                 wire:click="saveChannel"
-                spinner="saveChannel"
+                spinner
             />
         </x-slot:actions>
     </x-modal>
@@ -133,7 +134,7 @@
                 class="btn-error"
                 :label="__('Delete')"
                 wire:click="deleteChannel"
-                spinner="deleteChannel"
+                spinner
             />
         </x-slot:actions>
     </x-modal>

--- a/resources/views/livewire/configuration/organization.blade.php
+++ b/resources/views/livewire/configuration/organization.blade.php
@@ -17,7 +17,7 @@
                 class="btn-ghost btn-sm"
             />
             @can('create', \App\Models\Organization::class)
-                <x-button :label="__('New Organization')" icon="o-plus" class="btn-primary btn-sm" wire:click="openCreateModal" />
+                <x-button :label="__('New Organization')" icon="o-plus" class="btn-primary btn-sm" wire:click="openCreateModal" spinner />
             @endcan
         </x-card-heading>
 
@@ -46,9 +46,9 @@
                 {{-- update/delete policies already return false for the default org and non-super-admins --}}
                 @can('update', $org)
                     <div class="flex justify-end flex-nowrap gap-1">
-                        <x-button icon="o-pencil" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openEditModal('{{ $org->id }}')" :tooltip-left="__('Edit')" />
-                        <x-button icon="o-arrows-pointing-in" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openMergeModal('{{ $org->id }}')" :tooltip-left="__('Merge')" />
-                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDelete('{{ $org->id }}')" :tooltip-left="__('Delete')" />
+                        <x-button icon="o-pencil" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openEditModal('{{ $org->id }}')" spinner :tooltip-left="__('Edit')" />
+                        <x-button icon="o-arrows-pointing-in" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openMergeModal('{{ $org->id }}')" spinner :tooltip-left="__('Merge')" />
+                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDelete('{{ $org->id }}')" spinner :tooltip-left="__('Delete')" />
                     </div>
                 @endcan
             @endscope
@@ -61,7 +61,7 @@
         <x-input :label="__('Name')" wire:model="newOrgName" />
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showCreateModal = false" />
-            <x-button :label="__('Create')" class="btn-primary" wire:click="createOrganization" />
+            <x-button :label="__('Create')" class="btn-primary" wire:click="createOrganization" spinner />
         </x-slot:actions>
     </x-modal>
 
@@ -70,7 +70,7 @@
         <x-input :label="__('Name')" wire:model="editOrgName" />
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showEditModal = false" />
-            <x-button :label="__('Save')" class="btn-primary" wire:click="updateOrganization" />
+            <x-button :label="__('Save')" class="btn-primary" wire:click="updateOrganization" spinner />
         </x-slot:actions>
     </x-modal>
 
@@ -87,7 +87,7 @@
         />
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showMergeModal = false" />
-            <x-button :label="__('Merge')" class="btn-primary" wire:click="mergeOrganization" />
+            <x-button :label="__('Merge')" class="btn-primary" wire:click="mergeOrganization" spinner />
         </x-slot:actions>
     </x-modal>
 

--- a/resources/views/livewire/configuration/roles.blade.php
+++ b/resources/views/livewire/configuration/roles.blade.php
@@ -17,7 +17,7 @@
                 class="btn-ghost btn-sm"
             />
             @can('create', \Silber\Bouncer\Database\Role::class)
-                <x-button :label="__('New role')" icon="o-plus" wire:click="openCreate" class="btn-primary btn-sm" />
+                <x-button :label="__('New role')" icon="o-plus" wire:click="openCreate" spinner class="btn-primary btn-sm" />
             @endcan
         </x-card-heading>
 
@@ -43,10 +43,10 @@
             @scope('cell_actions', $role)
                 <div class="flex justify-end flex-nowrap gap-1">
                     @can('update', $role)
-                        <x-button icon="o-pencil" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openEdit({{ $role->id }})" :tooltip-left="__('Edit')" />
+                        <x-button icon="o-pencil" class="btn-ghost btn-xs tooltip tooltip-left" wire:click="openEdit({{ $role->id }})" spinner :tooltip-left="__('Edit')" />
                     @endcan
                     @can('delete', $role)
-                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDelete({{ $role->id }})" :tooltip-left="__('Delete')" />
+                        <x-button icon="o-trash" class="btn-ghost btn-xs text-error tooltip tooltip-left" wire:click="confirmDelete({{ $role->id }})" spinner :tooltip-left="__('Delete')" />
                     @endcan
                 </div>
             @endscope
@@ -66,7 +66,7 @@
 
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showFormModal = false" />
-            <x-button :label="__('Save')" class="btn-primary" wire:click="save" spinner="save" />
+            <x-button :label="__('Save')" class="btn-primary" wire:click="save" spinner />
         </x-slot:actions>
     </x-modal>
 

--- a/resources/views/livewire/dashboard/job-status-grid.blade.php
+++ b/resources/views/livewire/dashboard/job-status-grid.blade.php
@@ -27,6 +27,9 @@
                     @endphp
                     <button
                         wire:click="viewLogs('{{ $job->id }}')"
+                        wire:loading.attr="disabled"
+                        wire:loading.class="animate-pulse opacity-40"
+                        wire:target="viewLogs('{{ $job->id }}')"
                         data-server="{{ $serverName }}"
                         data-database="{{ $databaseName }}"
                         data-type="{{ $jobType }}"

--- a/resources/views/livewire/dashboard/latest-jobs.blade.php
+++ b/resources/views/livewire/dashboard/latest-jobs.blade.php
@@ -84,6 +84,7 @@
                                 <x-button
                                     icon="o-document-text"
                                     wire:click="viewLogs('{{ $job->id }}')"
+                                    spinner
                                     tooltip="{{ __('View Logs') }}"
                                     class="btn-ghost btn-xs shrink-0"
                                 />
@@ -97,6 +98,7 @@
                                 <x-button
                                     icon="o-document-text"
                                     wire:click="viewLogs('{{ $job->id }}')"
+                                    spinner
                                     tooltip="{{ __('View Logs') }}"
                                     class="btn-ghost btn-xs"
                                 />

--- a/resources/views/livewire/database-server/_backup-form.blade.php
+++ b/resources/views/livewire/database-server/_backup-form.blade.php
@@ -66,6 +66,7 @@
         @if(count($form->backups) > 1)
             <x-button
                 wire:click="removeBackup({{ $index }})"
+                spinner
                 icon="o-trash"
                 class="btn-ghost btn-sm text-error shrink-0"
                 tooltip="{{ __('Remove this backup configuration') }}"
@@ -102,6 +103,7 @@
                             @if(count($pathRows) > 1)
                                 <x-button
                                     wire:click="removeDatabasePath({{ $index }}, {{ $pathIndex }})"
+                                    spinner
                                     icon="o-trash"
                                     class="btn-ghost btn-square btn-sm text-error"
                                     type="button"
@@ -111,6 +113,7 @@
                     @endforeach
                     <x-button
                         wire:click="addDatabasePath({{ $index }})"
+                        spinner
                         icon="o-plus"
                         class="btn-ghost btn-sm"
                         :label="__('Add path')"
@@ -478,6 +481,9 @@
                                 <button
                                     type="button"
                                     wire:click="$set('form.backups.{{ $index }}.retention_days', {{ $mark }})"
+                                    wire:loading.attr="disabled"
+                                    wire:loading.class="opacity-50"
+                                    wire:target="form.backups.{{ $index }}.retention_days"
                                     class="text-xs tabular-nums font-mono transition-colors {{ (int) ($backup['retention_days'] ?? 0) === $mark ? 'font-bold text-primary' : 'text-base-content/40 hover:text-base-content/70' }}"
                                 >
                                     {{ $mark }}

--- a/resources/views/livewire/database-server/_form.blade.php
+++ b/resources/views/livewire/database-server/_form.blade.php
@@ -176,12 +176,9 @@ use App\Enums\DatabaseType;
                                 type="button"
                                 icon="{{ $form->connectionTestSuccess ? 'o-check-circle' : 'o-bolt' }}"
                                 wire:click="testConnection"
-                                :disabled="$form->testingConnection"
-                                spinner="testConnection"
+                                spinner
                             >
-                                @if($form->testingConnection)
-                                    {{ __('Testing...') }}
-                                @elseif($form->connectionTestSuccess)
+                                @if($form->connectionTestSuccess)
                                     {{ __('Connection Verified') }}
                                     @if(!empty($form->connectionTestDetails['ping_ms']))
                                         ({{ $form->connectionTestDetails['ping_ms'] }}ms)
@@ -194,6 +191,7 @@ use App\Enums\DatabaseType;
                             @if($form->connectionTestSuccess && !empty($form->connectionTestDetails['output']))
                                 <x-button
                                     wire:click="$toggle('form.showConnectionDetails')"
+                                    spinner="form.showConnectionDetails"
                                     class="btn-ghost btn-sm"
                                     icon="{{ $form->showConnectionDetails ? 'o-eye-slash' : 'o-eye' }}"
                                     :label="$form->showConnectionDetails ? __('Hide Details') : __('Show Details')"
@@ -294,6 +292,7 @@ use App\Enums\DatabaseType;
                     <div class="flex justify-center pt-2">
                         <x-button
                             wire:click="addBackup"
+                            spinner
                             icon="o-plus"
                             class="btn-outline btn-primary"
                             :label="__('Add another backup configuration')"
@@ -421,6 +420,9 @@ use App\Enums\DatabaseType;
                                             <button
                                                 type="button"
                                                 wire:click="$set('form.notification_channel_ids', [])"
+                                                wire:loading.attr="disabled"
+                                                wire:loading.class="opacity-50"
+                                                wire:target="form.notification_channel_ids"
                                                 class="text-xs text-base-content/60 hover:text-base-content hover:underline cursor-pointer"
                                             >
                                                 {{ __('Clear all') }}
@@ -435,6 +437,9 @@ use App\Enums\DatabaseType;
                                                 role="checkbox"
                                                 aria-checked="{{ $isSelected ? 'true' : 'false' }}"
                                                 wire:click="toggleNotificationChannel('{{ $channel->id }}')"
+                                                wire:loading.attr="disabled"
+                                                wire:loading.class="opacity-50"
+                                                wire:target="toggleNotificationChannel('{{ $channel->id }}')"
                                                 wire:key="channel-card-{{ $channel->id }}"
                                                 class="relative flex items-center gap-3 rounded-lg border-2 p-3 text-left transition-all cursor-pointer {{ $isSelected ? 'border-primary bg-primary/5 shadow-sm' : 'border-base-300 bg-base-100 hover:bg-base-200' }}"
                                             >

--- a/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
+++ b/resources/views/livewire/database-server/_ssh-tunnel-config.blade.php
@@ -199,7 +199,7 @@
                                 type="button"
                                 icon="o-sparkles"
                                 wire:click="generateSshKey"
-                                spinner="generateSshKey"
+                                spinner
                             >
                                 {{ __('Generate') }}
                             </x-button>
@@ -237,7 +237,7 @@
                         type="button"
                         icon="{{ $form->sshTestSuccess ? 'o-check-circle' : 'o-signal' }}"
                         wire:click="testSshConnection"
-                        spinner="testSshConnection"
+                        spinner
                     >
                         @if($form->sshTestSuccess)
                             {{ __('Connected') }}

--- a/resources/views/livewire/database-server/adminer-modal.blade.php
+++ b/resources/views/livewire/database-server/adminer-modal.blade.php
@@ -8,9 +8,7 @@
                         <span class="text-sm text-base-content/70">{{ $databaseType }}</span>
                         <h3 class="text-sm font-bold">{{ $serverName }}</h3>
                     </div>
-                    <button class="btn btn-sm btn-ghost btn-circle" @click="$wire.closeModal()">
-                        <x-icon name="o-x-mark" class="w-5 h-5" />
-                    </button>
+                    <x-button icon="o-x-mark" class="btn-sm btn-ghost btn-circle" wire:click="closeModal" spinner />
                 </div>
                 <div class="flex-1 min-h-0">
                     <iframe

--- a/resources/views/livewire/database-server/index.blade.php
+++ b/resources/views/livewire/database-server/index.blade.php
@@ -168,6 +168,7 @@
                         <x-menu-separator />
                         <x-menu-item :title="__('Delete')" icon="o-trash"
                                      wire:click="confirmDelete('{{ $server->id }}')"
+                                     spinner
                                      class="text-error" />
                     @endcan
                 </x-floating-dropdown>

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -123,7 +123,8 @@
                                   class="btn-primary btn-sm" wire:navigate />
                     @endcan
                     @can('delete', $server)
-                        <x-button icon="o-trash" wire:click="confirmDelete" tooltip-left="{{ __('Delete') }}"
+                        <x-button icon="o-trash" wire:click="confirmDelete"
+    spinner tooltip-left="{{ __('Delete') }}"
                                   class="btn-ghost btn-sm text-error" />
                     @endcan
                 </div>

--- a/resources/views/livewire/restore/index.blade.php
+++ b/resources/views/livewire/restore/index.blade.php
@@ -13,6 +13,7 @@
                     :label="__('New Restore')"
                     icon="o-plus"
                     wire:click="openNewRestore"
+                    spinner
                     class="btn-primary btn-sm"
                 />
             @endcan
@@ -158,6 +159,7 @@
                     <x-button
                         icon="o-document-text"
                         wire:click="viewLogs('{{ $job?->id }}')"
+                        spinner
                         :tooltip="__('View Logs')"
                         class="btn-ghost btn-sm"
                         :class="$job ? '' : 'opacity-30'"
@@ -168,6 +170,7 @@
                         <x-button
                             icon="o-trash"
                             wire:click="confirmDeleteRestore('{{ $restore->id }}')"
+                            spinner
                             :tooltip="__('Delete')"
                             class="btn-ghost btn-sm text-error"
                         />

--- a/resources/views/livewire/restore/modal.blade.php
+++ b/resources/views/livewire/restore/modal.blade.php
@@ -174,11 +174,11 @@
 
                     <div class="flex gap-2 mt-6">
                         @if($currentStep > 1)
-                            <x-button class="btn-ghost" wire:click="previousStep">{{ __('Back') }}</x-button>
+                            <x-button class="btn-ghost" wire:click="previousStep" spinner>{{ __('Back') }}</x-button>
                         @endif
                         <div class="flex-1"></div>
                         <x-button class="btn-ghost" @click="$wire.showModal = false">{{ __('Cancel') }}</x-button>
-                        <x-button class="btn-primary" wire:click="restore" spinner="restore">
+                        <x-button class="btn-primary" wire:click="restore" spinner>
                             {{ __('Restore Database') }}
                         </x-button>
                     </div>

--- a/resources/views/livewire/scheduled-restore/index.blade.php
+++ b/resources/views/livewire/scheduled-restore/index.blade.php
@@ -9,6 +9,7 @@
                     :label="__('New Scheduled Restore')"
                     icon="o-plus"
                     wire:click="openCreate"
+                    spinner
                     class="btn-primary btn-sm"
                 />
             @endcan
@@ -133,6 +134,7 @@
                         <x-button
                             icon="o-play"
                             wire:click="runNow('{{ $scheduledRestore->id }}')"
+                            spinner
                             :tooltip="__('Run now')"
                             class="btn-ghost btn-sm"
                         />
@@ -141,6 +143,7 @@
                         <x-button
                             icon="o-pencil"
                             wire:click="openEdit('{{ $scheduledRestore->id }}')"
+                            spinner
                             :tooltip="__('Edit')"
                             class="btn-ghost btn-sm"
                         />
@@ -149,6 +152,7 @@
                         <x-button
                             icon="o-trash"
                             wire:click="confirmDelete('{{ $scheduledRestore->id }}')"
+                            spinner
                             :tooltip="__('Delete')"
                             class="btn-ghost btn-sm text-error"
                         />

--- a/resources/views/livewire/scheduled-restore/modal.blade.php
+++ b/resources/views/livewire/scheduled-restore/modal.blade.php
@@ -96,19 +96,19 @@
             <div class="flex items-center gap-2 w-full justify-between">
                 <div>
                     @if($currentStep > 1)
-                        <x-button :label="__('Back')" icon="o-arrow-left" wire:click="previousStep" class="btn-ghost" />
+                        <x-button :label="__('Back')" icon="o-arrow-left" wire:click="previousStep" spinner class="btn-ghost" />
                     @endif
                 </div>
                 <div class="flex items-center gap-2">
                     <x-button :label="__('Cancel')" @click="$wire.showModal = false" class="btn-ghost" />
                     @if($currentStep < 3)
-                        <x-button :label="__('Next')" icon-right="o-arrow-right" wire:click="nextStep" class="btn-primary" />
+                        <x-button :label="__('Next')" icon-right="o-arrow-right" wire:click="nextStep" spinner class="btn-primary" />
                     @else
                         <x-button
                             :label="$editingId ? __('Save changes') : __('Create scheduled restore')"
                             icon="o-check"
                             wire:click="save"
-                            spinner="save"
+                            spinner
                             class="btn-primary"
                         />
                     @endif

--- a/resources/views/livewire/settings/delete-user-form.blade.php
+++ b/resources/views/livewire/settings/delete-user-form.blade.php
@@ -29,7 +29,7 @@
 
             <div class="flex justify-end gap-2">
                 <x-button label="{{ __('Cancel') }}" @click="$wire.showDeleteModal = false" />
-                <x-button label="{{ __('Delete account') }}" class="btn-error" type="submit" data-test="confirm-delete-user-button" />
+                <x-button label="{{ __('Delete account') }}" class="btn-error" type="submit" data-test="confirm-delete-user-button" spinner="deleteUser" />
             </div>
         </form>
     </x-modal>

--- a/resources/views/livewire/settings/password.blade.php
+++ b/resources/views/livewire/settings/password.blade.php
@@ -24,7 +24,7 @@
             />
 
             <div class="flex items-center justify-end">
-                <x-button type="submit" class="btn-primary" label="{{ __('Save') }}" data-test="update-password-button" />
+                <x-button type="submit" class="btn-primary" label="{{ __('Save') }}" data-test="update-password-button" spinner="updatePassword" />
             </div>
         </form>
     </x-card>

--- a/resources/views/livewire/settings/preferences.blade.php
+++ b/resources/views/livewire/settings/preferences.blade.php
@@ -16,14 +16,13 @@
         <x-card title="{{ __('Language') }}" subtitle="{{ __('Choose your preferred language') }}" class="mb-6">
             <div class="flex flex-wrap gap-3">
                 @foreach($availableLocales as $code => $label)
-                    <button
+                    <x-button
+                        :label="$label"
                         wire:click="setLocale('{{ $code }}')"
-                        wire:key="locale-{{ $code }}"
-                        aria-pressed="{{ $locale === $code ? 'true' : 'false' }}"
-                        class="btn {{ $locale === $code ? 'btn-primary' : 'btn-outline' }}"
-                    >
-                        {{ $label }}
-                    </button>
+                        spinner
+                        :aria-pressed="$locale === $code ? 'true' : 'false'"
+                        :class="$locale === $code ? 'btn-primary' : 'btn-outline'"
+                    />
                 @endforeach
             </div>
         </x-card>

--- a/resources/views/livewire/settings/profile.blade.php
+++ b/resources/views/livewire/settings/profile.blade.php
@@ -17,7 +17,7 @@
             />
 
             <div class="flex items-center justify-end">
-                <x-button type="submit" class="btn-primary" label="{{ __('Save') }}" data-test="update-profile-button" />
+                <x-button type="submit" class="btn-primary" label="{{ __('Save') }}" data-test="update-profile-button" spinner="updateProfileInformation" />
             </div>
         </form>
     </x-card>

--- a/resources/views/livewire/settings/two-factor.blade.php
+++ b/resources/views/livewire/settings/two-factor.blade.php
@@ -20,6 +20,7 @@
                             class="btn-error"
                             icon="o-shield-exclamation"
                             wire:click="disable"
+                            spinner
                             label="{{ __('Disable 2FA') }}"
                         />
                     </div>
@@ -38,6 +39,7 @@
                         class="btn-primary"
                         icon="o-shield-check"
                         wire:click="enable"
+                        spinner
                         label="{{ __('Enable 2FA') }}"
                     />
                 </div>
@@ -79,12 +81,14 @@
                         <x-button
                             class="btn-outline flex-1"
                             wire:click="resetVerification"
+                            spinner
                             label="{{ __('Back') }}"
                         />
 
                         <x-button
                             class="btn-primary flex-1"
                             wire:click="confirmTwoFactor"
+                            spinner
                             x-bind:disabled="$wire.code.length < 6"
                             label="{{ __('Confirm') }}"
                         />
@@ -116,6 +120,7 @@
                         :disabled="$errors->has('setupData')"
                         class="btn-primary w-full"
                         wire:click="showVerificationIfNecessary"
+                        spinner
                         label="{{ $this->modalConfig['buttonText'] }}"
                     />
                 </div>

--- a/resources/views/livewire/settings/two-factor/recovery-codes.blade.php
+++ b/resources/views/livewire/settings/two-factor/recovery-codes.blade.php
@@ -37,6 +37,7 @@
                     icon="o-arrow-path"
                     class="btn-outline"
                     wire:click="regenerateRecoveryCodes"
+                    spinner
                     label="{{ __('Regenerate Codes') }}"
                 />
             @endif

--- a/resources/views/livewire/snapshot/_comment.blade.php
+++ b/resources/views/livewire/snapshot/_comment.blade.php
@@ -21,8 +21,8 @@
         />
 
         <div class="flex items-center justify-end gap-1 mt-1">
-            <x-button :label="__('Cancel')" class="btn-ghost btn-xs" wire:click="cancelEditComment" />
-            <x-button :label="__('Save')" class="btn-primary btn-xs" wire:click="saveComment" spinner="saveComment" />
+            <x-button :label="__('Cancel')" class="btn-ghost btn-xs" wire:click="cancelEditComment" spinner />
+            <x-button :label="__('Save')" class="btn-primary btn-xs" wire:click="saveComment" spinner />
         </div>
     </div>
 @elseif($snapshot->comment)
@@ -35,6 +35,9 @@
             class="link link-hover min-w-0 text-start text-sm text-base-content/70 line-clamp-2 hover:text-base-content"
             @if($canEditComment)
                 wire:click="editComment('{{ $snapshot->id }}')"
+                wire:loading.attr="disabled"
+                wire:loading.class="opacity-50"
+                wire:target="editComment('{{ $snapshot->id }}')"
                 aria-label="{{ __('Edit comment') }}: {{ $snapshot->comment }}"
             @else
                 x-data="{ expanded: false }"
@@ -49,6 +52,7 @@
         :label="__('Add comment')"
         icon="o-plus"
         wire:click="editComment('{{ $snapshot->id }}')"
+        spinner
         class="btn-ghost btn-xs -ms-2 mt-1 font-normal text-base-content/50 transition-opacity hover:text-primary md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100"
     />
 @endif

--- a/resources/views/livewire/snapshot/_lock.blade.php
+++ b/resources/views/livewire/snapshot/_lock.blade.php
@@ -9,6 +9,7 @@
         :tooltip="$canLock ? __('Kept out of automatic cleanup. Click to unlock.') : __('Kept out of automatic cleanup.')"
         :disabled="! $canLock"
         wire:click="toggleLock('{{ $snapshot->id }}')"
+        spinner
         class="btn-ghost btn-xs font-normal text-base-content/50 hover:text-primary"
     />
 @elseif($canLock)
@@ -17,6 +18,7 @@
         icon="o-lock-open"
         :tooltip="__('Keep this snapshot out of automatic cleanup')"
         wire:click="toggleLock('{{ $snapshot->id }}')"
+        spinner
         class="btn-ghost btn-xs font-normal text-base-content/50 transition-opacity hover:text-primary md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100"
     />
 @endif

--- a/resources/views/livewire/snapshot/index.blade.php
+++ b/resources/views/livewire/snapshot/index.blade.php
@@ -134,6 +134,7 @@
                             <x-button
                                 icon="bi.database-fill-down"
                                 wire:click="triggerRestore('{{ $snapshot->id }}')"
+                                spinner
                                 :tooltip="__('Restore')"
                                 class="btn-ghost btn-sm text-success"
                             />
@@ -147,6 +148,7 @@
                                 <x-button
                                     icon="o-arrow-down-tray"
                                     wire:click="openDownloadModal('{{ $snapshot->id }}')"
+                                    spinner
                                     :tooltip="__('Download')"
                                     class="btn-ghost btn-sm text-primary"
                                 />
@@ -165,6 +167,7 @@
                     <x-button
                         icon="o-document-text"
                         wire:click="viewLogs('{{ $job?->id }}')"
+                        spinner
                         :tooltip="__('View Logs')"
                         class="btn-ghost btn-sm"
                         :class="$job ? '' : 'opacity-30'"
@@ -176,6 +179,7 @@
                             <x-button
                                 icon="o-trash"
                                 wire:click="confirmDeleteSnapshot('{{ $snapshot->id }}')"
+                                spinner
                                 :tooltip="__('Delete')"
                                 class="btn-ghost btn-sm text-error"
                             />
@@ -196,6 +200,7 @@
                             <x-button
                                 icon="o-x-mark"
                                 wire:click="confirmCancelJob('{{ $job->id }}')"
+                                spinner
                                 :tooltip="__('Cancel')"
                                 class="btn-ghost btn-sm text-error"
                             />

--- a/resources/views/livewire/user/index.blade.php
+++ b/resources/views/livewire/user/index.blade.php
@@ -76,6 +76,7 @@
                         <x-button
                             icon="o-clipboard-document"
                             wire:click="copyInvitationLink({{ $user->id }})"
+                            spinner
                             tooltip="{{ __('Copy Invitation Link') }}"
                             class="btn-ghost btn-sm text-info"
                         />
@@ -93,6 +94,7 @@
                         <x-button
                             icon="o-user-minus"
                             wire:click="confirmRemoveFromOrg({{ $user->id }})"
+                            spinner
                             tooltip="{{ __('Remove from organization') }}"
                             class="btn-ghost btn-sm text-warning"
                         />
@@ -101,6 +103,7 @@
                         <x-button
                             icon="o-trash"
                             wire:click="confirmDelete({{ $user->id }})"
+                            spinner
                             tooltip="{{ __('Delete') }}"
                             class="btn-ghost btn-sm text-error"
                         />
@@ -125,7 +128,7 @@
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showDeleteModal = false" />
             @unless($deleteBlockReason)
-                <x-button :label="__('Delete')" class="btn-error" wire:click="delete" spinner="delete" />
+                <x-button :label="__('Delete')" class="btn-error" wire:click="delete" spinner />
             @endunless
         </x-slot:actions>
     </x-modal>
@@ -142,7 +145,7 @@
         <x-slot:actions>
             <x-button :label="__('Cancel')" @click="$wire.showRemoveModal = false" />
             @unless($removeBlockReason)
-                <x-button :label="__('Remove')" class="btn-warning" wire:click="removeFromOrg" spinner="removeFromOrg" />
+                <x-button :label="__('Remove')" class="btn-warning" wire:click="removeFromOrg" spinner />
             @endunless
         </x-slot:actions>
     </x-modal>

--- a/resources/views/livewire/version-status.blade.php
+++ b/resources/views/livewire/version-status.blade.php
@@ -4,10 +4,13 @@
         {{-- Update available — eye-catching pill --}}
         <button
             wire:click="open"
+            wire:loading.attr="disabled"
+            wire:target="open"
             class="inline-flex items-center gap-1.5 cursor-pointer rounded-full px-2 py-0.5 bg-warning/10 border border-warning/20 text-warning text-sm font-medium hover:bg-warning/20 hover:border-warning/35 transition-all"
             title="{{ $latestVersion }} {{ __('available') }}"
         >
-            <span class="relative flex h-1.5 w-1.5 shrink-0">
+            <x-loading wire:loading wire:target="open" class="loading-spinner loading-xs" />
+            <span wire:loading.remove wire:target="open" class="relative flex h-1.5 w-1.5 shrink-0">
                 <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-warning opacity-60"></span>
                 <span class="relative inline-flex rounded-full h-1.5 w-1.5 bg-warning"></span>
             </span>
@@ -17,10 +20,13 @@
         {{-- Up to date or no latest info — subtle version with green dot --}}
         <button
             wire:click="open"
+            wire:loading.attr="disabled"
+            wire:target="open"
             class="inline-flex items-center gap-1.5 text-sm text-base-content/60 hover:text-base-content transition-colors cursor-pointer"
         >
+            <x-loading wire:loading wire:target="open" class="loading-spinner loading-xs" />
             @if($this->isUpToDate())
-                <span class="flex h-1.5 w-1.5 shrink-0">
+                <span wire:loading.remove wire:target="open" class="flex h-1.5 w-1.5 shrink-0">
                     <span class="block h-full w-full rounded-full bg-success opacity-70"></span>
                 </span>
             @endif
@@ -32,8 +38,11 @@
         {{-- No version info — plain link --}}
         <button
             wire:click="open"
-            class="link link-hover text-sm text-base-content/60"
+            wire:loading.attr="disabled"
+            wire:target="open"
+            class="inline-flex items-center gap-1.5 link link-hover text-sm text-base-content/60"
         >
+            <x-loading wire:loading wire:target="open" class="loading-spinner loading-xs" />
             {{ __('How to update?') }}
         </button>
     @endif

--- a/resources/views/livewire/volume/_form.blade.php
+++ b/resources/views/livewire/volume/_form.blade.php
@@ -79,14 +79,9 @@ use App\Enums\VolumeType;
                 type="button"
                 icon="o-arrow-path"
                 wire:click="testConnection"
-                :disabled="$form->testingConnection"
-                spinner="testConnection"
+                spinner
             >
-                @if($form->testingConnection)
-                    {{ __('Testing Connection...') }}
-                @else
-                    {{ __('Test Connection') }}
-                @endif
+                {{ __('Test Connection') }}
             </x-button>
         </div>
 
@@ -111,7 +106,7 @@ use App\Enums\VolumeType;
         <x-button class="btn-ghost" link="{{ route($cancelRoute) }}" wire:navigate>
             {{ __('Cancel') }}
         </x-button>
-        <x-button class="btn-primary" type="submit">
+        <x-button class="btn-primary" type="submit" spinner="save">
             {{ __($submitLabel) }}
         </x-button>
     </div>

--- a/resources/views/livewire/volume/index.blade.php
+++ b/resources/views/livewire/volume/index.blade.php
@@ -111,6 +111,7 @@
                         <x-button
                             icon="o-trash"
                             wire:click="confirmDelete('{{ $volume->id }}')"
+                            spinner
                             tooltip="{{ __('Delete') }}"
                             class="btn-ghost btn-sm text-error"
                         />


### PR DESCRIPTION
Buttons that fire a Livewire round trip gave no feedback while the request was in flight (the dashboard's View Logs is the obvious one, its modal takes a moment to render), and the buttons that did show a spinner each spelled it differently. This puts every action button on Mary's `spinner` prop with one rule per button kind and adds `x-submit-button` for the classic POST forms Livewire cannot see. CLAUDE.md documents the rule.

The `testingConnection` flag on the server and volume forms was set and cleared inside the same request, so its "Testing..." label never rendered. It is removed in favour of the spinner, together with the orphaned translations.

Worth a look: per-row spinners rely on Livewire matching `wire:target` with parameters, which Mary resolves from the click expression. The server index actions menu already used that, so it is a proven path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added loading spinners and disabled states across actions, forms, modals, tables, and navigation controls.
  - Added a reusable submit button with built-in submission feedback for authentication and classic forms.
  - Improved loading feedback for connection tests, backups, restores, token management, settings, and version updates.

- **UI Improvements**
  - Loading indicators now apply to individual actions, helping clarify which operation is in progress.
  - Connection test controls maintain consistent labels while displaying progress feedback.

- **Documentation**
  - Documented conventions for configuring loading states across button and form interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->