### PR TITLE
fix(security): keep the toast helpers out of the component public API

### DIFF
--- a/app/Traits/Toast.php
+++ b/app/Traits/Toast.php
@@ -7,7 +7,9 @@ use Livewire\Features\SupportRedirects\Redirector;
 
 trait Toast
 {
-    public function toast(
+    private const FALLBACK_ICON = 'o-information-circle';
+
+    protected function toast(
         string $type,
         string $title,
         ?string $description = null,
@@ -25,7 +27,9 @@ trait Toast
             'title' => $title,
             'description' => $description,
             'position' => $position,
-            'icon' => Blade::render("<x-mary-icon class='w-7 h-7' name='".$icon."' />"),
+            'icon' => Blade::render('<x-mary-icon class="w-7 h-7" :name="$name" />', [
+                'name' => preg_match('/\\A[A-Za-z0-9._-]+\\z/', $icon) === 1 ? $icon : self::FALLBACK_ICON,
+            ]),
             'css' => $css,
             'timeout' => $timeout,
             'noProgress' => $noProgress,
@@ -48,7 +52,7 @@ trait Toast
         return null;
     }
 
-    public function success(
+    protected function success(
         string $title,
         ?string $description = null,
         ?string $position = 'toast-bottom',
@@ -63,7 +67,7 @@ trait Toast
         return $this->toast('success', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $noProgress, $progressClass, $flashAs);
     }
 
-    public function warning(
+    protected function warning(
         string $title,
         ?string $description = null,
         ?string $position = 'toast-bottom',
@@ -78,7 +82,7 @@ trait Toast
         return $this->toast('warning', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $noProgress, $progressClass, $flashAs);
     }
 
-    public function error(
+    protected function error(
         string $title,
         ?string $description = null,
         ?string $position = 'toast-bottom',
@@ -93,7 +97,7 @@ trait Toast
         return $this->toast('error', $title, $description, $position, $icon, $css, $timeout, $redirectTo, $noProgress, $progressClass, $flashAs);
     }
 
-    public function info(
+    protected function info(
         string $title,
         ?string $description = null,
         ?string $position = 'toast-bottom',

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,6 +3,22 @@ import Chart from 'chart.js/auto';
 
 window.Chart = Chart;
 
+const successIcon = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true" class="inline flex-shrink-0 w-7 h-7"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/></svg>';
+
+window.successToast = (title, timeout = 6000) => window.toast({
+    toast: {
+        type: 'success',
+        title,
+        description: null,
+        position: 'toast-bottom',
+        icon: successIcon,
+        css: 'alert-success',
+        timeout,
+        noProgress: false,
+        progressClass: null,
+    },
+});
+
 document.addEventListener('alpine:init', () => {
     Alpine.directive('clipboard', (el, { expression }, { evaluate }) => {
         el.addEventListener('click', () => {

--- a/resources/views/components/invitation-link-modal.blade.php
+++ b/resources/views/components/invitation-link-modal.blade.php
@@ -15,7 +15,7 @@
             icon="o-clipboard-document"
             class="btn-primary"
             x-clipboard="$wire.invitationUrl"
-            x-on:clipboard-copied="$wire.success('{{ __('Link copied to clipboard!') }}', null, 'toast-bottom')"
+            x-on:clipboard-copied="successToast('{{ __('Link copied to clipboard!') }}')"
             tooltip="{{ __('Copy') }}"
         />
     </div>

--- a/resources/views/livewire/api-token/index.blade.php
+++ b/resources/views/livewire/api-token/index.blade.php
@@ -86,7 +86,7 @@
                 icon="o-clipboard-document"
                 class="btn-primary"
                 x-clipboard="$wire.newToken"
-                x-on:clipboard-copied="$wire.success('{{ __('Token copied to clipboard!') }}', null, 'toast-bottom')"
+                x-on:clipboard-copied="successToast('{{ __('Token copied to clipboard!') }}')"
                 tooltip="{{ __('Copy') }}"
             />
         </div>

--- a/resources/views/livewire/database-server/show.blade.php
+++ b/resources/views/livewire/database-server/show.blade.php
@@ -58,7 +58,7 @@
                                 icon="o-clipboard-document"
                                 class="btn-ghost btn-xs btn-circle shrink-0"
                                 x-clipboard="'{{ $server->id }}'"
-                                x-on:clipboard-copied="$wire.success('{{ __('Copied to clipboard!') }}', null, 'toast-bottom')"
+                                x-on:clipboard-copied="successToast('{{ __('Copied to clipboard!') }}')"
                                 :tooltip="__('Copy ID')"
                             />
                         </div>

--- a/resources/views/livewire/version-status.blade.php
+++ b/resources/views/livewire/version-status.blade.php
@@ -122,7 +122,7 @@
                         class="btn-ghost btn-xs"
                         :label="__('Copy')"
                         x-clipboard="$wire.dockerComposeCommand"
-                        x-on:clipboard-copied="$wire.success('{{ __('Copied to clipboard!') }}', null, 'toast-bottom')"
+                        x-on:clipboard-copied="successToast('{{ __('Copied to clipboard!') }}')"
                     />
                 </div>
                 <pre class="bg-neutral text-neutral-content rounded-box p-5 text-sm overflow-x-auto"><code class="break-all select-all whitespace-pre-wrap">{{ $dockerComposeCommand }}</code></pre>
@@ -144,7 +144,7 @@
                         class="btn-ghost btn-xs"
                         :label="__('Copy')"
                         x-clipboard="$wire.helmCommand"
-                        x-on:clipboard-copied="$wire.success('{{ __('Copied to clipboard!') }}', null, 'toast-bottom')"
+                        x-on:clipboard-copied="successToast('{{ __('Copied to clipboard!') }}')"
                     />
                 </div>
                 <pre class="bg-neutral text-neutral-content rounded-box p-5 text-sm overflow-x-auto"><code class="break-all select-all whitespace-pre-wrap">{{ $helmCommand }}</code></pre>
@@ -166,7 +166,7 @@
                         class="btn-ghost btn-xs"
                         :label="__('Copy')"
                         x-clipboard="$wire.dockerCommand"
-                        x-on:clipboard-copied="$wire.success('{{ __('Copied to clipboard!') }}', null, 'toast-bottom')"
+                        x-on:clipboard-copied="successToast('{{ __('Copied to clipboard!') }}')"
                     />
                 </div>
                 <pre class="bg-neutral text-neutral-content rounded-box p-5 text-sm overflow-x-auto"><code class="break-all select-all whitespace-pre-wrap">{{ $dockerCommand }}</code></pre>

--- a/tests/Feature/Security/ToastMethodExposureTest.php
+++ b/tests/Feature/Security/ToastMethodExposureTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Livewire\Auth\AcceptInvitation;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Livewire\Exceptions\MethodNotFoundException;
+use Livewire\Livewire;
+
+test('toast helpers are not part of a component public API', function (string $method) {
+    $user = User::factory()->create([
+        'password' => null,
+        'invitation_token' => Str::random(64),
+        'invitation_accepted_at' => null,
+    ]);
+
+    $component = Livewire::test(AcceptInvitation::class, ['token' => $user->invitation_token]);
+
+    expect(fn () => $component->call($method, 'title', 'description'))
+        ->toThrow(MethodNotFoundException::class);
+})->with(['toast', 'success', 'warning', 'error', 'info']);


### PR DESCRIPTION
The toast helpers were public on every component that uses the trait, so they sat in each component's client-facing method surface even though they only ever get called from the component's own actions. Making them protected keeps that surface to what the components actually mean to expose, and the icon now reaches the Mary icon component as a bound value rather than being concatenated into the rendered Blade string.

Six Alpine clipboard toasts called `$wire.success()` directly and had to move with it. They now go through a small `successToast()` helper in `app.js`, which renders the same toast without a server round trip for a copy-to-clipboard.

Verified in the browser that the toast still renders (icon, colour, progress bar) after the change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a consistent success notification when users copy invitation links, API tokens, database server IDs, and deployment configuration snippets.
  - Copy confirmations now use a dedicated success style, icon, placement, and configurable display duration.

- **Bug Fixes**
  - Improved toast icon handling by safely falling back to a standard information icon when an unsupported icon value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->