### PR TITLE
fix: fail translations:sync --check on a file sync would rewrite

### DIFF
--- a/app/Console/Commands/TranslationsSyncCommand.php
+++ b/app/Console/Commands/TranslationsSyncCommand.php
@@ -42,13 +42,18 @@ class TranslationsSyncCommand extends Command
             $missing = count($source) - count($translations);
             $stale = count($existing) - count($translations);
 
-            if (! $check && $translations !== $existing) {
-                $this->write($path, $translations);
+            // Comparing the rendered file rather than the parsed array also catches the
+            // things parsing hides: key order, the stripped banner, the indent width.
+            $rendered = $this->render($translations);
+            $needsWrite = $rendered !== file_get_contents($path);
+
+            if (! $check && $needsWrite) {
+                file_put_contents($path, $rendered);
             }
 
-            $this->report($locale, $missing, $stale, $check);
+            $this->report($locale, $missing, $stale, $needsWrite, $check);
 
-            if ($missing > 0 || $stale > 0) {
+            if ($missing > 0 || $needsWrite) {
                 $outOfSync = true;
             }
         }
@@ -92,7 +97,7 @@ class TranslationsSyncCommand extends Command
         return $pruned;
     }
 
-    private function report(string $locale, int $missing, int $stale, bool $check): void
+    private function report(string $locale, int $missing, int $stale, bool $needsWrite, bool $check): void
     {
         $summary = sprintf('  %s: %d missing', $locale, $missing);
 
@@ -100,7 +105,11 @@ class TranslationsSyncCommand extends Command
             $summary .= sprintf($check ? ', %d stale' : ', %d stale removed', $stale);
         }
 
-        $missing === 0 && $stale === 0 ? $this->info($summary) : $this->warn($summary);
+        if ($needsWrite && $stale === 0) {
+            $summary .= $check ? ', needs formatting' : ', reformatted';
+        }
+
+        $missing === 0 && ! $needsWrite ? $this->info($summary) : $this->warn($summary);
     }
 
     /**
@@ -124,14 +133,14 @@ class TranslationsSyncCommand extends Command
     /**
      * @param  array<string, string>  $translations
      */
-    private function write(string $path, array $translations): void
+    private function render(array $translations): string
     {
         $json = json_encode(
             $translations,
             JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
         );
 
-        file_put_contents($path, $this->indentWithTwoSpaces($json)."\n");
+        return $this->indentWithTwoSpaces($json)."\n";
     }
 
     private function indentWithTwoSpaces(string $json): string

--- a/tests/Feature/TranslationsSyncTest.php
+++ b/tests/Feature/TranslationsSyncTest.php
@@ -55,3 +55,19 @@ test('check reports a locale that is out of sync without writing, and exits non-
 
     expect(readLangFile($this->langPath, 'fr'))->toHaveKey('Stale');
 });
+
+test('check fails on a file sync would rewrite even when no key is missing', function () {
+    writeLangFile($this->langPath, 'en', ['Backup' => 'Backup', 'Restore' => 'Restore']);
+    // Same keys as the source, in the wrong order and carrying the translator's banner.
+    writeLangFile($this->langPath, 'fr', [
+        '_comment' => 'WARNING: This is an auto-generated file.',
+        'Restore' => 'Restaurer',
+        'Backup' => 'Backup',
+    ]);
+
+    $this->artisan('translations:sync --check')
+        ->expectsOutputToContain('fr: 0 missing, needs formatting')
+        ->assertFailed();
+
+    expect(readLangFile($this->langPath, 'fr'))->toHaveKey('_comment');
+});


### PR DESCRIPTION
Follow-up to #602, from a CodeRabbit comment that landed after it merged.

`--check` compared key sets, so a locale holding every key but in the wrong order, or still carrying the banner the translator stamps into each file, reported "0 missing" and exited 0 while a real `translations:sync` would rewrite it. `make check-translation` could therefore call a file clean that was not.

It now compares the rendered file rather than the parsed array, which also covers the indent width.

This is not theoretical: running the stricter check against the translations in #603 immediately found that `el.json` and `zh_TW.json` had never been normalised after their final translation pass — both still carried the banner and 4-space indentation, and the old check passed them. #603 has been corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation synchronization now detects locale files that differ in formatting, ordering, or generated headers.
  * Check mode correctly reports formatting issues and exits unsuccessfully without modifying files.
* **Tests**
  * Added coverage for detecting improperly formatted locale files during synchronization checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->