### PR TITLE
fix(security): re-verify the invitation and derive the Adminer frame URL server-side

### DIFF
--- a/app/Livewire/Auth/AcceptInvitation.php
+++ b/app/Livewire/Auth/AcceptInvitation.php
@@ -7,6 +7,7 @@ use App\Traits\Toast;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Layout;
+use Livewire\Attributes\Locked;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
@@ -14,8 +15,10 @@ class AcceptInvitation extends Component
 {
     use Toast;
 
+    #[Locked]
     public User $user;
 
+    #[Locked]
     public string $token;
 
     #[Validate('required|string|min:8|confirmed')]
@@ -26,8 +29,37 @@ class AcceptInvitation extends Component
     public function mount(string $token): void
     {
         $this->token = $token;
+        $this->user = $this->pendingInvitation();
+    }
 
-        $user = User::where('invitation_token', $token)
+    public function accept(): void
+    {
+        $this->validate();
+
+        $user = $this->pendingInvitation();
+
+        $user->update([
+            'password' => $this->password,
+            'invitation_token' => null,
+            'invitation_accepted_at' => now(),
+        ]);
+
+        Auth::login($user);
+
+        $this->success(
+            title: __('Welcome! Your account is ready.'),
+            redirectTo: route('dashboard')
+        );
+    }
+
+    /**
+     * The user the token still invites, resolved from the database on every
+     * call so a pending invitation is what grants the password change, not
+     * the state the page was rendered with.
+     */
+    private function pendingInvitation(): User
+    {
+        $user = User::where('invitation_token', $this->token)
             ->whereNull('invitation_accepted_at')
             ->first();
 
@@ -35,25 +67,7 @@ class AcceptInvitation extends Component
             abort(404, __('Invalid or expired invitation link.'));
         }
 
-        $this->user = $user;
-    }
-
-    public function accept(): void
-    {
-        $this->validate();
-
-        $this->user->update([
-            'password' => $this->password,
-            'invitation_token' => null,
-            'invitation_accepted_at' => now(),
-        ]);
-
-        Auth::login($this->user);
-
-        $this->success(
-            title: __('Welcome! Your account is ready.'),
-            redirectTo: route('dashboard')
-        );
+        return $user;
     }
 
     #[Layout('layouts::auth')]

--- a/app/Livewire/DatabaseServer/AdminerModal.php
+++ b/app/Livewire/DatabaseServer/AdminerModal.php
@@ -21,12 +21,12 @@ class AdminerModal extends Component
     public string $adminerUrl = '';
 
     #[On('open-adminer-modal')]
-    public function openModal(string $serverName, string $databaseIcon, string $databaseType, string $adminerUrl): void
+    public function openModal(string $serverName, string $databaseIcon, string $databaseType): void
     {
         $this->serverName = $serverName;
         $this->databaseIcon = $databaseIcon;
         $this->databaseType = $databaseType;
-        $this->adminerUrl = $adminerUrl;
+        $this->adminerUrl = route('adminer');
         $this->showModal = true;
     }
 

--- a/app/Traits/OpensAdminerForServer.php
+++ b/app/Traits/OpensAdminerForServer.php
@@ -22,7 +22,6 @@ trait OpensAdminerForServer
             serverName: $server->name,
             databaseIcon: $server->database_type->icon(),
             databaseType: $server->database_type->label(),
-            adminerUrl: route('adminer'),
         );
     }
 }

--- a/tests/Feature/Auth/AcceptInvitationTest.php
+++ b/tests/Feature/Auth/AcceptInvitationTest.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\Auth\AcceptInvitation;
 use App\Models\User;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 use Livewire\Livewire;
 
@@ -80,4 +81,45 @@ test('password must be at least 8 characters', function () {
         ->set('password_confirmation', 'short')
         ->call('accept')
         ->assertHasErrors(['password']);
+});
+
+test('an accepted invitation cannot be accepted a second time', function () {
+    $token = Str::random(64);
+    $user = User::factory()->create([
+        'password' => null,
+        'invitation_token' => $token,
+        'invitation_accepted_at' => null,
+    ]);
+
+    $component = Livewire::test(AcceptInvitation::class, ['token' => $token])
+        ->set('password', 'newpassword123')
+        ->set('password_confirmation', 'newpassword123')
+        ->call('accept');
+
+    $component->set('password', 'otherpassword123')
+        ->set('password_confirmation', 'otherpassword123')
+        ->call('accept')
+        ->assertStatus(404);
+
+    expect(Hash::check('newpassword123', $user->fresh()->password))->toBeTrue();
+});
+
+test('a revoked invitation cannot be accepted', function () {
+    $token = Str::random(64);
+    $user = User::factory()->create([
+        'password' => null,
+        'invitation_token' => $token,
+        'invitation_accepted_at' => null,
+    ]);
+
+    $component = Livewire::test(AcceptInvitation::class, ['token' => $token]);
+
+    $user->update(['invitation_token' => Str::random(64)]);
+
+    $component->set('password', 'newpassword123')
+        ->set('password_confirmation', 'newpassword123')
+        ->call('accept')
+        ->assertStatus(404);
+
+    expect($user->fresh()->password)->toBeNull();
 });

--- a/tests/Feature/Livewire/DatabaseServer/AdminerModalTest.php
+++ b/tests/Feature/Livewire/DatabaseServer/AdminerModalTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Livewire\DatabaseServer\AdminerModal;
+use Livewire\Livewire;
+
+test('the modal frames the application adminer route', function () {
+    Livewire::test(AdminerModal::class)
+        ->call('openModal', 'Production', 'o-circle-stack', 'MySQL')
+        ->assertSet('adminerUrl', route('adminer'))
+        ->assertSet('showModal', true);
+});


### PR DESCRIPTION
Two places trusted state that was fixed when a page was rendered rather than re-reading it when the action ran.

The invitation component resolved the token in `mount()` and then acted on the user it had loaded, so what allowed the password to be set was the state the page rendered with rather than a pending invitation. Both entry points now resolve it from the database on every call, and the two properties carrying that state are locked.

The Adminer modal took the frame URL from whoever opened it, even though there is only ever one value for it, and `#[Locked]` covers client updates to a property but not what a method assigns to it. It comes from the route now, so the listener no longer carries a URL at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invitation acceptance now validates the invitation at the time of submission, preventing reused, revoked, or modified invitations from changing account credentials.
  * The Adminer modal now consistently opens with the correct Adminer destination.

* **Tests**
  * Added coverage for invalid and previously accepted invitations.
  * Added coverage confirming the Adminer modal opens with the expected destination and display state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->